### PR TITLE
Make canary judges pluggable.

### DIFF
--- a/json-formats.md
+++ b/json-formats.md
@@ -23,7 +23,9 @@ Atlas and Stackdriver are used.
         "q": "name,CpuRawUser,:eq,:sum,name,numProcs,:eq,:sum,:div"
       },
       "analysisConfigurations": {
-        "canary": { }
+        "canary": {
+          "judge": "dredd-v1.0"
+        }
       },
       "groups": ["system"]
     },
@@ -78,7 +80,9 @@ Atlas and Stackdriver are used.
         "metricType": "compute.googleapis.com/instance/cpu/utilization"
       },
       "analysisConfigurations": {
-        "canary": { }
+        "canary": {
+          "judge": "dredd-v1.0"
+        }
       },
       "groups": ["system"]
     }

--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryJudge.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryJudge.java
@@ -22,5 +22,6 @@ import com.netflix.kayenta.metrics.MetricSetPair;
 import java.util.List;
 
 public interface CanaryJudge {
+  String getName();
   CanaryJudgeResult judge(CanaryConfig canaryConfig, List<MetricSetPair> metricSetPairList);
 }

--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryJudgeDummy.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryJudgeDummy.java
@@ -25,17 +25,22 @@ import java.util.List;
 import java.util.Random;
 
 @Component
-// TODO(duftler): Make the canary judge a pluggable component.
-// TODO(mgraff, or duftler): move to its own subproject once it's pluggable.
 public class CanaryJudgeDummy implements CanaryJudge {
+  private static final String NAME = "dredd-v1.0";
+
   private Random random = new Random();
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
 
   @Override
   public CanaryJudgeResult judge(CanaryConfig canaryConfig, List<MetricSetPair> metricSetPairList) {
     // TODO: "You're the judge; so judge!"
 
     CanaryJudgeScore score = CanaryJudgeScore.builder().score(random.nextDouble() * 100).build();
-    CanaryJudgeResult result = CanaryJudgeResult.builder().score(score).build();
+    CanaryJudgeResult result = CanaryJudgeResult.builder().judgeName(NAME).score(score).build();
     return result;
   }
 }

--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/results/CanaryJudgeResult.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/results/CanaryJudgeResult.java
@@ -36,6 +36,10 @@ public class CanaryJudgeResult {
 
   @NotNull
   @Getter
+  private String judgeName;
+
+  @NotNull
+  @Getter
   private Map<String, CanaryAnalysisResult> results;
 
   @NotNull

--- a/kayenta-core/src/main/java/com/netflix/kayenta/controllers/CanaryJudgesController.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/controllers/CanaryJudgesController.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.controllers;
+
+import com.netflix.kayenta.canary.CanaryJudge;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/judges")
+public class CanaryJudgesController {
+
+  @Autowired
+  List<CanaryJudge> canaryJudges;
+
+  @ApiOperation(value = "Retrieve a list of all configured canary judges")
+  @RequestMapping(method = RequestMethod.GET)
+  List<CanaryJudge> list() {
+    return canaryJudges;
+  }
+}

--- a/kayenta-judge-netflix/src/main/scala/com/netflix/kayenta/judge/netflix/NetflixJudge.scala
+++ b/kayenta-judge-netflix/src/main/scala/com/netflix/kayenta/judge/netflix/NetflixJudge.scala
@@ -23,6 +23,10 @@ import com.netflix.kayenta.canary.{CanaryConfig, CanaryJudge}
 import com.netflix.kayenta.metrics.MetricSetPair
 
 class NetflixJudge extends CanaryJudge {
+  override def getName(): String = {
+    "netflixJudge-v1.0"
+  }
+
   override def judge(canaryConfig: CanaryConfig, metricSetPairList: util.List[MetricSetPair]): CanaryJudgeResult = {
     val result = CanaryJudgeResult.builder().build()
     result

--- a/kayenta-web/config/kayenta.yml
+++ b/kayenta-web/config/kayenta.yml
@@ -51,6 +51,7 @@ swagger:
     - /canaryConfig.*
     - /credentials.*
     - /fetch.*
+    - /judges.*
     - /metricSetList.*
     - /metricSetPairList.*
     - /pipeline.*

--- a/scratch/atlas_canary_config.json
+++ b/scratch/atlas_canary_config.json
@@ -15,7 +15,7 @@
       ],
       "analysisConfigurations": {
         "canary": {
-
+          "judge": "dredd-v1.0"
         }
       }
     },

--- a/scratch/stackdriver_canary_config.json
+++ b/scratch/stackdriver_canary_config.json
@@ -12,7 +12,7 @@
       },
       "analysisConfigurations": {
         "canary": {
-
+          "judge": "dredd-v1.0"
         }
       },
       "groups": [


### PR DESCRIPTION
Add 'judge' configuration attribute.
Add /judges endpoint to query for list of configured judges.