### PR TITLE
Use the absolute value of the calculated point estimate

### DIFF
--- a/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/classifiers/metric/MannWhitneyClassifier.scala
+++ b/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/classifiers/metric/MannWhitneyClassifier.scala
@@ -55,8 +55,10 @@ class MannWhitneyClassifier(fraction: Double=0.25, confLevel: Double=0.95, mw: M
     * @param testResult
     * @return
     */
-  def calculateBounds(testResult: MannWhitneyResult):  (Double, Double)={
-    val criticalValue = fraction * testResult.estimate
+  def calculateBounds(testResult: MannWhitneyResult):  (Double, Double) = {
+    val estimate = math.abs(testResult.estimate)
+    val criticalValue = fraction * estimate
+
     val lowerBound = -1 * criticalValue
     val upperBound = criticalValue
     (lowerBound, upperBound)


### PR DESCRIPTION
Use the absolute value of the Hodges–Lehmann estimator when calculating the upper and lower classification bounds.