### PR TITLE
chore(comments): fixed comments pointing to metric source api docs

### DIFF
--- a/kayenta-datadog/src/main/java/com/netflix/kayenta/datadog/service/DatadogRemoteService.java
+++ b/kayenta-datadog/src/main/java/com/netflix/kayenta/datadog/service/DatadogRemoteService.java
@@ -20,6 +20,8 @@ import retrofit.http.GET;
 import retrofit.http.Query;
 
 public interface DatadogRemoteService {
+
+  //See https://docs.datadoghq.com/api/?lang=python#query-time-series-points
   @GET("/api/v1/query")
   DatadogTimeSeries getTimeSeries(@Query("api_key") String apiKey,
                                   @Query("application_key") String applicationKey,

--- a/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/service/PrometheusRemoteService.java
+++ b/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/service/PrometheusRemoteService.java
@@ -32,7 +32,7 @@ public interface PrometheusRemoteService {
                                      @Query("end") String end,
                                      @Query("step") Long step);
 
-  // See https://prometheus.io/docs/querying/api/#range-queries
+  // See https://prometheus.io/docs/querying/api/#querying-label-values
   @GET("/api/v1/label/__name__/values")
   PrometheusMetricDescriptorsResponse listMetricDescriptors();
 }


### PR DESCRIPTION
Just a small initial commit to get my feet wet.
Fixes the link to api docs for Prometheus and added a similar link for datadog in comments.
Please review.

comment-fix
