### PR TITLE
feat(prometheus): Initial step at plumbing in prometheus -- incomplete

### DIFF
--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryMetricSetQueryConfig.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryMetricSetQueryConfig.java
@@ -20,10 +20,12 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.netflix.kayenta.canary.providers.AtlasCanaryMetricSetQueryConfig;
+import com.netflix.kayenta.canary.providers.PrometheusCanaryMetricSetQueryConfig;
 import com.netflix.kayenta.canary.providers.StackdriverCanaryMetricSetQueryConfig;
 
 @JsonTypeInfo(use= JsonTypeInfo.Id.NAME, include= JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes({@JsonSubTypes.Type(value = AtlasCanaryMetricSetQueryConfig.class, name = "atlas"),
+               @JsonSubTypes.Type(value = PrometheusCanaryMetricSetQueryConfig.class, name = "prometheus"),
                @JsonSubTypes.Type(value = StackdriverCanaryMetricSetQueryConfig.class, name = "stackdriver")})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public interface CanaryMetricSetQueryConfig {}

--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/providers/PrometheusCanaryMetricSetQueryConfig.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/providers/PrometheusCanaryMetricSetQueryConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.canary.providers;
+
+import com.netflix.kayenta.canary.CanaryMetricSetQueryConfig;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+// TODO(duftler): Figure out how to move this into the kayenta-prometheus module? Doing so as-is would introduce a circular dependency.
+public class PrometheusCanaryMetricSetQueryConfig implements CanaryMetricSetQueryConfig {
+
+  @NotNull
+  @Getter
+  private String metricName;
+
+  @Getter
+  private String aggregationPeriod;
+
+  @Getter
+  private String instancePattern;
+
+  @Getter
+  private List<String> labelBindings;
+
+  @Getter
+  private List<String> sumByFields;
+}

--- a/kayenta-prometheus/kayenta-prometheus.gradle
+++ b/kayenta-prometheus/kayenta-prometheus.gradle
@@ -1,0 +1,14 @@
+dependencies {
+  compile project(":kayenta-core")
+
+  // compile spinnaker.dependency('bootWeb')
+  compile "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
+
+  // compile spinnaker.dependency("korkSwagger")
+  compile "com.netflix.spinnaker.kork:kork-swagger:$korkVersion"
+
+  // compile spinnaker.dependency('lombok')
+  compile "org.projectlombok:lombok:1.16.10"
+
+  compile "com.netflix.spinnaker.orca:orca-core:$orcaVersion"
+}

--- a/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/canary/PrometheusCanaryScope.java
+++ b/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/canary/PrometheusCanaryScope.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.prometheus.canary;
+
+import com.netflix.kayenta.canary.CanaryScope;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class PrometheusCanaryScope extends CanaryScope {
+
+  @NotNull
+  private String type;
+
+  @NotNull
+  private String intervalStartTimeIso;
+
+  @NotNull
+  private String intervalEndTimeIso;
+}

--- a/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/canary/PrometheusCanaryScopeFactory.java
+++ b/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/canary/PrometheusCanaryScopeFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.prometheus.canary;
+
+import com.netflix.kayenta.canary.CanaryScope;
+import com.netflix.kayenta.canary.CanaryScopeFactory;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Map;
+
+@Component
+public class PrometheusCanaryScopeFactory implements CanaryScopeFactory {
+
+  @Override
+  public boolean handles(String serviceType) {
+    return "prometheus".equals(serviceType);
+  }
+
+  @Override
+  public CanaryScope buildCanaryScope(String scope,
+                                      Instant startTimeInstant,
+                                      Instant endTimeInstant,
+                                      String step,
+                                      Map<String, String> extendedScopeParams) {
+    PrometheusCanaryScope prometheusCanaryScope = new PrometheusCanaryScope();
+    prometheusCanaryScope.setScope(scope);
+    prometheusCanaryScope.setStart(startTimeInstant.toEpochMilli() + "");
+    prometheusCanaryScope.setEnd(endTimeInstant.toEpochMilli() + "");
+    prometheusCanaryScope.setIntervalStartTimeIso(startTimeInstant + "");
+    prometheusCanaryScope.setIntervalEndTimeIso(endTimeInstant + "");
+    prometheusCanaryScope.setStep(step);
+
+    if (extendedScopeParams != null && extendedScopeParams.containsKey("type")) {
+      prometheusCanaryScope.setType(extendedScopeParams.get("type"));
+    }
+
+    return prometheusCanaryScope;
+  }
+}

--- a/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/config/PrometheusConfiguration.java
+++ b/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/config/PrometheusConfiguration.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.prometheus.config;
+
+import com.netflix.kayenta.prometheus.metrics.PrometheusMetricsService;
+import com.netflix.kayenta.prometheus.security.PrometheusCredentials;
+import com.netflix.kayenta.prometheus.security.PrometheusNamedAccountCredentials;
+import com.netflix.kayenta.prometheus.service.PrometheusRemoteService;
+import com.netflix.kayenta.metrics.MetricsService;
+import com.netflix.kayenta.retrofit.config.RetrofitClientFactory;
+import com.netflix.kayenta.security.AccountCredentials;
+import com.netflix.kayenta.security.AccountCredentialsRepository;
+import com.squareup.okhttp.OkHttpClient;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.CollectionUtils;
+
+import java.io.IOException;
+import java.util.List;
+
+@Configuration
+@EnableConfigurationProperties
+@ConditionalOnProperty("kayenta.prometheus.enabled")
+@ComponentScan({"com.netflix.kayenta.prometheus"})
+@Slf4j
+public class PrometheusConfiguration {
+
+  @Bean
+  @ConfigurationProperties("kayenta.prometheus")
+  PrometheusConfigurationProperties prometheusConfigurationProperties() {
+    return new PrometheusConfigurationProperties();
+  }
+
+  // This is following Atlas pattern, which uses a single global service.
+  // However, I might rather have an endpoint per account or some list of services if monitoring is partitioned
+  // across multiple prometheus servers. I dont know how to wire that up in Spring unless I were to change
+  // the RemoteService to a facade that used an endpoint from the request (either injected or from credentials used).
+  @Bean
+  MetricsService prometheusMetricsService(PrometheusConfigurationProperties prometheusConfigurationProperties,
+                                     AccountCredentialsRepository accountCredentialsRepository,
+                                     PrometheusRemoteService prometheusRemoteService) throws IOException {
+    PrometheusMetricsService.PrometheusMetricsServiceBuilder prometheusMetricsServiceBuilder = PrometheusMetricsService.builder();
+    prometheusMetricsServiceBuilder.scopeLabel(prometheusConfigurationProperties.getScopeLabel());
+
+    for (PrometheusManagedAccount prometheusManagedAccount : prometheusConfigurationProperties.getAccounts()) {
+      String name = prometheusManagedAccount.getName();
+      List<AccountCredentials.Type> supportedTypes = prometheusManagedAccount.getSupportedTypes();
+
+      log.info("Registering Prometheus account {} with supported types {}.", name, supportedTypes);
+
+      PrometheusCredentials prometheusCredentials =
+        PrometheusCredentials
+          .builder()
+          .build();
+      PrometheusNamedAccountCredentials.PrometheusNamedAccountCredentialsBuilder prometheusNamedAccountCredentialsBuilder =
+        PrometheusNamedAccountCredentials
+          .builder()
+          .name(name)
+          .credentials(prometheusCredentials);
+
+      if (!CollectionUtils.isEmpty(supportedTypes)) {
+        if (supportedTypes.contains(AccountCredentials.Type.METRICS_STORE)) {
+          prometheusNamedAccountCredentialsBuilder.prometheusRemoteService(prometheusRemoteService);
+        }
+
+        prometheusNamedAccountCredentialsBuilder.supportedTypes(supportedTypes);
+      }
+
+      PrometheusNamedAccountCredentials prometheusNamedAccountCredentials = prometheusNamedAccountCredentialsBuilder.build();
+      accountCredentialsRepository.save(name, prometheusNamedAccountCredentials);
+      prometheusMetricsServiceBuilder.accountName(name);
+    }
+
+    PrometheusMetricsService prometheusMetricsService = prometheusMetricsServiceBuilder.build();
+
+    log.info("Populated PrometheusMetricsService with {} Prometheus accounts.", prometheusMetricsService.getAccountNames().size());
+
+    return prometheusMetricsService;
+  }
+
+  @Bean
+  PrometheusRemoteService prometheusRemoteService(PrometheusResponseConverter prometheusConverter,
+                                                  PrometheusConfigurationProperties prometheusConfigurationProperties,
+                                                  RetrofitClientFactory retrofitClientFactory,
+                                                  OkHttpClient okHttpClient) {
+    return retrofitClientFactory.createClient(PrometheusRemoteService.class,
+                                              prometheusConverter,
+                                              prometheusConfigurationProperties.getEndpoint(),
+                                              okHttpClient);
+  }
+}

--- a/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/config/PrometheusConfigurationProperties.java
+++ b/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/config/PrometheusConfigurationProperties.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.prometheus.config;
+
+import com.netflix.kayenta.retrofit.config.RemoteService;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+
+// TODO(ewiseblatt):
+// @Data this class instead of @Getter/Setter and final the "accounts".
+public class PrometheusConfigurationProperties {
+
+  /**
+   * TODO(ewiseblatt):
+   * We're saying "instance" here by default, which is built-in to Prometheus.
+   * However, in practice this should be overriden to "host" where "host"
+   * is injected on scrape by the prometheus.yml configuration. The install
+   * for prometheus when using the --gce option does this, but that is the
+   * only configuration that does at this time.
+   *
+   * The difference is that prometheus adds "instance" as the __address__,
+   * which is the <host>:<port> but the <host> is typically an IP address.
+   * Instance can be explicitly overriden as well, but should be the particular
+   * service endpoint.
+   *
+   * In general, you do want the particular service endpoint in order to get
+   * the particular service of interest. In the case of looking for node_cpu,
+   * which is the default, then you would need to add the node_exporter service
+   * to the request (i.e. instance is <host>:9100). Using the above "host", this
+   * would collect *all* node_cpu from that host. However we assume that only
+   * the node_exporter is exporting "node_cpu" so there is only one (port 9100).
+   *
+   * I need to clean this up. Perhaps by configuring default prometheus to use
+   * the dns name instead of the IP in general for the __address__. Regardless,
+   * the application scraping can determine its own "instance" value (as well
+   * as "host") in which case the operator might need to compensate in how they
+   * configure this scopeLabel value and query using it.
+   */
+  @Getter
+  @Setter
+  private String scopeLabel = "instance";
+
+  // Location of prometheus server.
+  @NotNull
+  @Getter
+  @Setter
+  private RemoteService endpoint;
+
+  @Getter
+  private List<PrometheusManagedAccount> accounts = new ArrayList<>();
+}

--- a/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/config/PrometheusManagedAccount.java
+++ b/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/config/PrometheusManagedAccount.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.prometheus.config;
+
+import com.netflix.kayenta.security.AccountCredentials;
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Data
+public class PrometheusManagedAccount {
+
+  @NotNull
+  private String name;
+
+  private List<AccountCredentials.Type> supportedTypes;
+}

--- a/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/config/PrometheusResponseConverter.java
+++ b/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/config/PrometheusResponseConverter.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.prometheus.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.kayenta.prometheus.model.PrometheusResults;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import retrofit.converter.ConversionException;
+import retrofit.converter.Converter;
+import retrofit.mime.TypedInput;
+import retrofit.mime.TypedOutput;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+
+@Component
+@Slf4j
+public class PrometheusResponseConverter implements Converter {
+
+  private static final ObjectMapper objectMapper = new ObjectMapper()
+    .setSerializationInclusion(NON_NULL)
+    .disable(FAIL_ON_UNKNOWN_PROPERTIES);
+
+  @Override
+  public List<PrometheusResults> fromBody(TypedInput body, Type type) throws ConversionException {
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(body.in()))) {
+      String json = reader.readLine();
+      Map responseMap = objectMapper.readValue(json, Map.class);
+      Map data = (Map)responseMap.get("data");
+      List<Map> resultList = (List<Map>)data.get("result");
+      if (resultList == null || resultList.isEmpty()) {
+        log.error("Received no data from Prometheus.");
+        return null;
+      }
+
+      List<PrometheusResults> prometheusResultsList = new ArrayList<PrometheusResults>(resultList.size());
+      for (Map elem : resultList) {
+          Map<String, String> tags = (Map<String, String>)elem.get("metric");
+          String id = tags.get("__name__");
+          String query = id; // !!! I dont know the original query
+          tags.remove("__name__");
+
+          List<List> values = (List<List>)elem.get("values");
+          List<Double> dataValues = new ArrayList<Double>(values.size());
+          for (List tuple : values) {
+              dataValues.add(Double.valueOf((String)tuple.get(1)));
+          }
+
+          long startSecs = ((Integer)values.get(0).get(0)).longValue();
+          long stepSecs = ((Integer)values.get(1).get(0)).longValue() - startSecs;
+          long endSecs = startSecs + values.size() * stepSecs;
+          prometheusResultsList.add(
+              new PrometheusResults(id, query,
+                                    startSecs, stepSecs, endSecs,
+                                    tags, dataValues));
+      }
+
+      return prometheusResultsList;
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+    return null;
+  }
+
+  @Override
+  public TypedOutput toBody(Object object) {
+    return null;
+  }
+}

--- a/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/controllers/PrometheusFetchController.java
+++ b/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/controllers/PrometheusFetchController.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.prometheus.controllers;
+
+import com.netflix.kayenta.prometheus.canary.PrometheusCanaryScope;
+import com.netflix.kayenta.canary.CanaryMetricConfig;
+import com.netflix.kayenta.canary.providers.PrometheusCanaryMetricSetQueryConfig;
+import com.netflix.kayenta.metrics.SynchronousQueryProcessor;
+import com.netflix.kayenta.security.AccountCredentials;
+import com.netflix.kayenta.security.AccountCredentialsRepository;
+import com.netflix.kayenta.security.CredentialsHelper;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+@RestController
+@RequestMapping("/fetch/prometheus")
+@Slf4j
+public class PrometheusFetchController {
+
+  @Autowired
+  AccountCredentialsRepository accountCredentialsRepository;
+
+  @Autowired
+  SynchronousQueryProcessor synchronousQueryProcessor;
+
+  @RequestMapping(value = "/query", method = RequestMethod.POST)
+  public String queryMetrics(@RequestParam(required = false) final String metricsAccountName,
+                             @RequestParam(required = false) final String storageAccountName,
+                             @ApiParam(defaultValue = "node_cpu") @RequestParam String metricName,
+                             @RequestParam(required = false, defaultValue = "60s") String aggregationPeriod,
+                             @RequestParam(required = false, defaultValue = "localhost:9100") String scope,
+                             @RequestParam(required = false, defaultValue = "mode=~\"user|system\"\njob=\"node\"") List<String> labelBindings,
+                             @RequestParam(required = false) List<String> sumByFields,
+
+                             @ApiParam(defaultValue = "cpu") @RequestParam String metricSetName,
+                             @ApiParam(defaultValue = "2017-08-17T21:13:00Z") @RequestParam String start,
+                             @ApiParam(defaultValue = "2017-08-17T21:30:00Z") @RequestParam String end,
+                             @ApiParam(defaultValue = "15s") @RequestParam String step) throws IOException {
+    String resolvedMetricsAccountName = CredentialsHelper.resolveAccountByNameOrType(metricsAccountName,
+                                                                                     AccountCredentials.Type.METRICS_STORE,
+                                                                                     accountCredentialsRepository);
+    String resolvedStorageAccountName = CredentialsHelper.resolveAccountByNameOrType(storageAccountName,
+                                                                                     AccountCredentials.Type.OBJECT_STORE,
+                                                                                     accountCredentialsRepository);
+
+    PrometheusCanaryMetricSetQueryConfig prometheusCanaryMetricSetQueryConfig =
+      PrometheusCanaryMetricSetQueryConfig
+        .builder()
+        .metricName(metricName)
+        .aggregationPeriod(aggregationPeriod)
+        .labelBindings(labelBindings)
+        .sumByFields(sumByFields)
+        .build();
+    CanaryMetricConfig canaryMetricConfig =
+      CanaryMetricConfig
+        .builder()
+        .name(metricSetName)
+        .query(prometheusCanaryMetricSetQueryConfig)
+        .build();
+
+    PrometheusCanaryScope prometheusCanaryScope = new PrometheusCanaryScope();
+    prometheusCanaryScope.setScope(scope);
+    prometheusCanaryScope.setStart(start);
+    prometheusCanaryScope.setEnd(end);
+    prometheusCanaryScope.setStep(step);
+
+    return synchronousQueryProcessor.processQuery(resolvedMetricsAccountName,
+                                                  resolvedStorageAccountName,
+                                                  Collections.singletonList(canaryMetricConfig),
+                                                  prometheusCanaryScope).get(0);
+  }
+}

--- a/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/metrics/PrometheusMetricsService.java
+++ b/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/metrics/PrometheusMetricsService.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.prometheus.metrics;
+
+import com.netflix.kayenta.prometheus.canary.PrometheusCanaryScope;
+import com.netflix.kayenta.prometheus.model.PrometheusResults;
+import com.netflix.kayenta.prometheus.security.PrometheusNamedAccountCredentials;
+import com.netflix.kayenta.prometheus.service.PrometheusRemoteService;
+import com.netflix.kayenta.canary.CanaryMetricConfig;
+import com.netflix.kayenta.canary.CanaryScope;
+import com.netflix.kayenta.canary.providers.PrometheusCanaryMetricSetQueryConfig;
+import com.netflix.kayenta.metrics.MetricSet;
+import com.netflix.kayenta.metrics.MetricsService;
+import com.netflix.kayenta.security.AccountCredentialsRepository;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Singular;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.validation.constraints.NotNull;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Builder
+@Slf4j
+public class PrometheusMetricsService implements MetricsService {
+
+  @NotNull
+  private String scopeLabel;
+
+  @NotNull
+  @Singular
+  @Getter
+  private List<String> accountNames;
+
+  @Autowired
+  AccountCredentialsRepository accountCredentialsRepository;
+
+  @Override
+  public boolean servicesAccount(String accountName) {
+    return accountNames.contains(accountName);
+  }
+
+  private StringBuilder addScopeFilter(StringBuilder queryBuilder, String scope, PrometheusCanaryMetricSetQueryConfig queryConfig) {
+    List<String> filters = queryConfig.getLabelBindings();
+    if (filters == null) {
+      filters = new ArrayList<String>();
+    }
+
+    if (scope != null && (!scope.isEmpty() || !scope.equals(".*"))) {
+      filters.add(scopeLabel + "=~\"" + scope + "\"");
+    }
+
+    if (!filters.isEmpty()) {
+      String sep = "";
+      queryBuilder.append('{');
+      for (String binding : filters) {
+        queryBuilder.append(sep);
+        queryBuilder.append(binding);
+        sep = ",";
+      }
+      queryBuilder.append('}');
+    }
+
+    return queryBuilder;
+  }
+
+  private StringBuilder addRateQuery(StringBuilder queryBuilder, PrometheusCanaryMetricSetQueryConfig queryConfig) {
+    String period = queryConfig.getAggregationPeriod();
+    if (period != null && !period.trim().isEmpty()) {
+      queryBuilder.insert(0, "rate(");
+      queryBuilder.append("[" + period + "])");
+    }
+    return queryBuilder;
+  }
+
+  private StringBuilder addSumQuery(StringBuilder queryBuilder, PrometheusCanaryMetricSetQueryConfig queryConfig) {
+    List<String> sumByFields = queryConfig.getSumByFields();
+    if (sumByFields != null && !sumByFields.isEmpty()) {
+        queryBuilder.insert(0, "sum (");
+        queryBuilder.append(") by (");
+        String sep = "";
+        for (String elem : sumByFields) {
+          queryBuilder.append(sep);
+          queryBuilder.append(elem);
+          sep = ",";
+        }
+        queryBuilder.append(")");
+    }
+    return queryBuilder;
+  }
+
+  @Override
+  public List<MetricSet> queryMetrics(String accountName,
+                                      CanaryMetricConfig canaryMetricConfig,
+                                      CanaryScope canaryScope) throws IOException {
+    if (!(canaryScope instanceof PrometheusCanaryScope)) {
+      throw new IllegalArgumentException("Canary scope not instance of PrometheusCanaryScope: " + canaryScope);
+    }
+
+    PrometheusCanaryScope prometheusCanaryScope = (PrometheusCanaryScope)canaryScope;
+    PrometheusNamedAccountCredentials credentials = (PrometheusNamedAccountCredentials)accountCredentialsRepository
+      .getOne(accountName)
+      .orElseThrow(() -> new IllegalArgumentException("Unable to resolve account " + accountName + "."));
+    PrometheusRemoteService prometheusRemoteService = credentials.getPrometheusRemoteService();
+    PrometheusCanaryMetricSetQueryConfig queryConfig = (PrometheusCanaryMetricSetQueryConfig)canaryMetricConfig.getQuery();
+
+    StringBuilder queryBuilder = new StringBuilder(queryConfig.getMetricName());
+    queryBuilder = addScopeFilter(queryBuilder, prometheusCanaryScope.getScope(), queryConfig);
+    queryBuilder = addRateQuery(queryBuilder, queryConfig);
+    queryBuilder = addSumQuery(queryBuilder, queryConfig);
+
+    List<PrometheusResults> prometheusResultsList = prometheusRemoteService.fetch(queryBuilder.toString(),
+                                                                                  prometheusCanaryScope.getStart(),
+                                                                                  prometheusCanaryScope.getEnd(),
+                                                                                  prometheusCanaryScope.getStep());
+    List<MetricSet> metricSetList = new ArrayList<>();
+
+    for (PrometheusResults prometheusResults : prometheusResultsList) {
+        Instant responseStartTimeInstant = Instant.ofEpochSecond(prometheusResults.getStartSecs());
+      MetricSet.MetricSetBuilder metricSetBuilder =
+        MetricSet.builder()
+          .name(canaryMetricConfig.getName())
+          .startTimeMillis(TimeUnit.NANOSECONDS.toMillis(prometheusResults.getStartSecs()))
+          .startTimeIso(responseStartTimeInstant.toString())
+          .stepMillis(TimeUnit.SECONDS.toMillis(prometheusResults.getStepSecs()))
+          .values(prometheusResults.getValues());
+
+      Map<String, String> tags = prometheusResults.getTags();
+
+      if (tags != null) {
+        metricSetBuilder.tags(tags);
+      }
+
+      metricSetList.add(metricSetBuilder.build());
+    }
+
+    return metricSetList;
+  }
+}

--- a/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/model/PrometheusResults.java
+++ b/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/model/PrometheusResults.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.prometheus.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.validation.constraints.NotNull;
+import java.util.Map;
+import java.util.List;
+
+@Builder
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+public class PrometheusResults {
+
+  @NotNull
+  @Getter
+  private String id;
+
+  @NotNull
+  @Getter
+  private String query;
+
+  @NotNull
+  @Getter
+  private long startSecs;
+
+  @NotNull
+  @Getter
+  private long stepSecs;
+
+  @NotNull
+  @Getter
+  private long endSecs;
+
+  @NotNull
+  @Getter
+  private Map<String, String> tags;
+
+  @NotNull
+  @Getter
+  private List<Double> values;
+}

--- a/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/orca/PrometheusFetchStage.java
+++ b/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/orca/PrometheusFetchStage.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.prometheus.orca;
+
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
+import com.netflix.spinnaker.orca.pipeline.TaskNode;
+import com.netflix.spinnaker.orca.pipeline.model.Execution;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PrometheusFetchStage {
+
+  @Bean
+  StageDefinitionBuilder prometheusFetchStageBuilder(){
+    return new StageDefinitionBuilder() {
+      @Override
+      public <T extends Execution<T>> void taskGraph(Stage<T> stage, TaskNode.Builder builder) {
+        builder.withTask("prometheusFetch", PrometheusFetchTask.class);
+      }
+
+      @Override
+      public String getType() {
+        return "prometheusFetch";
+      }
+    };
+  }
+}

--- a/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/orca/PrometheusFetchTask.java
+++ b/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/orca/PrometheusFetchTask.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.prometheus.orca;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.kayenta.canary.CanaryConfig;
+import com.netflix.kayenta.metrics.SynchronousQueryProcessor;
+import com.netflix.kayenta.security.AccountCredentials;
+import com.netflix.kayenta.security.AccountCredentialsRepository;
+import com.netflix.kayenta.security.CredentialsHelper;
+import com.netflix.kayenta.prometheus.canary.PrometheusCanaryScope;
+import com.netflix.kayenta.storage.ObjectType;
+import com.netflix.kayenta.storage.StorageService;
+import com.netflix.kayenta.storage.StorageServiceRepository;
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.RetryableTask;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class PrometheusFetchTask implements RetryableTask {
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @Autowired
+  AccountCredentialsRepository accountCredentialsRepository;
+
+  @Autowired
+  StorageServiceRepository storageServiceRepository;
+
+  @Autowired
+  SynchronousQueryProcessor synchronousQueryProcessor;
+
+  @Override
+  public long getBackoffPeriod() {
+    // TODO(duftler): Externalize this configuration.
+    // TODO(ewiseblatt): Copied from stackdriver.
+    return Duration.ofSeconds(2).toMillis();
+  }
+
+  @Override
+  public long getTimeout() {
+    // TODO(duftler): Externalize this configuration.
+    // TODO(ewiseblatt): Copied from stackdriver.
+    return Duration.ofMinutes(2).toMillis();
+  }
+
+  @Override
+  public TaskResult execute(Stage stage) {
+    Map<String, Object> context = stage.getContext();
+    String metricsAccountName = (String)context.get("metricsAccountName");
+    String storageAccountName = (String)context.get("storageAccountName");
+    String canaryConfigId = (String)context.get("canaryConfigId");
+    PrometheusCanaryScope prometheusCanaryScope =
+      objectMapper.convertValue(stage.getContext().get("prometheusCanaryScope"), PrometheusCanaryScope.class);
+    String resolvedMetricsAccountName = CredentialsHelper.resolveAccountByNameOrType(metricsAccountName,
+                                                                                     AccountCredentials.Type.METRICS_STORE,
+                                                                                     accountCredentialsRepository);
+    String resolvedStorageAccountName = CredentialsHelper.resolveAccountByNameOrType(storageAccountName,
+                                                                                     AccountCredentials.Type.OBJECT_STORE,
+                                                                                     accountCredentialsRepository);
+    StorageService storageService =
+      storageServiceRepository
+        .getOne(resolvedStorageAccountName)
+        .orElseThrow(() -> new IllegalArgumentException("No storage service was configured; unable to load canary config."));
+
+    try {
+      CanaryConfig canaryConfig =
+        storageService.loadObject(resolvedStorageAccountName, ObjectType.CANARY_CONFIG, canaryConfigId.toLowerCase());
+
+
+      Instant startTimeInstant = Instant.parse(prometheusCanaryScope.getIntervalStartTimeIso());
+      long startTimeMillis = startTimeInstant.toEpochMilli();
+      Instant endTimeInstant = Instant.parse(prometheusCanaryScope.getIntervalEndTimeIso());
+      long endTimeMillis = endTimeInstant.toEpochMilli();
+      /*
+      prometheusCanaryScope.setStart(startTimeMillis + "");
+      prometheusCanaryScope.setEnd(endTimeMillis + "");
+      */
+      prometheusCanaryScope.setStart(prometheusCanaryScope.getIntervalStartTimeIso());
+      prometheusCanaryScope.setEnd(prometheusCanaryScope.getIntervalEndTimeIso());
+
+      List<String> metricSetListIds = synchronousQueryProcessor.processQuery(resolvedMetricsAccountName,
+                                                                             resolvedStorageAccountName,
+                                                                             canaryConfig.getMetrics(),
+                                                                             prometheusCanaryScope);
+
+      Map outputs = Collections.singletonMap("metricSetListIds", metricSetListIds);
+
+      return new TaskResult(ExecutionStatus.SUCCEEDED, outputs);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/security/PrometheusCredentials.java
+++ b/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/security/PrometheusCredentials.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.prometheus.security;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Optional;
+
+@Builder
+@Data
+@Slf4j
+// TODO(ewisbelatt): Not sure what kind of credentials or configuration is really required here yet.
+//       Prometheus does not have security. To secure it, you front it with a webserver that adds security (e.g. basic auth).
+//       So this is likely just a username/password.
+public class PrometheusCredentials {
+
+  private static String applicationVersion =
+    Optional.ofNullable(PrometheusCredentials.class.getPackage().getImplementationVersion()).orElse("Unknown");
+}

--- a/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/security/PrometheusNamedAccountCredentials.java
+++ b/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/security/PrometheusNamedAccountCredentials.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.prometheus.security;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.netflix.kayenta.prometheus.service.PrometheusRemoteService;
+import com.netflix.kayenta.retrofit.config.RemoteService;
+import com.netflix.kayenta.security.AccountCredentials;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Singular;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Builder
+@Data
+public class PrometheusNamedAccountCredentials implements AccountCredentials<PrometheusCredentials> {
+
+  @NotNull
+  private String name;
+
+  @NotNull
+  @Singular
+  private List<Type> supportedTypes;
+
+  @NotNull
+  private PrometheusCredentials credentials;
+
+  // The prometheus server location.
+  @NotNull
+  private RemoteService endpoint;
+
+  @Override
+  public String getType() {
+    return "prometheus";
+  }
+
+  @JsonIgnore
+  PrometheusRemoteService prometheusRemoteService;
+}

--- a/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/service/PrometheusRemoteService.java
+++ b/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/service/PrometheusRemoteService.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.prometheus.service;
+
+import com.netflix.kayenta.prometheus.model.PrometheusResults;
+import retrofit.http.GET;
+import retrofit.http.Query;
+
+import java.util.List;
+
+public interface PrometheusRemoteService {
+
+  // See https://prometheus.io/docs/querying/api/#range-queries
+  @GET("/api/v1/query_range")
+  List<PrometheusResults> fetch(@Query("query") String query,
+                           @Query("start") String start,
+                           @Query("end") String end,
+                           @Query("step") String step);
+}

--- a/kayenta-web/kayenta-web.gradle
+++ b/kayenta-web/kayenta-web.gradle
@@ -21,6 +21,7 @@ dependencies {
   compile project(':kayenta-google')
   compile project(':kayenta-objectstore-memory')
   compile project(':kayenta-orca')
+  compile project(':kayenta-prometheus')
   compile project(':kayenta-stackdriver')
 
   // compile spinnaker.dependency('bootActuator')

--- a/kayenta-web/src/main/java/com/netflix/kayenta/Main.java
+++ b/kayenta-web/src/main/java/com/netflix/kayenta/Main.java
@@ -22,6 +22,7 @@ import com.netflix.kayenta.config.WebConfiguration;
 import com.netflix.kayenta.gcs.config.GcsConfiguration;
 import com.netflix.kayenta.google.config.GoogleConfiguration;
 import com.netflix.kayenta.memory.config.MemoryConfiguration;
+import com.netflix.kayenta.prometheus.config.PrometheusConfiguration;
 import com.netflix.kayenta.stackdriver.config.StackdriverConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -42,6 +43,7 @@ import java.util.Map;
   KayentaConfiguration.class,
   MemoryConfiguration.class,
   StackdriverConfiguration.class,
+  PrometheusConfiguration.class,
   WebConfiguration.class
 })
 @ComponentScan({

--- a/scratch/prometheus_canary_config.json
+++ b/scratch/prometheus_canary_config.json
@@ -1,0 +1,40 @@
+{
+  "name": "MySamplePrometheusCanaryConfig",
+  "description": "Example Automated Canary Analysis (ACA) Configuration using Prometheus",
+  "configVersion": 1.0,
+  "metrics": [
+    {
+      "serviceName": "prometheus",
+      "name": "cpu",
+      "query": {
+        "type": "prometheus",
+        "metricName": "node_cpu",
+        "metricAggregationPeriod": "60s",
+        "metricLabelBindings": ["mode=~\"user|system\"", "job=\"node\""]
+      },
+      "analysisConfigurations": {
+        "canary": {
+          "judge": "dredd-v1.0"
+        }
+      },
+      "groups": [
+        "system"
+      ]
+    }
+  ],
+  "services": {
+    "prometheus": {
+      "type": "prometheus",
+      "name": "prometheus"
+    }
+  },
+  "classifier": {
+    "groupWeights": {
+      "system": 100.0
+    },
+    "scoreThresholds": {
+      "pass": 95.0,
+      "marginal": 75.0
+    }
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,6 +23,7 @@ include 'kayenta-google'
 include 'kayenta-judge-netflix'
 include 'kayenta-objectstore-memory'
 include 'kayenta-orca'
+include 'kayenta-prometheus'
 include 'kayenta-stackdriver'
 include 'kayenta-web'
 


### PR DESCRIPTION
This seems sufficient to make /fetch/prometheus/query requests
and view /metricSetList results.

Here is an example configuration for kayenta-local.yml
  prometheus:
    enabled: true
    endpoint:
      baseUrl: http://localhost:9090

    accounts:
      - name: my-prometheus-server
        supportedTypes:
          - METRICS_STORE


@duftler