### PR TITLE
feat(judge): implement NaN replacement strategy

### DIFF
--- a/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/NetflixACAJudge.scala
+++ b/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/NetflixACAJudge.scala
@@ -109,9 +109,9 @@ class NetflixACAJudge extends CanaryJudge with StrictLogging {
   /**
     * Metric Transformations
     */
-  def transformMetric(metric: Metric, nanStrategy: NanStrategy): Metric = {
+  def transformMetric(metric: Metric, nanStrategy: NaNStrategy): Metric = {
     val detector = new IQRDetector(factor = 3.0, reduceSensitivity = true)
-    val transform = if (nanStrategy == NanStrategy.Remove) {
+    val transform = if (nanStrategy == NaNStrategy.Remove) {
       Function.chain[Metric](Seq(Transforms.removeNaNs(_), Transforms.removeOutliers(_, detector)))
     } else {
       Function.chain[Metric](Seq(Transforms.replaceNaNs(_), Transforms.removeOutliers(_, detector)))
@@ -139,7 +139,7 @@ class NetflixACAJudge extends CanaryJudge with StrictLogging {
     val directionality = MetricDirection.parse(directionalityString)
 
     val nanStrategyString = MapUtils.getAsStringWithDefault("none", metricConfig.getAnalysisConfigurations, "canary", "nanStrategy")
-    val nanStrategy = NanStrategy.parse(nanStrategyString)
+    val nanStrategy = NaNStrategy.parse(nanStrategyString)
 
     //=============================================
     // Metric Transformation (Remove NaN values, etc.)

--- a/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/NetflixACAJudge.scala
+++ b/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/NetflixACAJudge.scala
@@ -133,9 +133,11 @@ class NetflixACAJudge extends CanaryJudge with StrictLogging {
     val experiment = Metric(metric.getName, experimentValues, label="Canary")
     val control = Metric(metric.getName, controlValues, label="Baseline")
 
-    val directionalityOption = MapUtils.get(metricConfig.getAnalysisConfigurations, "canary", "direction")
-    val directionalityString = if (directionalityOption.isDefined) directionalityOption.get.toString else "default"
+    val directionalityString = MapUtils.getAsStringWithDefault("either", metricConfig.getAnalysisConfigurations, "canary", "direction")
     val directionality = MetricDirection.parse(directionalityString)
+
+    val nanStrategyString = MapUtils.getAsStringWithDefault("none", metricConfig.getAnalysisConfigurations, "canary", "nanStrategy")
+    val nanStrategy = NanStrategy.parse(nanStrategyString)
 
     //=============================================
     // Metric Transformation (Remove NaN values, etc.)

--- a/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/classifiers/metric/BaseMetricClassifier.scala
+++ b/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/classifiers/metric/BaseMetricClassifier.scala
@@ -26,7 +26,7 @@ case object Nodata extends MetricClassificationLabel
 case object Error extends MetricClassificationLabel
 
 sealed trait MetricDirection
-object MetricDirection{
+object MetricDirection {
   case object Increase extends MetricDirection
   case object Decrease extends MetricDirection
   case object Either extends MetricDirection
@@ -37,6 +37,20 @@ object MetricDirection{
       case "decrease" => MetricDirection.Decrease
       case "either" => MetricDirection.Either
       case _ =>  MetricDirection.Either
+    }
+  }
+}
+
+sealed trait NanStrategy
+object NanStrategy {
+  case object None extends NanStrategy
+  case object Remove extends NanStrategy
+
+  def parse(nanStrategy: String): NanStrategy = {
+    nanStrategy match {
+      case "none" => NanStrategy.None
+      case "remove" => NanStrategy.Remove
+      case _ => NanStrategy.None
     }
   }
 }

--- a/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/classifiers/metric/BaseMetricClassifier.scala
+++ b/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/classifiers/metric/BaseMetricClassifier.scala
@@ -41,16 +41,16 @@ object MetricDirection {
   }
 }
 
-sealed trait NanStrategy
-object NanStrategy {
-  case object Remove extends NanStrategy
-  case object Replace extends NanStrategy
+sealed trait NaNStrategy
+object NaNStrategy {
+  case object Remove extends NaNStrategy
+  case object Replace extends NaNStrategy
 
-  def parse(nanStrategy: String): NanStrategy = {
+  def parse(nanStrategy: String): NaNStrategy = {
     nanStrategy match {
-      case "remove" => NanStrategy.Remove
-      case "replace" => NanStrategy.Replace
-      case _ => NanStrategy.Remove
+      case "remove" => NaNStrategy.Remove
+      case "replace" => NaNStrategy.Replace
+      case _ => NaNStrategy.Remove
     }
   }
 }

--- a/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/classifiers/metric/BaseMetricClassifier.scala
+++ b/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/classifiers/metric/BaseMetricClassifier.scala
@@ -43,14 +43,14 @@ object MetricDirection {
 
 sealed trait NanStrategy
 object NanStrategy {
-  case object None extends NanStrategy
   case object Remove extends NanStrategy
+  case object Replace extends NanStrategy
 
   def parse(nanStrategy: String): NanStrategy = {
     nanStrategy match {
-      case "none" => NanStrategy.None
       case "remove" => NanStrategy.Remove
-      case _ => NanStrategy.None
+      case "replace" => NanStrategy.Replace
+      case _ => NanStrategy.Remove
     }
   }
 }
@@ -58,5 +58,6 @@ object NanStrategy {
 case class MetricClassification(classification: MetricClassificationLabel, reason: Option[String], ratio: Double)
 
 abstract class BaseMetricClassifier {
-  def classify(control: Metric, experiment: Metric, direction: MetricDirection = MetricDirection.Either): MetricClassification
+  def classify(control: Metric, experiment: Metric,
+               direction: MetricDirection = MetricDirection.Either): MetricClassification
 }

--- a/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/classifiers/metric/MannWhitneyClassifier.scala
+++ b/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/classifiers/metric/MannWhitneyClassifier.scala
@@ -22,7 +22,7 @@ import org.apache.commons.math3.stat.StatUtils
 
 case class MannWhitneyResult(lowerConfidence: Double, upperConfidence: Double, estimate: Double)
 
-class MannWhitneyClassifier(tolerance: Double=0.25, confLevel: Double=0.95) extends BaseMetricClassifier{
+class MannWhitneyClassifier(tolerance: Double=0.25, confLevel: Double=0.95) extends BaseMetricClassifier {
 
   /**
     * Mann-Whitney U Test
@@ -30,7 +30,7 @@ class MannWhitneyClassifier(tolerance: Double=0.25, confLevel: Double=0.95) exte
     * @param experimentValues
     * @param controlValues
     */
-  def MannWhitneyUTest(experimentValues: Array[Double], controlValues: Array[Double]): MannWhitneyResult ={
+  def MannWhitneyUTest(experimentValues: Array[Double], controlValues: Array[Double]): MannWhitneyResult = {
     val mw = new MannWhitney()
     val params =
       MannWhitneyParams(mu = 0, confidenceLevel = confLevel, controlData = controlValues, experimentData = experimentValues)
@@ -58,18 +58,18 @@ class MannWhitneyClassifier(tolerance: Double=0.25, confLevel: Double=0.95) exte
   override def classify(control: Metric, experiment: Metric, direction: MetricDirection): MetricClassification = {
 
     //Check if there is no-data for the experiment or control
-    if(experiment.values.isEmpty || control.values.isEmpty){
+    if (experiment.values.isEmpty || control.values.isEmpty) {
       return MetricClassification(Nodata, None, 0.0)
     }
 
     //Check if the experiment and control data are equal
-    if (experiment.values.sorted.sameElements(control.values.sorted)){
+    if (experiment.values.sorted.sameElements(control.values.sorted)) {
       val reason = s"The ${experiment.label} and ${control.label} data are identical"
       return MetricClassification(Pass, Some(reason), 1.0)
     }
 
     //Check the number of unique observations; check for tied ranks
-    if (experiment.values.union(control.values).distinct.length == 1){
+    if (experiment.values.union(control.values).distinct.length == 1) {
       return MetricClassification(Pass, None, 1.0)
     }
 

--- a/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/classifiers/metric/MeanInequalityClassifier.scala
+++ b/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/classifiers/metric/MeanInequalityClassifier.scala
@@ -25,12 +25,12 @@ import org.apache.commons.math3.stat.StatUtils
   * Compare the mean value of the experiment population to the mean value of the control population.
   * This classifier is primary used for benchmarking.
   */
-class MeanInequalityClassifier extends BaseMetricClassifier{
+class MeanInequalityClassifier extends BaseMetricClassifier {
 
   override def classify(control: Metric, experiment: Metric, direction: MetricDirection): MetricClassification = {
 
     //Check if there is no-data for the experiment or control
-    if(experiment.values.isEmpty || control.values.isEmpty){
+    if (experiment.values.isEmpty || control.values.isEmpty) {
       return MetricClassification(Nodata, None, 0.0)
     }
 
@@ -38,11 +38,11 @@ class MeanInequalityClassifier extends BaseMetricClassifier{
     val controlMean = StatUtils.mean(control.values)
     val ratio = experimentMean/controlMean
 
-    if((direction == MetricDirection.Increase || direction == MetricDirection.Either) && experimentMean > controlMean){
+    if ((direction == MetricDirection.Increase || direction == MetricDirection.Either) && experimentMean > controlMean)  {
       val reason = s"The ${experiment.label} mean was greater than the ${control.label} mean"
       return MetricClassification(High, Some(reason), ratio)
 
-    }else if((direction == MetricDirection.Decrease || direction == MetricDirection.Either) && experimentMean < controlMean){
+    } else if ((direction == MetricDirection.Decrease || direction == MetricDirection.Either) && experimentMean < controlMean) {
       val reason = s"The ${experiment.label} mean was less than the ${control.label} mean"
       return MetricClassification(Low, Some(reason), ratio)
     }

--- a/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/preprocessing/Transforms.scala
+++ b/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/preprocessing/Transforms.scala
@@ -53,7 +53,7 @@ object Transforms {
     * @param value
     * @return
     */
-  def replaceNaNs(data: Array[Double], value: Double): Array[Double]= {
+  def replaceNaNs(data: Array[Double], value: Double): Array[Double] = {
     data.map(x => if (x.isNaN) value else x)
   }
 

--- a/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/preprocessing/Transforms.scala
+++ b/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/preprocessing/Transforms.scala
@@ -27,7 +27,7 @@ object Transforms {
     * @param data
     * @return
     */
-  def removeNaNs(data: Array[Double]): Array[Double] ={
+  def removeNaNs(data: Array[Double]): Array[Double] = {
     data.filter(x => !x.isNaN)
   }
 
@@ -40,13 +40,21 @@ object Transforms {
   }
 
   /**
+    * Replace NaN values with 0.0 from the input metric.
+    * @param metric
+    */
+  def replaceNaNs(metric: Metric): Metric = {
+    metric.copy(values = replaceNaNs(metric.values, 0))
+  }
+
+  /**
     * Replace NaN values from the input array
     * @param data
     * @param value
     * @return
     */
-  def replaceNaNs(data: Array[Double], value: Double): Array[Double]={
-    data.map(x => if(x.isNaN) value else x)
+  def replaceNaNs(data: Array[Double], value: Double): Array[Double]= {
+    data.map(x => if (x.isNaN) value else x)
   }
 
   /**
@@ -54,9 +62,9 @@ object Transforms {
     * @param data
     * @param detector
     */
-  def removeOutliers(data: Array[Double], detector: BaseOutlierDetector): Array[Double] ={
+  def removeOutliers(data: Array[Double], detector: BaseOutlierDetector): Array[Double] = {
     val outliers = detector.detect(data)
-    data.zip(outliers).collect{case (v, false) => v}
+    data.zip(outliers).collect{ case (v, false) => v }
   }
 
   /**

--- a/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/utils/MapUtils.scala
+++ b/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/utils/MapUtils.scala
@@ -39,4 +39,8 @@ object MapUtils {
       }
     }
   }
+
+  def getAsStringWithDefault(default: String, data: Any, path: String*): String = {
+    get(data, path: _*).getOrElse(default).toString
+  }
 }

--- a/kayenta-judge/src/test/scala/com/netflix/kayenta/judge/TransformSuite.scala
+++ b/kayenta-judge/src/test/scala/com/netflix/kayenta/judge/TransformSuite.scala
@@ -16,13 +16,13 @@
 
 package com.netflix.kayenta.judge
 
-import com.netflix.kayenta.judge.preprocessing.Transforms.{removeNaNs, removeOutliers}
+import com.netflix.kayenta.judge.preprocessing.Transforms.{removeNaNs, replaceNaNs, removeOutliers}
 import com.netflix.kayenta.judge.detectors.{IQRDetector, KSigmaDetector}
 import com.netflix.kayenta.judge.preprocessing.Transforms
 import org.scalatest.FunSuite
 
 
-class TransformSuite extends FunSuite{
+class TransformSuite extends FunSuite {
 
   test("Remove Single NaN"){
     val testData = Array(0.0, 1.0, Double.NaN, 1.0, 0.0)
@@ -32,7 +32,7 @@ class TransformSuite extends FunSuite{
     assert(result === truth)
   }
 
-  test("Remove Multiple NaN"){
+  test("Remove Multiple NaN") {
     val testData = Array(Double.NaN, Double.NaN, Double.NaN)
     val truth = Array[Double]()
 
@@ -40,7 +40,15 @@ class TransformSuite extends FunSuite{
     assert(result === truth)
   }
 
-  test("IQR Outlier Removal"){
+  test("Replace NANs") {
+    val testData = Array(Double.NaN, 10.10, 20.20, 30.30, Double.NaN, 40.40)
+    val truth = Array(0.0, 10.10, 20.20, 30.30, 0.0, 40.40)
+
+    val result = replaceNaNs(testData, 0.0)
+    assert(result === truth)
+  }
+
+  test("IQR Outlier Removal") {
     val testData = Array(21.0, 23.0, 24.0, 25.0, 50.0, 29.0, 23.0, 21.0)
     val truth = Array(21.0, 23.0, 24.0, 25.0, 29.0, 23.0, 21.0)
 
@@ -49,7 +57,7 @@ class TransformSuite extends FunSuite{
     assert(result === truth)
   }
 
-  test("KSigma Outlier Removal"){
+  test("KSigma Outlier Removal") {
     val testData = Array(1.0, 1.0, 1.0, 1.0, 1.0, 20.0, 1.0, 1.0, 1.0, 1.0, 1.0)
     val truth = Array(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
 


### PR DESCRIPTION
This change makes it possible to specify a NaN replacement strategy, in addition to the (default) removal policy we now have.  It will replace with 0, which is currently the only sane value to replace it with.