### PR TITLE
feat(judge): Implement criticality

### DIFF
--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/results/CanaryAnalysisResult.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/results/CanaryAnalysisResult.java
@@ -76,5 +76,6 @@ public class CanaryAnalysisResult {
   //
   @NotNull
   @Getter
-  private String criticality;
+  @Builder.Default
+  private String criticality = "normal";
 }

--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/results/CanaryAnalysisResult.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/results/CanaryAnalysisResult.java
@@ -68,4 +68,13 @@ public class CanaryAnalysisResult {
   @NotNull
   @Getter
   private Map<String, Object> resultMetadata;
+
+  //
+  // Set to one of "normal", "critical", or "report-only" by the classifier,
+  // which is currently just copied from the config.  Having it here prevents
+  // having to look it up in the scorer.
+  //
+  @NotNull
+  @Getter
+  private String criticality;
 }

--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/results/CanaryAnalysisResult.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/results/CanaryAnalysisResult.java
@@ -69,8 +69,7 @@ public class CanaryAnalysisResult {
   @Getter
   private Map<String, Object> resultMetadata;
 
-  @NotNull
   @Getter
   @Builder.Default
-  private Boolean critical = false;
+  private boolean critical = false;
 }

--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/results/CanaryAnalysisResult.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/results/CanaryAnalysisResult.java
@@ -77,5 +77,5 @@ public class CanaryAnalysisResult {
   @NotNull
   @Getter
   @Builder.Default
-  private String criticality = "normal";
+  private Boolean critical = false;
 }

--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/results/CanaryAnalysisResult.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/results/CanaryAnalysisResult.java
@@ -69,11 +69,6 @@ public class CanaryAnalysisResult {
   @Getter
   private Map<String, Object> resultMetadata;
 
-  //
-  // Set to one of "normal", "critical", or "report-only" by the classifier,
-  // which is currently just copied from the config.  Having it here prevents
-  // having to look it up in the scorer.
-  //
   @NotNull
   @Getter
   @Builder.Default

--- a/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/NetflixACAJudge.scala
+++ b/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/NetflixACAJudge.scala
@@ -141,8 +141,7 @@ class NetflixACAJudge extends CanaryJudge with StrictLogging {
     val nanStrategyString = MapUtils.getAsStringWithDefault("none", metricConfig.getAnalysisConfigurations, "canary", "nanStrategy")
     val nanStrategy = NaNStrategy.parse(nanStrategyString)
 
-    val criticalityString = MapUtils.getAsStringWithDefault("normal", metricConfig.getAnalysisConfigurations, "canary", "criticality")
-    val criticality = Criticality.parse(criticalityString)
+    val critical = MapUtils.getAsBooleanWithDefault(false, metricConfig.getAnalysisConfigurations, "canary", "critical")
 
     //=============================================
     // Metric Transformation (Remove NaN values, etc.)
@@ -168,7 +167,7 @@ class NetflixACAJudge extends CanaryJudge with StrictLogging {
       .groups(metricConfig.getGroups)
       .experimentMetadata(Map("stats" -> DescriptiveStatistics.toMap(experimentStats).asJava.asInstanceOf[Object]).asJava)
       .controlMetadata(Map("stats" -> DescriptiveStatistics.toMap(controlStats).asJava.asInstanceOf[Object]).asJava)
-      .criticality(criticality.toString)
+      .critical(critical)
 
     try {
       val metricClassification = mannWhitney.classify(transformedControl, transformedExperiment, directionality)

--- a/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/NetflixACAJudge.scala
+++ b/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/NetflixACAJudge.scala
@@ -141,6 +141,9 @@ class NetflixACAJudge extends CanaryJudge with StrictLogging {
     val nanStrategyString = MapUtils.getAsStringWithDefault("none", metricConfig.getAnalysisConfigurations, "canary", "nanStrategy")
     val nanStrategy = NaNStrategy.parse(nanStrategyString)
 
+    val criticalityString = MapUtils.getAsStringWithDefault("normal", metricConfig.getAnalysisConfigurations, "canary", "criticality")
+    val criticality = Criticality.parse(criticalityString)
+
     //=============================================
     // Metric Transformation (Remove NaN values, etc.)
     // ============================================
@@ -165,6 +168,7 @@ class NetflixACAJudge extends CanaryJudge with StrictLogging {
       .groups(metricConfig.getGroups)
       .experimentMetadata(Map("stats" -> DescriptiveStatistics.toMap(experimentStats).asJava.asInstanceOf[Object]).asJava)
       .controlMetadata(Map("stats" -> DescriptiveStatistics.toMap(controlStats).asJava.asInstanceOf[Object]).asJava)
+      .criticality(criticality.toString)
 
     try {
       val metricClassification = mannWhitney.classify(transformedControl, transformedExperiment, directionality)

--- a/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/classifiers/metric/BaseMetricClassifier.scala
+++ b/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/classifiers/metric/BaseMetricClassifier.scala
@@ -55,28 +55,6 @@ object NaNStrategy {
   }
 }
 
-sealed trait Criticality
-object Criticality {
-  case object Normal extends Criticality {
-    override def toString: String = "normal"
-  }
-  case object Critical extends Criticality {
-    override def toString: String = "critical"
-  }
-  case object ReportOnly extends Criticality {
-    override def toString: String = "report-only"
-  }
-
-  def parse(criticality: String): Criticality = {
-    criticality match {
-      case "normal" => Criticality.Normal
-      case "critical" => Criticality.Critical
-      case "report-only" => Criticality.ReportOnly
-      case _ => Criticality.Normal
-    }
-  }
-}
-
 case class MetricClassification(classification: MetricClassificationLabel, reason: Option[String], ratio: Double)
 
 abstract class BaseMetricClassifier {

--- a/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/classifiers/metric/BaseMetricClassifier.scala
+++ b/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/classifiers/metric/BaseMetricClassifier.scala
@@ -55,6 +55,28 @@ object NaNStrategy {
   }
 }
 
+sealed trait Criticality
+object Criticality {
+  case object Normal extends Criticality {
+    override def toString: String = "normal"
+  }
+  case object Critical extends Criticality {
+    override def toString: String = "critical"
+  }
+  case object ReportOnly extends Criticality {
+    override def toString: String = "report-only"
+  }
+
+  def parse(criticality: String): Criticality = {
+    criticality match {
+      case "normal" => Criticality.Normal
+      case "critical" => Criticality.Critical
+      case "report-only" => Criticality.ReportOnly
+      case _ => Criticality.Normal
+    }
+  }
+}
+
 case class MetricClassification(classification: MetricClassificationLabel, reason: Option[String], ratio: Double)
 
 abstract class BaseMetricClassifier {

--- a/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/scorers/WeightedSumScorer.scala
+++ b/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/scorers/WeightedSumScorer.scala
@@ -17,14 +17,13 @@
 package com.netflix.kayenta.judge.scorers
 
 import com.netflix.kayenta.canary.results.CanaryAnalysisResult
-import com.netflix.kayenta.judge.classifiers.metric.{Pass, High, Low}
+import com.netflix.kayenta.judge.classifiers.metric.{Criticality, High, Low, Pass}
 
 import scala.collection.JavaConverters._
 
-class WeightedSumScorer(groupWeights: Map[String, Double]) extends BaseScorer{
+class WeightedSumScorer(groupWeights: Map[String, Double]) extends BaseScorer {
 
-  private def calculateGroupScore(groupName: String, classificationLabels: List[String]): GroupScore ={
-
+  private def calculateGroupScore(groupName: String, classificationLabels: List[String]): GroupScore = {
     val labelCounts = classificationLabels.groupBy(identity).mapValues(_.size)
     val numMetrics = classificationLabels.size
 
@@ -33,19 +32,21 @@ class WeightedSumScorer(groupWeights: Map[String, Double]) extends BaseScorer{
     val numLow = labelCounts.getOrElse(Low.toString, 0)
     val numTotal = numHigh + numLow + numPass
 
-    val hasNoData = if(numTotal == 0) true else false
-    val score = if(!hasNoData) (numPass/numTotal.toDouble) * 100 else 0.0
+    val hasNoData = numTotal == 0
+    val score = if (!hasNoData) (numPass/numTotal.toDouble) * 100 else 0.0
 
     GroupScore(groupName, score, hasNoData, labelCounts, numMetrics)
   }
 
-  private def calculateGroupScores(metricResults: List[CanaryAnalysisResult]): List[GroupScore] ={
+  private def calculateGroupScores(metricResults: List[CanaryAnalysisResult]): List[GroupScore] = {
 
-    val groupLabels = metricResults.flatMap{ metric =>
-      metric.getGroups.asScala.map{ group => (group, metric.getClassification)}
+    val groupLabels = metricResults.filter { metric =>
+      !metric.getCriticality.equals("report-only")
+    }.flatMap { metric =>
+      metric.getGroups.asScala.map { group => (group, metric.getClassification) }
     }.groupBy(_._1).mapValues(_.map(_._2))
 
-    groupLabels.map{ case (groupName, labels) => calculateGroupScore(groupName, labels)}.toList
+    groupLabels.map { case (groupName, labels) => calculateGroupScore(groupName, labels) }.toList
   }
 
   private def calculateSummaryScore(groupResults: List[GroupScore]): Double ={
@@ -58,7 +59,7 @@ class WeightedSumScorer(groupWeights: Map[String, Double]) extends BaseScorer{
 
     //Determine which groups do not have weights associated with them
     val groupDifference = groupSet.diff(groupWeightSet)
-    val calculatedWeight = if(groupDifference.nonEmpty) (100-groupWeightSum)/groupDifference.size else 0.0
+    val calculatedWeight = if (groupDifference.nonEmpty) (100-groupWeightSum)/groupDifference.size else 0.0
 
     //Compute the summary score based on the group score and weights
     var summaryScore: Double = 0.0
@@ -70,10 +71,22 @@ class WeightedSumScorer(groupWeights: Map[String, Double]) extends BaseScorer{
     summaryScore
   }
 
+  def criticalFailures(results: List[CanaryAnalysisResult]): Boolean = {
+    val criticalFailures = results.filter { result =>
+      result.getCriticality.equals(Criticality.Critical.toString) && !result.getClassification.equals(Pass.toString)
+    }
+    criticalFailures.nonEmpty
+  }
+
   override def score(results: List[CanaryAnalysisResult]): ScoreResult = {
     val groupScores = calculateGroupScores(results)
     val summaryScore = calculateSummaryScore(groupScores)
-    ScoreResult(Some(groupScores), summaryScore, results.size)
+
+    if (criticalFailures(results)) {
+      ScoreResult(Some(groupScores), 0.0, results.size)
+    } else {
+      ScoreResult(Some(groupScores), summaryScore, results.size)
+    }
   }
 
 }

--- a/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/scorers/WeightedSumScorer.scala
+++ b/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/scorers/WeightedSumScorer.scala
@@ -70,7 +70,7 @@ class WeightedSumScorer(groupWeights: Map[String, Double]) extends BaseScorer {
   }
 
   def criticalFailures(results: List[CanaryAnalysisResult]): Boolean = {
-    val criticalFailures = results.filter { result => result.getCritical && !result.getClassification.equals(Pass.toString) }
+    val criticalFailures = results.filter { result => result.isCritical && !result.getClassification.equals(Pass.toString) }
     criticalFailures.nonEmpty
   }
 

--- a/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/scorers/WeightedSumScorer.scala
+++ b/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/scorers/WeightedSumScorer.scala
@@ -17,7 +17,7 @@
 package com.netflix.kayenta.judge.scorers
 
 import com.netflix.kayenta.canary.results.CanaryAnalysisResult
-import com.netflix.kayenta.judge.classifiers.metric.{Criticality, High, Low, Pass}
+import com.netflix.kayenta.judge.classifiers.metric.{High, Low, Pass}
 
 import scala.collection.JavaConverters._
 
@@ -40,9 +40,7 @@ class WeightedSumScorer(groupWeights: Map[String, Double]) extends BaseScorer {
 
   private def calculateGroupScores(metricResults: List[CanaryAnalysisResult]): List[GroupScore] = {
 
-    val groupLabels = metricResults.filter { metric =>
-      !metric.getCriticality.equals("report-only")
-    }.flatMap { metric =>
+    val groupLabels = metricResults.flatMap { metric =>
       metric.getGroups.asScala.map { group => (group, metric.getClassification) }
     }.groupBy(_._1).mapValues(_.map(_._2))
 
@@ -72,9 +70,7 @@ class WeightedSumScorer(groupWeights: Map[String, Double]) extends BaseScorer {
   }
 
   def criticalFailures(results: List[CanaryAnalysisResult]): Boolean = {
-    val criticalFailures = results.filter { result =>
-      result.getCriticality.equals(Criticality.Critical.toString) && !result.getClassification.equals(Pass.toString)
-    }
+    val criticalFailures = results.filter { result => result.getCritical && !result.getClassification.equals(Pass.toString) }
     criticalFailures.nonEmpty
   }
 

--- a/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/utils/MapUtils.scala
+++ b/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/utils/MapUtils.scala
@@ -43,4 +43,9 @@ object MapUtils {
   def getAsStringWithDefault(default: String, data: Any, path: String*): String = {
     get(data, path: _*).getOrElse(default).toString
   }
+
+  def getAsBooleanWithDefault(default: Boolean, data: Any, path: String*): Boolean = {
+    get(data, path: _*).getOrElse(default).asInstanceOf[Boolean]
+  }
+
 }

--- a/kayenta-judge/src/test/scala/com/netflix/kayenta/judge/ScorerSuite.scala
+++ b/kayenta-judge/src/test/scala/com/netflix/kayenta/judge/ScorerSuite.scala
@@ -172,14 +172,13 @@ class ScorerSuite extends FunSuite {
 
     val passMetric = CanaryAnalysisResult.builder()
       .name("test-metric-pass")
-      .criticality("normal")
       .classification(Pass.toString)
       .groups(List[String]("test-group").asJava)
       .build()
 
     val highMetric = CanaryAnalysisResult.builder()
       .name("test-metric-high")
-      .criticality("critical")
+      .critical(true)
       .classification(High.toString)
       .groups(List[String]("test-group").asJava)
       .build()
@@ -194,42 +193,20 @@ class ScorerSuite extends FunSuite {
 
     val passMetric = CanaryAnalysisResult.builder()
       .name("test-metric-low")
-      .criticality("normal")
+      .critical(false)
       .classification(Low.toString)
       .groups(List[String]("test-group").asJava)
       .build()
 
     val highMetric = CanaryAnalysisResult.builder()
       .name("test-metric-pass2")
-      .criticality("critical")
+      .critical(true)
       .classification(Pass.toString)
       .groups(List[String]("test-group").asJava)
       .build()
 
     val scores = weightedSumScorer.score(List(passMetric, highMetric))
     assert(scores.summaryScore == 50.0)
-  }
-
-  test("Weighted Sum Group Scorer: Two metrics, one good (normal), one fail (report-only)") {
-    val groupWeights = Map[String, Double]()
-    val weightedSumScorer = new WeightedSumScorer(groupWeights)
-
-    val passMetric = CanaryAnalysisResult.builder()
-      .name("test-metric-pass")
-      .criticality("normal")
-      .classification(Pass.toString)
-      .groups(List[String]("test-group").asJava)
-      .build()
-
-    val highMetric = CanaryAnalysisResult.builder()
-      .name("test-metric-high")
-      .criticality("report-only")
-      .classification(High.toString)
-      .groups(List[String]("test-group").asJava)
-      .build()
-
-    val scores = weightedSumScorer.score(List(passMetric, highMetric))
-    assert(scores.summaryScore == 100.0)
   }
 
 }

--- a/kayenta-judge/src/test/scala/com/netflix/kayenta/judge/ScorerSuite.scala
+++ b/kayenta-judge/src/test/scala/com/netflix/kayenta/judge/ScorerSuite.scala
@@ -24,9 +24,9 @@ import org.scalatest.Matchers._
 
 import scala.collection.JavaConverters._
 
-class ScorerSuite extends FunSuite{
+class ScorerSuite extends FunSuite {
 
-  test("Weighted Sum Group Scorer: Single Metric Pass"){
+  test("Weighted Sum Group Scorer: Single Metric Pass") {
     val groupWeights = Map[String, Double]()
     val weightedSumScorer = new WeightedSumScorer(groupWeights)
 
@@ -40,7 +40,7 @@ class ScorerSuite extends FunSuite{
     assert(scores.summaryScore == 100.0)
   }
 
-  test("Weighted Sum Group Scorer: Single Metric Fail"){
+  test("Weighted Sum Group Scorer: Single Metric Fail") {
     val groupWeights = Map[String, Double]()
     val weightedSumScorer = new WeightedSumScorer(groupWeights)
 
@@ -54,7 +54,7 @@ class ScorerSuite extends FunSuite{
     assert(scores.summaryScore == 0.0)
   }
 
-  test("Weighted Sum Group Scorer: One Group, Two Metrics"){
+  test("Weighted Sum Group Scorer: One Group, Two Metrics") {
     val groupWeights = Map[String, Double]()
     val weightedSumScorer = new WeightedSumScorer(groupWeights)
 
@@ -74,7 +74,7 @@ class ScorerSuite extends FunSuite{
     assert(scores.summaryScore == 50.0)
   }
 
-  test("Weighted Sum Group Scorer: One Group, Three Metrics"){
+  test("Weighted Sum Group Scorer: One Group, Three Metrics") {
     val groupWeights = Map[String, Double]()
     val weightedSumScorer = new WeightedSumScorer(groupWeights)
 
@@ -100,7 +100,7 @@ class ScorerSuite extends FunSuite{
     assert(scores.summaryScore === (33.33 +- 1.0e-2))
   }
 
-  test("Weighted Sum Group Scorer: Two Groups, Three Metrics"){
+  test("Weighted Sum Group Scorer: Two Groups, Three Metrics") {
     val groupWeights = Map[String, Double]("group-1" -> 75.0, "group-2" -> 25.0)
     val weightedSumScorer = new WeightedSumScorer(groupWeights)
 
@@ -126,7 +126,7 @@ class ScorerSuite extends FunSuite{
     assert(scores.summaryScore == 75.0)
   }
 
-  test("Weighted Sum Group Scorer: Two Groups, Three Metrics (Equal Weight)"){
+  test("Weighted Sum Group Scorer: Two Groups, Three Metrics (Equal Weight)") {
     val groupWeights = Map[String, Double]("group-1" -> 50.0, "group-2" -> 50.0)
     val weightedSumScorer = new WeightedSumScorer(groupWeights)
 
@@ -152,7 +152,7 @@ class ScorerSuite extends FunSuite{
     assert(scores.summaryScore == 25.0)
   }
 
-  test("Weighted Sum Group Scorer: No Data"){
+  test("Weighted Sum Group Scorer: No Data") {
     val groupWeights = Map[String, Double]()
     val weightedSumScorer = new WeightedSumScorer(groupWeights)
 
@@ -164,6 +164,72 @@ class ScorerSuite extends FunSuite{
 
     val scores = weightedSumScorer.score(List(metricClassification))
     assert(scores.summaryScore == 0.0)
+  }
+
+  test("Weighted Sum Group Scorer: Two metrics, one good (normal), one fail (critical)") {
+    val groupWeights = Map[String, Double]()
+    val weightedSumScorer = new WeightedSumScorer(groupWeights)
+
+    val passMetric = CanaryAnalysisResult.builder()
+      .name("test-metric-pass")
+      .criticality("normal")
+      .classification(Pass.toString)
+      .groups(List[String]("test-group").asJava)
+      .build()
+
+    val highMetric = CanaryAnalysisResult.builder()
+      .name("test-metric-high")
+      .criticality("critical")
+      .classification(High.toString)
+      .groups(List[String]("test-group").asJava)
+      .build()
+
+    val scores = weightedSumScorer.score(List(passMetric, highMetric))
+    assert(scores.summaryScore == 0.0)
+  }
+
+  test("Weighted Sum Group Scorer: Two metrics, one low (normal), one good (critical)") {
+    val groupWeights = Map[String, Double]()
+    val weightedSumScorer = new WeightedSumScorer(groupWeights)
+
+    val passMetric = CanaryAnalysisResult.builder()
+      .name("test-metric-low")
+      .criticality("normal")
+      .classification(Low.toString)
+      .groups(List[String]("test-group").asJava)
+      .build()
+
+    val highMetric = CanaryAnalysisResult.builder()
+      .name("test-metric-pass2")
+      .criticality("critical")
+      .classification(Pass.toString)
+      .groups(List[String]("test-group").asJava)
+      .build()
+
+    val scores = weightedSumScorer.score(List(passMetric, highMetric))
+    assert(scores.summaryScore == 50.0)
+  }
+
+  test("Weighted Sum Group Scorer: Two metrics, one good (normal), one fail (report-only)") {
+    val groupWeights = Map[String, Double]()
+    val weightedSumScorer = new WeightedSumScorer(groupWeights)
+
+    val passMetric = CanaryAnalysisResult.builder()
+      .name("test-metric-pass")
+      .criticality("normal")
+      .classification(Pass.toString)
+      .groups(List[String]("test-group").asJava)
+      .build()
+
+    val highMetric = CanaryAnalysisResult.builder()
+      .name("test-metric-high")
+      .criticality("report-only")
+      .classification(High.toString)
+      .groups(List[String]("test-group").asJava)
+      .build()
+
+    val scores = weightedSumScorer.score(List(passMetric, highMetric))
+    assert(scores.summaryScore == 100.0)
   }
 
 }


### PR DESCRIPTION
Implement a new metric feature that indicates if a metric should be report-only, normal, or critical.  Critical metrics which fail cause the entire canary to fail with a 0.0 score, although group scores will be reported normally.  report-only metrics are ignored entirely, including in any counts of number of passes, highs, lows, etc.