### PR TITLE
Config delete operation should normalize config name to match create operation

### DIFF
--- a/kayenta-web/src/main/java/com/netflix/kayenta/controllers/CanaryConfigController.java
+++ b/kayenta-web/src/main/java/com/netflix/kayenta/controllers/CanaryConfigController.java
@@ -139,7 +139,7 @@ public class CanaryConfigController {
         .getOne(resolvedAccountName)
         .orElseThrow(() -> new IllegalArgumentException("No storage service was configured; unable to delete canary config."));
 
-    storageService.deleteObject(resolvedAccountName, ObjectType.CANARY_CONFIG, canaryConfigId);
+    storageService.deleteObject(resolvedAccountName, ObjectType.CANARY_CONFIG, canaryConfigId.toLowerCase());
 
     response.setStatus(HttpStatus.NO_CONTENT.value());
   }


### PR DESCRIPTION
Should match the config create operation: https://github.com/Netflix-Skunkworks/kayenta/blob/master/kayenta-web/src/main/java/com/netflix/kayenta/controllers/CanaryConfigController.java#L111

@duftler 