### PR TITLE
feat(thresholds): require on execution, remove from config

### DIFF
--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryClassifierConfig.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryClassifierConfig.java
@@ -33,8 +33,4 @@ public class CanaryClassifierConfig {
   @Singular
   @Getter
   private Map<String, Double> groupWeights;
-
-  @NotNull
-  @Getter
-  private CanaryClassifierThresholdsConfig scoreThresholds;
 }

--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryExecutionRequest.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryExecutionRequest.java
@@ -29,6 +29,7 @@ public class CanaryExecutionRequest {
   @NotNull
   protected Map<String, CanaryScopePair> scopes;
 
+  @NotNull
   protected CanaryClassifierThresholdsConfig thresholds;
 
   protected List<Metadata> metadata;

--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/ExecutionMapper.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/ExecutionMapper.java
@@ -387,14 +387,9 @@ public class ExecutionMapper {
           .put("experimentRefidPrefix", CanaryStageNames.REFID_FETCH_EXPERIMENT_PREFIX)
           .build());
 
-    CanaryClassifierThresholdsConfig orchestratorScoreThresholds = canaryExecutionRequest.getThresholds();
-
+    final CanaryClassifierThresholdsConfig orchestratorScoreThresholds = canaryExecutionRequest.getThresholds();
     if (orchestratorScoreThresholds == null) {
-      if (canaryConfig.getClassifier() == null || canaryConfig.getClassifier().getScoreThresholds() == null) {
-        throw new IllegalArgumentException("Classifier thresholds must be specified in either the canary config, or the execution request.");
-      }
-      // The score thresholds were not explicitly passed in from the orchestrator (i.e. Spinnaker), so just use the canary config values.
-      orchestratorScoreThresholds = canaryConfig.getClassifier().getScoreThresholds();
+      throw new IllegalArgumentException("Execution request must contain thresholds");
     }
 
     String canaryExecutionRequestJSON = objectMapper.writeValueAsString(canaryExecutionRequest);

--- a/kayenta-core/src/main/java/com/netflix/kayenta/controllers/CanaryJudgesController.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/controllers/CanaryJudgesController.java
@@ -16,6 +16,7 @@
 
 package com.netflix.kayenta.controllers;
 
+import com.netflix.kayenta.canary.CanaryClassifierThresholdsConfig;
 import com.netflix.kayenta.canary.CanaryConfig;
 import com.netflix.kayenta.canary.CanaryJudge;
 import com.netflix.kayenta.canary.CanaryJudgeConfig;
@@ -65,7 +66,9 @@ public class CanaryJudgesController {
   public CanaryJudgeResult judge(@RequestParam(required = false) final String configurationAccountName,
                                  @RequestParam(required = false) final String storageAccountName,
                                  @RequestParam(required = false) final String canaryConfigId,
-                                 @RequestParam(required = false) final String metricSetPairListId) {
+                                 @RequestParam(required = false) final String metricSetPairListId,
+                                 @RequestParam final Double passThreshold,
+                                 @RequestParam final Double marginalThreshold) {
     String resolvedConfigurationAccountName = CredentialsHelper.resolveAccountByNameOrType(configurationAccountName,
                                                                                            AccountCredentials.Type.CONFIGURATION_STORE,
                                                                                            accountCredentialsRepository);
@@ -103,7 +106,8 @@ public class CanaryJudgesController {
     }
 
     List<MetricSetPair> metricSetPairList = storageService.loadObject(resolvedStorageAccountName, ObjectType.METRIC_SET_PAIR_LIST, metricSetPairListId);
+    CanaryClassifierThresholdsConfig canaryClassifierThresholdsConfig = CanaryClassifierThresholdsConfig.builder().pass(passThreshold).marginal(marginalThreshold).build();
 
-    return canaryJudge.judge(canaryConfig, canaryConfig.getClassifier().getScoreThresholds(), metricSetPairList);
+    return canaryJudge.judge(canaryConfig, canaryClassifierThresholdsConfig, metricSetPairList);
   }
 }


### PR DESCRIPTION
Remove thresholds from canary configs, as they are specified by Spinnaker, and make more sense in general to be runtime parameters.  Having them in two places also causes confusion for users.

A similar PR will be made to remove this from the canary config UI.