### PR TITLE
feat(orca): Start orca queue processing after subsystems report healthy.

### DIFF
--- a/kayenta-core/src/main/java/com/netflix/kayenta/index/config/IndexConfiguration.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/index/config/IndexConfiguration.java
@@ -39,13 +39,13 @@ public class IndexConfiguration {
   }
 
   @Bean
-  CanaryConfigIndexingAgent canaryConfigCachingAgent(String currentInstanceId,
-                                                     JedisPool jedisPool,
-                                                     AccountCredentialsRepository accountCredentialsRepository,
-                                                     StorageServiceRepository storageServiceRepository,
-                                                     ObjectMapper kayentaObjectMapper,
-                                                     CanaryConfigIndex canaryConfigIndex,
-                                                     IndexConfigurationProperties indexConfigurationProperties) {
+  CanaryConfigIndexingAgent canaryConfigIndexingAgent(String currentInstanceId,
+                                                      JedisPool jedisPool,
+                                                      AccountCredentialsRepository accountCredentialsRepository,
+                                                      StorageServiceRepository storageServiceRepository,
+                                                      ObjectMapper kayentaObjectMapper,
+                                                      CanaryConfigIndex canaryConfigIndex,
+                                                      IndexConfigurationProperties indexConfigurationProperties) {
     return new CanaryConfigIndexingAgent(currentInstanceId,
                                          jedisPool,
                                          accountCredentialsRepository,


### PR DESCRIPTION
Canary config indexing agent now reports health as well.
Pipelines can still be initiated before queue processing starts; once it starts, the queued messages will be processed (or another kayenta instance will process them).