### PR TITLE
Try to work around / diagnose the ongoing timeout issue in atlas

### DIFF
--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/metrics/AtlasMetricsService.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/metrics/AtlasMetricsService.java
@@ -42,10 +42,7 @@ import javax.validation.constraints.NotNull;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -85,6 +82,7 @@ public class AtlasMetricsService implements MetricsService {
                                       CanaryScope canaryScope) throws IOException {
 
     OkHttpClient okHttpClient = new OkHttpClient();
+    // TODO: (mgraff, duftler) -- we should find out the defaults, and if too small, make this reasonable / configurable
     okHttpClient.setConnectTimeout(90, TimeUnit.SECONDS);
     okHttpClient.setReadTimeout(90, TimeUnit.SECONDS);
 
@@ -127,7 +125,8 @@ public class AtlasMetricsService implements MetricsService {
                                                                    atlasCanaryScope.getStart().toEpochMilli(),
                                                                    atlasCanaryScope.getEnd().toEpochMilli(),
                                                                    isoStep,
-                                                                   credentials.getFetchId());
+                                                                   credentials.getFetchId(),
+                                                                   UUID.randomUUID() + "");
     Map<String, AtlasResults> idToAtlasResultsMap = AtlasResultsHelper.merge(atlasResultsList);
     List<MetricSet> metricSetList = new ArrayList<>();
 

--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/service/AtlasRemoteService.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/service/AtlasRemoteService.java
@@ -30,5 +30,6 @@ public interface AtlasRemoteService {
                            @Query("s") Long start,
                            @Query("e") Long end,
                            @Query("step") String step,
-                           @Query("id") String id);
+                           @Query("id") String id,
+                           @Query("kayentaQueryUUID") String kayentaQueryUUID);
 }


### PR DESCRIPTION
Working on #124.  Atlas is timing out, and I am not yet sure why.

Strangely, I see a GET followed by a 200 status, then another GET for the same URL, followed by another 200 status reply.  This is normal as both my control and experiment scopes are the same.  However, I then later get an ERROR response, and this makes no sense.

This PR does two things:  One, sets the connect and read timeout on the http client to 90 seconds.  Two, it adds a random UUID to every query, which should allow for more easy pairing of any ERROR responses with the associated GET/PUT/etc.