### PR TITLE
ignore port, as it's going away, and prevents http/https from working

### DIFF
--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/model/Backend.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/model/Backend.java
@@ -42,10 +42,6 @@ public class Backend {
 
   @NotNull
   @Getter
-  private int port;
-
-  @NotNull
-  @Getter
   private List<String> environments;
 
   @NotNull
@@ -67,8 +63,6 @@ public class Backend {
       .replace("$(dataset)", dataset)
       .replace("$(region)", region)
       .replace("$(env)", environment);
-    if ((method.equals("http") && port != 80) || (method.equals("https") && port != 443))
-      ret += ":" + port;
     return method + "://" + ret;
   }
 }

--- a/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/BackendsTest.java
+++ b/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/BackendsTest.java
@@ -68,46 +68,9 @@ public class BackendsTest {
   }
 
   @Test
-  public void formattingReplacesDeploymentAndOmitsPort80() {
-    Backend backend = Backend.builder()
-      .cname("deployment=$(deployment)")
-      .port(80)
-      .build();
-    assertEquals("http://deployment=main",
-                 backend.getUri("http", "main", "global", "region", "test"));
-    assertEquals("https://deployment=main:80",
-                 backend.getUri("https", "main", "global", "region", "test"));
-  }
-
-  @Test
-  public void formattingReplacesDeploymentAndOmitsPort443() {
-    Backend backend = Backend.builder()
-      .cname("deployment=$(deployment)")
-      .port(443)
-      .build();
-    assertEquals("http://deployment=main:443",
-                 backend.getUri("http", "main", "global", "region", "test"));
-    assertEquals("https://deployment=main",
-                 backend.getUri("https", "main", "global", "region", "test"));
-  }
-
-  @Test
-  public void formattingReplacesDeploymentAndIncludesPort() {
-    Backend backend = Backend.builder()
-      .cname("deployment=$(deployment)")
-      .port(8000)
-      .build();
-    assertEquals("http://deployment=main:8000",
-                 backend.getUri("http", "main", "global", "region", "test"));
-    assertEquals("https://deployment=main:8000",
-                 backend.getUri("https", "main", "global", "region", "test"));
-  }
-
-  @Test
-  public void formattingReplacesAllThethings() {
+  public void formattingReplacesAllTheThings() {
     Backend backend = Backend.builder()
       .cname("deployment=$(deployment).region=$(region).env=$(env).dataset=$(dataset).envAgain=$(env)")
-      .port(80)
       .build();
     assertEquals("http://deployment=xmain.region=xregion.env=xtest.dataset=xglobal.envAgain=xtest",
                  backend.getUri("http", "xmain", "xglobal", "xregion", "xtest"));


### PR DESCRIPTION
backends.json is removing the port, as most apps ignore it anyway since they choose https now, and that prevents the port from working usefully.