### PR TITLE
feat(prometheus): Minor cleanup relating to K8S support.

### DIFF
--- a/json-formats.md
+++ b/json-formats.md
@@ -128,6 +128,46 @@ Atlas, Stackdriver and Prometheus are used.
   }
 }
 ```
+```JSON
+{
+  "name": "MySampleK8SPrometheusCanaryConfigWithCustomFilterTemplate",
+  "description": "Example Kayenta Configuration with Custom Filter Template using Prometheus for K8S",
+  "configVersion": "1.0",
+  "applications": [
+    "myapp"
+  ],
+  "judge": {
+    "name": "dredd-v1.0",
+    "judgeConfigurations": { }
+  },
+  "metrics": [
+    {
+      "name": "cpu_usage_seconds",
+      "query": {
+        "type": "prometheus",
+        "metricName": "container_cpu_usage_seconds_total",
+        "labelBindings": [ ],
+        "customFilterTemplate": "my-template"
+      },
+      "groups": ["system"],
+      "analysisConfigurations": { },
+      "scopeName": "default"
+    }
+  ],
+  "templates": {
+    "my-template": "container_name='${container_name}'"
+  },
+  "classifier": {
+    "groupWeights": {
+      "system": 100.0
+    },
+    "scoreThresholds": {
+      "pass": 95.0,
+      "marginal": 75.0
+    }
+  }
+}
+```
 ## Canary Data Archival Format
 
 This format is used to store the results from a specific canary run.

--- a/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/controllers/PrometheusFetchController.java
+++ b/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/controllers/PrometheusFetchController.java
@@ -92,6 +92,14 @@ public class PrometheusFetchController {
     start = determineDefaultProperty(start, "start", prometheusConfigurationTestControllerDefaultProperties);
     end = determineDefaultProperty(end, "end", prometheusConfigurationTestControllerDefaultProperties);
 
+    if (StringUtils.isEmpty(start)) {
+      throw new IllegalArgumentException("Start time is required.");
+    }
+
+    if (StringUtils.isEmpty(end)) {
+      throw new IllegalArgumentException("End time is required.");
+    }
+
     String resolvedMetricsAccountName = CredentialsHelper.resolveAccountByNameOrType(metricsAccountName,
                                                                                      AccountCredentials.Type.METRICS_STORE,
                                                                                      accountCredentialsRepository);

--- a/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/metrics/PrometheusMetricsService.java
+++ b/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/metrics/PrometheusMetricsService.java
@@ -105,9 +105,10 @@ public class PrometheusMetricsService implements MetricsService {
       } else if ("aws_ec2_instance".equals(resourceType)) {
         addEC2Filters("asg_groupName", scope, region, filters);
       } else {
-        log.warn("There is no explicit support for resourceType '" + resourceType + "'. Your mileage may vary.");
+        throw new IllegalArgumentException("There is no explicit support for resourceType '" + resourceType + "'. " +
+                                           "You may build whatever query makes sense for your environment via label " +
+                                           "bindings and custom filter templates.");
       }
-      // TODO(duftler): Add support for K8S resource types.
     } else {
       List<String> customFilterTokens = Arrays.asList(customFilter.split(","));
 

--- a/kayenta-stackdriver/src/main/java/com/netflix/kayenta/stackdriver/controllers/StackdriverFetchController.java
+++ b/kayenta-stackdriver/src/main/java/com/netflix/kayenta/stackdriver/controllers/StackdriverFetchController.java
@@ -95,6 +95,14 @@ public class StackdriverFetchController {
     startTimeIso = determineDefaultProperty(startTimeIso, "start", stackdriverConfigurationTestControllerDefaultProperties);
     endTimeIso = determineDefaultProperty(endTimeIso, "end", stackdriverConfigurationTestControllerDefaultProperties);
 
+    if (StringUtils.isEmpty(startTimeIso)) {
+      throw new IllegalArgumentException("Start time is required.");
+    }
+
+    if (StringUtils.isEmpty(endTimeIso)) {
+      throw new IllegalArgumentException("End time is required.");
+    }
+
     String resolvedMetricsAccountName = CredentialsHelper.resolveAccountByNameOrType(metricsAccountName,
                                                                                      AccountCredentials.Type.METRICS_STORE,
                                                                                      accountCredentialsRepository);


### PR DESCRIPTION
No hard-coded support is needed for kubernetes. The user can specify whatever labels make sense and use custom filter templates to treat the injected scope/region/... as values.