### PR TITLE
record atlas query and url used to retrieve data as UI assist

### DIFF
--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/metrics/AtlasMetricsService.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/metrics/AtlasMetricsService.java
@@ -176,6 +176,9 @@ public class AtlasMetricsService implements MetricsService {
         metricSetBuilder.tags(filteredTags);
       }
 
+      metricSetBuilder.attribute("query", decoratedQuery);
+      metricSetBuilder.attribute("baseURL", uri);
+
       metricSetList.add(metricSetBuilder.build());
     }
 

--- a/kayenta-core/src/main/java/com/netflix/kayenta/metrics/MetricSet.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/metrics/MetricSet.java
@@ -58,6 +58,10 @@ public class MetricSet {
   @Getter
   private List<Double> values;
 
+  @Singular
+  @Getter
+  private Map<String, String> attributes;
+
   @JsonIgnore
   private String metricSetKey;
 
@@ -67,6 +71,7 @@ public class MetricSet {
                    String startTimeIso,
                    long stepMillis,
                    List<Double> values,
+                   Map<String, String> attributes,
                    String metricSetKey) {
     this.name = name;
     this.tags = tags;
@@ -74,6 +79,7 @@ public class MetricSet {
     this.startTimeIso = startTimeIso;
     this.stepMillis = stepMillis;
     this.values = values;
+    this.attributes = attributes;
     this.metricSetKey = metricSetKey;
   }
 

--- a/kayenta-core/src/main/java/com/netflix/kayenta/metrics/MetricSetMixerService.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/metrics/MetricSetMixerService.java
@@ -84,6 +84,13 @@ public class MetricSetMixerService {
         .scope("control", controlScope)
         .scope("experiment", experimentScope);
 
+    if (controlMetricSet.getAttributes() != null) {
+      metricSetPairBuilder.attribute("control", controlMetricSet.getAttributes());
+    }
+    if (experimentMetricSet.getAttributes() != null) {
+      metricSetPairBuilder.attribute("experiment", experimentMetricSet.getAttributes());
+    }
+
     return metricSetPairBuilder.build();
   }
 

--- a/kayenta-core/src/main/java/com/netflix/kayenta/metrics/MetricSetPair.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/metrics/MetricSetPair.java
@@ -50,16 +50,22 @@ public class MetricSetPair {
   @Getter
   private Map<String, MetricSetScope> scopes;
 
+  @Getter
+  @Singular
+  private Map<String, Map<String, String>> attributes;
+
   public MetricSetPair(String name,
                        String id,
                        Map<String, String> tags,
                        Map<String, List<Double>> values,
-                       Map<String, MetricSetScope> scopes) {
+                       Map<String, MetricSetScope> scopes,
+                       Map<String, Map<String, String>> attributes) {
     this.name = name;
     this.id = id;
     this.tags = tags;
     this.values = values;
     this.scopes = scopes;
+    this.attributes = attributes;
   }
 
   @Builder

--- a/kayenta-core/src/test/groovy/com/netflix/kayenta/metrics/MetricSetMixerServiceSpec.groovy
+++ b/kayenta-core/src/test/groovy/com/netflix/kayenta/metrics/MetricSetMixerServiceSpec.groovy
@@ -28,6 +28,7 @@ class MetricSetMixerServiceSpec extends Specification {
       .name('cpu')
       .values([1, 3, 5, 7])
       .tag("tagName", "tagValue")
+      .attribute("attributeName", "attributeValue")
       .build()
 
   @Shared
@@ -36,6 +37,7 @@ class MetricSetMixerServiceSpec extends Specification {
       .name('cpu')
       .values([2, 4, 6, 8])
       .tag("tagName", "tagValue")
+      .attribute("attributeName", "attributeValue")
       .build()
 
   @Shared
@@ -128,6 +130,7 @@ class MetricSetMixerServiceSpec extends Specification {
       experiment: [2, 4, 6, 8]
     ]
     metricSetPair.tags == [tagName: "tagValue"]
+    metricSetPair.attributes == [ control: [ attributeName: "attributeValue" ], experiment: [ attributeName: "attributeValue" ]]
   }
 
   void "Mixing sets should produce an id field"() {


### PR DESCRIPTION
Closes #122 

This adds a generic "attributes" string -> string map to MetricSet and copies them into the MetricSetPair when created, similar to the way scopes are copied.

This will allow us to know the computed query string and URI used to retrieve the data from Atlas, so UIs can create deep-linking into our data explorer without the need to reconstruct the scoped query entirely or know anything about our atlas backends.