### PR TITLE
Add /canary/ endpoint, remove metricSetPairListId from old location

### DIFF
--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryExecutionStatusResponse.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryExecutionStatusResponse.java
@@ -37,9 +37,6 @@ public class CanaryExecutionStatusResponse {
 
   protected CanaryResult result;
 
-  // TODO: (mgraff) Remove this once our UIs are set up to get it from the canary result itself
-  protected String metricSetPairListId;
-
   //
   // buildTime is when the pipeline was first created.
   // startTime refers to the time the pipeline started running.


### PR DESCRIPTION
This is an intermediate update to provide an endpoint for `GET /canary/executionId`, which is the first step to removing the `GET /canary/configId/executionId` endpoint in a later commit.

This also completes the last part of removing the metricSetListId from the endpoint return and instead puts them in the location where they will be archived.

This will close #168 