### PR TITLE
feat(cors-headers): add if we have an Origin header on request

### DIFF
--- a/kayenta-web/src/main/java/com/netflix/kayenta/config/WebConfiguration.java
+++ b/kayenta-web/src/main/java/com/netflix/kayenta/config/WebConfiguration.java
@@ -17,12 +17,16 @@
 package com.netflix.kayenta.config;
 
 import com.google.common.collect.ImmutableList;
+import com.netflix.kayenta.filters.KayentaCorsFilter;
 import com.netflix.kayenta.interceptors.MetricsInterceptor;
 import com.netflix.spectator.api.Registry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
@@ -44,5 +48,12 @@ public class WebConfiguration extends WebMvcConfigurerAdapter {
         ImmutableList.of("BasicErrorController")
       )
     );
+  }
+
+  @Bean
+  FilterRegistrationBean simpleCORSFilter() {
+    FilterRegistrationBean frb = new FilterRegistrationBean(new KayentaCorsFilter());
+    frb.setOrder(Ordered.HIGHEST_PRECEDENCE);
+    return frb;
   }
 }

--- a/kayenta-web/src/main/java/com/netflix/kayenta/filters/KayentaCorsFilter.java
+++ b/kayenta-web/src/main/java/com/netflix/kayenta/filters/KayentaCorsFilter.java
@@ -1,0 +1,31 @@
+package com.netflix.kayenta.filters;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class KayentaCorsFilter implements Filter {
+
+  public KayentaCorsFilter() {}
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {}
+
+  @Override
+  public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
+    HttpServletResponse response = (HttpServletResponse) res;
+    HttpServletRequest request = (HttpServletRequest) req;
+    String origin = request.getHeader("Origin");
+    if (origin != null && origin.length() > 0) {
+      response.setHeader("Access-Control-Allow-Origin", origin);
+      response.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, DELETE, PUT, PATCH");
+      response.setHeader("Access-Control-Max-Age", "3600");
+      response.setHeader("Access-Control-Allow-Headers", "x-requested-with, content-type");
+    }
+    chain.doFilter(req, res);
+  }
+
+  @Override
+  public void destroy() {}
+}


### PR DESCRIPTION
This will echo back the contents of the `Origin` header, if present, and add additional CORS headers.  No checking is done on the origin; this could be added later if needed.