### PR TITLE
feat(CanaryConfigIndexingAgent): add current and expected counts

### DIFF
--- a/kayenta-core/src/main/java/com/netflix/kayenta/index/CanaryConfigIndexingAgent.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/index/CanaryConfigIndexingAgent.java
@@ -267,15 +267,18 @@ public class CanaryConfigIndexingAgent extends AbstractHealthIndicator {
       }
     }
 
+    int expectedByApplicationIndexCount = configurationStoreAccountCredentialsSet.size();
     // So long as this instance has performed an indexing, or failed to acquire the lock since another instance was in
     // the process of indexing, the index should be available. We also verify that the number of by-application index
     // keys matches the number of configured configuration store accounts.
-    if (cyclesCompleted > 0 && existingByApplicationIndexCount == configurationStoreAccountCredentialsSet.size()) {
+    if (cyclesCompleted > 0 && existingByApplicationIndexCount == expectedByApplicationIndexCount) {
       builder.up();
     } else {
       builder.down();
     }
 
+    builder.withDetail("existingByApplicationIndexCount", existingByApplicationIndexCount);
+    builder.withDetail("expectedByApplicationIndexCount", expectedByApplicationIndexCount);
     builder.withDetail("cyclesInitiated", cyclesInitiated);
     builder.withDetail("cyclesCompleted", cyclesCompleted);
   }


### PR DESCRIPTION
These affect the health check, and when they are different will cause a DOWN status to be returned.  However, there wasn't any insight as to why.  This exposes those two values.

Note that this check causes Kayenta to go down from time to time, and I'm not sure if this is a good thing or not.  I do think the health check should be related to the ability and success of updating the canary config cache, but I'm not sure if it behaves this way or not currently.  I fear if it fetches the index, until it's finished loading the whole list again, it may not report healthy.