### PR TITLE
fix(judge): Handle tied ranks by adding Gaussian white noise

### DIFF
--- a/kayenta-judge/kayenta-judge.gradle
+++ b/kayenta-judge/kayenta-judge.gradle
@@ -17,7 +17,7 @@ dependencies {
 
 task scalaTest(dependsOn: ['testClasses'], type: JavaExec) {
   main = 'org.scalatest.tools.Runner'
-  args = ['-R', 'build/classes/test', '-o']
+  args = ['-R', 'build/classes/scala/test', '-o']
   classpath = sourceSets.test.runtimeClasspath
 }
 

--- a/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/preprocessing/Transforms.scala
+++ b/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/preprocessing/Transforms.scala
@@ -18,14 +18,13 @@ package com.netflix.kayenta.judge.preprocessing
 
 import com.netflix.kayenta.judge.Metric
 import com.netflix.kayenta.judge.detectors.BaseOutlierDetector
+import com.netflix.kayenta.judge.utils.RandomUtils
 
 
 object Transforms {
 
   /**
     * Remove NaN values from the input array
-    * @param data
-    * @return
     */
   def removeNaNs(data: Array[Double]): Array[Double] = {
     data.filter(x => !x.isNaN)
@@ -33,7 +32,6 @@ object Transforms {
 
   /**
     * Remove NaN values from the input metric
-    * @param metric
     */
   def removeNaNs(metric: Metric): Metric = {
     metric.copy(values = removeNaNs(metric.values))
@@ -41,7 +39,6 @@ object Transforms {
 
   /**
     * Replace NaN values with 0.0 from the input metric.
-    * @param metric
     */
   def replaceNaNs(metric: Metric): Metric = {
     metric.copy(values = replaceNaNs(metric.values, 0))
@@ -49,9 +46,6 @@ object Transforms {
 
   /**
     * Replace NaN values from the input array
-    * @param data
-    * @param value
-    * @return
     */
   def replaceNaNs(data: Array[Double], value: Double): Array[Double] = {
     data.map(x => if (x.isNaN) value else x)
@@ -59,8 +53,6 @@ object Transforms {
 
   /**
     * Remove outliers from the input array
-    * @param data
-    * @param detector
     */
   def removeOutliers(data: Array[Double], detector: BaseOutlierDetector): Array[Double] = {
     val outliers = detector.detect(data)
@@ -69,12 +61,26 @@ object Transforms {
 
   /**
     * Remove outliers from the input metric
-    * @param metric
-    * @param detector
-    * @return
     */
   def removeOutliers(metric: Metric, detector: BaseOutlierDetector): Metric = {
     metric.copy(values = removeOutliers(metric.values, detector))
   }
+
+  /**
+    * Add Gaussian noise to the input array
+    */
+  def addGaussianNoise(data: Array[Double], mean: Double, stdev: Double): Array[Double] = {
+    val noise = RandomUtils.normal(mean, stdev, data.length)
+    (data, noise).zipped.map(_ + _)
+  }
+
+  /**
+    * Add Gaussian noise to the input metric
+    */
+  def addGaussianNoise(metric: Metric, mean: Double, stdev: Double): Metric = {
+    metric.copy(values = addGaussianNoise(metric.values, mean, stdev))
+  }
+
+
 
 }

--- a/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/utils/RandomUtils.scala
+++ b/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/utils/RandomUtils.scala
@@ -1,0 +1,26 @@
+package com.netflix.kayenta.judge.utils
+
+import scala.util.Random
+
+object RandomUtils {
+
+  private var random = new Random()
+
+  /**
+    * Initialize Random with the desired seed
+    */
+  def init(seed: Int): Unit = {
+    random = new Random(seed)
+  }
+
+  /**
+    * Draw random samples from a normal (Gaussian) distribution.
+    * @param mean Mean (“centre”) of the distribution.
+    * @param stdev Standard deviation (spread or “width”) of the distribution.
+    * @param numSamples Number of samples to draw
+    */
+  def normal(mean: Double, stdev: Double, numSamples: Int): Array[Double] ={
+    List.fill(numSamples)(random.nextGaussian() * stdev + mean).toArray
+  }
+
+}

--- a/kayenta-judge/src/test/scala/com/netflix/kayenta/judge/ClassifierSuite.scala
+++ b/kayenta-judge/src/test/scala/com/netflix/kayenta/judge/ClassifierSuite.scala
@@ -17,7 +17,6 @@
 package com.netflix.kayenta.judge
 
 import com.netflix.kayenta.judge.classifiers.metric._
-import com.netflix.kayenta.mannwhitney.MannWhitney
 import org.scalatest.FunSuite
 
 
@@ -374,6 +373,32 @@ class ClassifierSuite extends FunSuite{
     assert(result.classification == Pass)
   }
 
+  test("Mann-Whitney Majority Tied Observations"){
+    val experimentData = Array(1.0, 1.0, 1.0, 1.0, 10.0)
+    val controlData = Array(1.0, 1.0, 1.0, 1.0, 1.0)
+
+    val experimentMetric = Metric("pass-metric", experimentData, "canary")
+    val controlMetric = Metric("pass-metric", controlData, "baseline")
+
+    val classifier = new MannWhitneyClassifier(tolerance = 0.10, confLevel = 0.95)
+    val result = classifier.classify(controlMetric, experimentMetric, MetricDirection.Either)
+
+    assert(result.classification == Pass)
+  }
+
+  test("Mann-Whitney Tied Ranks"){
+    val experimentData = Array(10.0, 10.0, 10.0, 10.0, 10.0)
+    val controlData = Array(1.0, 1.0, 1.0, 1.0, 1.0)
+
+    val experimentMetric = Metric("high-metric", experimentData, "canary")
+    val controlMetric = Metric("high-metric", controlData, "baseline")
+
+    val classifier = new MannWhitneyClassifier(tolerance = 0.10, confLevel = 0.95)
+    val result = classifier.classify(controlMetric, experimentMetric, MetricDirection.Either)
+
+    assert(result.classification == High)
+  }
+  
   test("Mean Inequality Classifier Test: High Metric"){
     val experimentData = Array(10.0, 20.0, 30.0, 40.0, 50.0)
     val controlData = Array(1.0, 2.0, 3.0, 4.0, 5.0)

--- a/kayenta-judge/src/test/scala/com/netflix/kayenta/judge/ClassifierSuite.scala
+++ b/kayenta-judge/src/test/scala/com/netflix/kayenta/judge/ClassifierSuite.scala
@@ -398,7 +398,20 @@ class ClassifierSuite extends FunSuite{
 
     assert(result.classification == High)
   }
-  
+
+  test("Mann-Whitney Tied Ranks With Zeros"){
+    val experimentData = Array(10.0, 10.0, 10.0, 10.0, 10.0)
+    val controlData = Array(0.0, 0.0, 0.0, 0.0, 0.0)
+
+    val experimentMetric = Metric("high-metric", experimentData, "canary")
+    val controlMetric = Metric("high-metric", controlData, "baseline")
+
+    val classifier = new MannWhitneyClassifier(tolerance = 0.10, confLevel = 0.95)
+    val result = classifier.classify(controlMetric, experimentMetric, MetricDirection.Either)
+
+    assert(result.classification == High)
+  }
+
   test("Mean Inequality Classifier Test: High Metric"){
     val experimentData = Array(10.0, 20.0, 30.0, 40.0, 50.0)
     val controlData = Array(1.0, 2.0, 3.0, 4.0, 5.0)

--- a/kayenta-judge/src/test/scala/com/netflix/kayenta/judge/TransformSuite.scala
+++ b/kayenta-judge/src/test/scala/com/netflix/kayenta/judge/TransformSuite.scala
@@ -16,10 +16,13 @@
 
 package com.netflix.kayenta.judge
 
-import com.netflix.kayenta.judge.preprocessing.Transforms.{removeNaNs, replaceNaNs, removeOutliers}
+import com.netflix.kayenta.judge.preprocessing.Transforms.{removeNaNs, removeOutliers, replaceNaNs}
 import com.netflix.kayenta.judge.detectors.{IQRDetector, KSigmaDetector}
 import com.netflix.kayenta.judge.preprocessing.Transforms
+import com.netflix.kayenta.judge.utils.RandomUtils
+import org.apache.commons.math3.stat.StatUtils
 import org.scalatest.FunSuite
+import org.scalatest.Matchers._
 
 
 class TransformSuite extends FunSuite {
@@ -65,5 +68,22 @@ class TransformSuite extends FunSuite {
     val result = removeOutliers(testData, detector)
     assert(result === truth)
   }
+
+  test("Add Gaussian Noise"){
+    val seed = 12345
+    RandomUtils.init(seed)
+
+    val testData = Array(0.0, 0.0, 0.0, 0.0, 0.0)
+    val transformed = Transforms.addGaussianNoise(testData, mean = 1.0, stdev = 1.0)
+
+    val transformedMean = StatUtils.mean(transformed)
+    val transformedStdev = math.sqrt(StatUtils.variance(transformed))
+
+    assert(transformedMean === (1.0 +- 0.2))
+    assert(transformedStdev === (1.0 +- 0.2))
+    assert(transformed.length === testData.length)
+  }
+
+
 
 }

--- a/kayenta-judge/src/test/scala/com/netflix/kayenta/judge/UtilsSuite.scala
+++ b/kayenta-judge/src/test/scala/com/netflix/kayenta/judge/UtilsSuite.scala
@@ -18,12 +18,45 @@ package com.netflix.kayenta.judge
 
 import java.util.Collections
 
-import com.netflix.kayenta.judge.utils.MapUtils
+import com.netflix.kayenta.judge.utils.{MapUtils, RandomUtils}
+import org.apache.commons.math3.stat.StatUtils
 import org.scalatest.FunSuite
+import org.scalatest.Matchers._
 
-class MapUtilsSuite extends FunSuite {
+class UtilsSuite extends FunSuite {
 
-  test("get path") {
+  test("RandomUtils List of Random Samples (Zero Mean)"){
+    val seed = 123456789
+    RandomUtils.init(seed)
+    val randomSample: Array[Double] = RandomUtils.normal(mean = 0.0, stdev = 1.0, numSamples = 500)
+
+    val mean = StatUtils.mean(randomSample)
+    val variance = StatUtils.variance(randomSample)
+
+    assert(mean === (0.0 +- 0.2))
+    assert(variance === (1.0 +- 0.2))
+    assert(randomSample.length === 500)
+  }
+
+  test("RandomUtils List of Random Samples (Non-zero Mean)"){
+    val seed = 123456789
+    RandomUtils.init(seed)
+    val randomSample: Array[Double] = RandomUtils.normal(mean = 10.0, stdev = 3.0, numSamples = 1000)
+
+    val mean = StatUtils.mean(randomSample)
+    val stdev =  math.sqrt(StatUtils.variance(randomSample))
+
+    assert(mean === (10.0 +- 0.2))
+    assert(stdev === (3.0 +- 0.2))
+    assert(randomSample.length === 1000)
+  }
+
+  test("RandomUtils Random Sample (Zero Variance)"){
+    val randomSample = RandomUtils.normal(mean = 0.0, stdev = 0.0, numSamples = 1)
+    assert(randomSample.head === 0.0)
+  }
+
+  test("MapUtils Get Path") {
     val map = Map(
       "foo" -> Map(
         "bar" -> 42,
@@ -47,18 +80,20 @@ class MapUtilsSuite extends FunSuite {
     assert(MapUtils.get(map, "list", "c") === None)
   }
 
-  test("get of null") {
+  test("MapUtils Get of Null") {
     assert(MapUtils.get(null, "this", "and", "that") === None)
   }
 
-  test("get of java map") {
+  test("MapUtils Get of Java Map") {
     val foo: java.util.Map[String, Object] = new java.util.HashMap()
     foo.put("bar", new Integer(42))
     foo.put("baz", "abc")
+
     val list: java.util.List[Object] = new java.util.ArrayList()
     list.add(Collections.singletonMap("a", "1"))
     list.add(Collections.singletonMap("b", "2"))
     list.add(Collections.singletonMap("a", "3"))
+
     val map: java.util.Map[String, Object] = new java.util.HashMap()
     map.put("foo", foo)
     map.put("list", list)


### PR DESCRIPTION
Handle the scenario (degenerate distribution) where the ranks, as computed by Mann-Whitney, are tied resulting in an `Error` classification as discussed in #301 . 

To address this, we add a small amount of [Gaussian white noise](https://en.wikipedia.org/wiki/White_noise) to the input signal when both the experiment and control signals are constant.


