### PR TITLE
Support looking up canary config by name.

### DIFF
--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryConfig.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryConfig.java
@@ -20,6 +20,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.Singular;
 import lombok.ToString;
 
@@ -35,6 +36,7 @@ public class CanaryConfig {
 
   @NotNull
   @Getter
+  @Setter
   private String name;
 
   @NotNull

--- a/kayenta-core/src/main/java/com/netflix/kayenta/storage/StorageService.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/storage/StorageService.java
@@ -18,6 +18,6 @@ package com.netflix.kayenta.storage;
 
 public interface StorageService {
   boolean servicesAccount(String accountName);
-  <T> T loadObject(String accountName, ObjectType objectType, String objectKey);
+  <T> T loadObject(String accountName, ObjectType objectType, String objectKey) throws IllegalArgumentException;
   <T> void storeObject(String accountName, ObjectType objectType, String objectKey, T obj);
 }

--- a/kayenta-gcs/src/main/java/com/netflix/kayenta/gcs/storage/GcsStorageService.java
+++ b/kayenta-gcs/src/main/java/com/netflix/kayenta/gcs/storage/GcsStorageService.java
@@ -60,7 +60,7 @@ public class GcsStorageService implements StorageService {
   }
 
   @Override
-  public <T> T loadObject(String accountName, ObjectType objectType, String objectKey) {
+  public <T> T loadObject(String accountName, ObjectType objectType, String objectKey) throws IllegalArgumentException {
     GoogleNamedAccountCredentials credentials = (GoogleNamedAccountCredentials)accountCredentialsRepository
       .getOne(accountName)
       .orElseThrow(() -> new IllegalArgumentException("Unable to resolve account " + accountName + "."));

--- a/kayenta-web/src/main/java/com/netflix/kayenta/controllers/MetricSetListController.java
+++ b/kayenta-web/src/main/java/com/netflix/kayenta/controllers/MetricSetListController.java
@@ -66,7 +66,7 @@ public class MetricSetListController {
 
   @RequestMapping(consumes = "application/context+json", method = RequestMethod.POST)
   public String storeMetricSetList(@RequestParam(required = false) final String accountName,
-                                    @RequestBody List<MetricSet> metricSetList) throws IOException {
+                                   @RequestBody List<MetricSet> metricSetList) throws IOException {
     String resolvedAccountName = CredentialsHelper.resolveAccountByNameOrType(accountName,
                                                                               AccountCredentials.Type.OBJECT_STORE,
                                                                               accountCredentialsRepository);


### PR DESCRIPTION
Use canary config name in path to bucket.
Populate canary config name with uuid if missing.
Don't allow naming collisions on POST of canary config.
Reject canary config names not conforming to restrictions.