### PR TITLE
Remove groupWeights from the CanaryConfig

### DIFF
--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryConfig.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryConfig.java
@@ -80,11 +80,6 @@ public class CanaryConfig {
   private Map<String, CanaryServiceConfig> services;
 
   @NotNull
-  @Singular
-  @Getter
-  private Map<String, Double> groupWeights;
-
-  @NotNull
   @Getter
   private CanaryClassifierConfig classifier;
 


### PR DESCRIPTION
Remove `groupWeights` from the root of the `CanaryConfig`. The `groupWeights` object is already defined in `CanaryClassifierConfig`.