### PR TITLE
implement Atlas id= query param

### DIFF
--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/config/AtlasConfiguration.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/config/AtlasConfiguration.java
@@ -76,6 +76,7 @@ public class AtlasConfiguration {
           .builder()
           .name(name)
           .credentials(atlasCredentials)
+          .fetchId(atlasManagedAccount.getFetchId())
           .backendUpdater(updater);
 
       if (!CollectionUtils.isEmpty(supportedTypes)) {

--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/config/AtlasManagedAccount.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/config/AtlasManagedAccount.java
@@ -31,5 +31,7 @@ public class AtlasManagedAccount {
   @NotNull
   String backendsJsonBaseUrl;
 
+  String fetchId;
+
   private List<AccountCredentials.Type> supportedTypes;
 }

--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/metrics/AtlasMetricsService.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/metrics/AtlasMetricsService.java
@@ -123,7 +123,8 @@ public class AtlasMetricsService implements MetricsService {
     List<AtlasResults> atlasResultsList = atlasRemoteService.fetch(decoratedQuery,
                                                                    atlasCanaryScope.getStart().toEpochMilli(),
                                                                    atlasCanaryScope.getEnd().toEpochMilli(),
-                                                                   isoStep);
+                                                                   isoStep,
+                                                                   credentials.getFetchId());
     Map<String, AtlasResults> idToAtlasResultsMap = AtlasResultsHelper.merge(atlasResultsList);
     List<MetricSet> metricSetList = new ArrayList<>();
 

--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/security/AtlasNamedAccountCredentials.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/security/AtlasNamedAccountCredentials.java
@@ -40,6 +40,8 @@ public class AtlasNamedAccountCredentials implements AccountCredentials<AtlasCre
   @NotNull
   private AtlasCredentials credentials;
 
+  private String fetchId;
+
   @Override
   public String getType() {
     return "atlas";

--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/service/AtlasRemoteService.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/service/AtlasRemoteService.java
@@ -29,5 +29,6 @@ public interface AtlasRemoteService {
   List<AtlasResults> fetch(@Query("q") String q,
                            @Query("s") Long start,
                            @Query("e") Long end,
-                           @Query("step") String step);
+                           @Query("step") String step,
+                           @Query("id") String id);
 }


### PR DESCRIPTION
Setting id= on an Atlas query URL allows rate limiting by id from Atlas clusters.

This is set via fetchId in the account config, and if omitted will be omitted from the query.