### PR TITLE
allow config to be submitted at runtime

### DIFF
--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryAdhocExecutionRequest.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryAdhocExecutionRequest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.kayenta.canary;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+public class CanaryAdhocExecutionRequest {
+  @NotNull
+  protected CanaryConfig canaryConfig;
+
+  @NotNull
+  protected CanaryExecutionRequest executionRequest;
+}

--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/orca/CanaryJudgeStage.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/orca/CanaryJudgeStage.java
@@ -22,6 +22,8 @@ import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.Nonnull;
+
 @Component
 public class CanaryJudgeStage {
 
@@ -29,10 +31,11 @@ public class CanaryJudgeStage {
   StageDefinitionBuilder canaryJudgeStageBuilder(){
     return new StageDefinitionBuilder() {
       @Override
-      public void taskGraph(Stage stage, TaskNode.Builder builder) {
+      public void taskGraph(@Nonnull Stage stage, @Nonnull TaskNode.Builder builder) {
         builder.withTask("canaryJudge", CanaryJudgeTask.class);
       }
 
+      @Nonnull
       @Override
       public String getType() {
         return "canaryJudge";

--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/orca/SetupCanaryStage.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/orca/SetupCanaryStage.java
@@ -22,6 +22,8 @@ import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.Nonnull;
+
 @Component
 public class SetupCanaryStage {
 
@@ -29,10 +31,11 @@ public class SetupCanaryStage {
   StageDefinitionBuilder setupCanaryStageBuilder() {
     return new StageDefinitionBuilder() {
       @Override
-      public void taskGraph(Stage stage, TaskNode.Builder builder) {
+      public void taskGraph(@Nonnull Stage stage, @Nonnull TaskNode.Builder builder) {
         builder.withTask("setupCanary", SetupCanaryTask.class);
       }
 
+      @Nonnull
       @Override
       public String getType() {
         return "setupCanary";


### PR DESCRIPTION
Matt, if you could review this and see if you think it's the right direction or not.  I would prefer to always just provide the config in the context, but it doesn't look like contexts in orca work like I thought:  getContext() seems to search previous outputs, but doesn't search previous contexts, so we can't just set it on the setupCanaryStage and have that stage do nothing.  In all cases, we have the config, but putting it on the context in effect doubles the size of the pipeline's state because the config is stored twice, once in the context, once in the output.  Not putting it in the output means it's not returned by subsequent stage's getContext() calls.

One (messy and wrong-seeming) approach is to search for the setupCanaryStage by name and directly get the config from its context, then we could set it once, and use setupCanaryStage as a simple placeholder with no tasks.