### PR TITLE
add metadata

### DIFF
--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryExecutionRequest.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryExecutionRequest.java
@@ -20,6 +20,7 @@ import lombok.Data;
 import javax.validation.constraints.NotNull;
 import java.time.Duration;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -29,6 +30,8 @@ public class CanaryExecutionRequest {
   protected Map<String, CanaryScopePair> scopes;
 
   protected CanaryClassifierThresholdsConfig thresholds;
+
+  protected List<Metadata> metadata;
 
   public Duration calculateDuration() {
     Set<Duration> durationsFound = new HashSet<>();

--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/Metadata.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/Metadata.java
@@ -1,0 +1,23 @@
+package com.netflix.kayenta.canary;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NonNull;
+
+@Data
+public class Metadata {
+  @Getter
+  @NonNull
+  protected String name;
+
+  @Getter
+  @NonNull
+  protected String value;
+
+  // 'hidden' is a UI-hint to show or not show this value by default in the UI,
+  // likely in a generic way.
+  @Getter
+  @Builder.Default
+  protected Boolean hidden = false;
+}


### PR DESCRIPTION
This adds the metadata list to the execution request, which can be used to describe things we want to remember about this execution, like who did it, why it was done, application build info, etc.

Spinnaker should set interesting metadata when requesting a run, so the user viewing a report can easily determine what that canary report applies to.