### PR TITLE
fix(judge): Use the correct key to retrieve the metric direction.

### DIFF
--- a/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/NetflixACAJudge.scala
+++ b/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/NetflixACAJudge.scala
@@ -164,7 +164,7 @@ class NetflixACAJudge extends CanaryJudge with StrictLogging {
     val experiment = Metric(metric.getName, experimentValues, label="Canary")
     val control = Metric(metric.getName, controlValues, label="Baseline")
 
-    val directionalityOption = MapUtils.get(metricConfig.getAnalysisConfigurations, "canary", "directionality")
+    val directionalityOption = MapUtils.get(metricConfig.getAnalysisConfigurations, "canary", "direction")
     val directionalityString = if (directionalityOption.isDefined) directionalityOption.get.toString else "default"
     val directionality = MetricDirection.parse(directionalityString)
 


### PR DESCRIPTION
Use the correct key to retrieve the metric direction from the canary config.