### PR TITLE
feat(locations): provide location hints for atlas

### DIFF
--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/backends/BackendDatabase.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/backends/BackendDatabase.java
@@ -19,8 +19,10 @@ package com.netflix.kayenta.atlas.backends;
 import com.netflix.kayenta.atlas.model.Backend;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class BackendDatabase {
 
@@ -52,5 +54,14 @@ public class BackendDatabase {
 
   public synchronized void update(List<Backend> newBackends) {
     backends = newBackends;
+  }
+
+  public synchronized List<String> getLocations() {
+    ArrayList<String> locations = new ArrayList<>();
+
+    for (Backend backend : backends) {
+      locations.addAll(backend.getTargets());
+    }
+    return locations.stream().distinct().collect(Collectors.toList());
   }
 }

--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/config/AtlasConfiguration.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/config/AtlasConfiguration.java
@@ -59,7 +59,7 @@ public class AtlasConfiguration {
 
   @Bean
   MetricsService atlasMetricsService(AtlasConfigurationProperties atlasConfigurationProperties,
-                                     AccountCredentialsRepository accountCredentialsRepository) throws IOException {
+                                     AccountCredentialsRepository accountCredentialsRepository) {
     AtlasMetricsService.AtlasMetricsServiceBuilder atlasMetricsServiceBuilder = AtlasMetricsService.builder();
 
     for (AtlasManagedAccount atlasManagedAccount : atlasConfigurationProperties.getAccounts()) {
@@ -81,6 +81,7 @@ public class AtlasConfiguration {
           .name(name)
           .credentials(atlasCredentials)
           .fetchId(atlasManagedAccount.getFetchId())
+          .recommendedLocations(atlasManagedAccount.getRecommendedLocations())
           .backendUpdater(updater);
 
       if (!CollectionUtils.isEmpty(supportedTypes)) {

--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/security/AtlasCredentials.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/security/AtlasCredentials.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 @Builder
 @Data
 @Slf4j
-// TODO: Not sure what kind of credentials or configuration is really required here yet.
 public class AtlasCredentials {
 
   private static String applicationVersion =

--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/security/AtlasNamedAccountCredentials.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/security/AtlasNamedAccountCredentials.java
@@ -24,6 +24,7 @@ import lombok.Data;
 import lombok.Singular;
 
 import javax.validation.constraints.NotNull;
+import java.util.Collections;
 import java.util.List;
 
 @Builder
@@ -37,16 +38,33 @@ public class AtlasNamedAccountCredentials implements AccountCredentials<AtlasCre
   @Singular
   private List<Type> supportedTypes;
 
-  @NotNull
-  private AtlasCredentials credentials;
-
-  private String fetchId;
-
   @Override
   public String getType() {
     return "atlas";
   }
 
+  @NotNull
+  private AtlasCredentials credentials;
+
+  private String fetchId;
+
+  private List<String> recommendedLocations;
+
   @JsonIgnore
   private BackendUpdater backendUpdater;
+
+  @Override
+  public List<String> getLocations() {
+    return getBackendUpdater().getBackendDatabase().getLocations();
+  }
+
+  @Override
+  public List<String> getRecommendedLocations() {
+    if (recommendedLocations == null) {
+      return Collections.emptyList();
+    } else {
+      return recommendedLocations;
+    }
+  }
+
 }

--- a/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/BackendTest.java
+++ b/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/BackendTest.java
@@ -1,0 +1,43 @@
+package com.netflix.kayenta.atlas;
+
+import com.netflix.kayenta.atlas.model.Backend;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class BackendTest {
+  @Test
+  public void backendGetTargetsTestEnvDataset() {
+    ArrayList regions = new ArrayList<>();
+    regions.add("regionOne");
+    regions.add("regionTwo");
+
+    ArrayList environments = new ArrayList<>();
+    environments.add("envOne");
+    environments.add("envTwo");
+
+    Backend backend = Backend.builder().target("$(env).$(region).$(dataset)").dataset("myDataset").deployment("myDeployment").environments(environments).regions(regions).build();
+    List<String> targets = backend.getTargets();
+    assertEquals(4, targets.size());
+    assert(targets.contains("envOne.regionOne.myDataset"));
+    assert(targets.contains("envTwo.regionOne.myDataset"));
+    assert(targets.contains("envOne.regionTwo.myDataset"));
+    assert(targets.contains("envTwo.regionTwo.myDataset"));
+  }
+
+  @Test
+  public void backendGetTargetsTestNoEnvDataset() {
+    ArrayList regions = new ArrayList<>();
+    regions.add("regionOne");
+    regions.add("regionTwo");
+
+    Backend backend = Backend.builder().target("$(region).$(dataset)").dataset("myDataset").deployment("myDeployment").environments(null).regions(regions).build();
+    List<String> targets = backend.getTargets();
+    assertEquals(2, targets.size());
+    assert(targets.contains("regionOne.myDataset"));
+    assert(targets.contains("regionTwo.myDataset"));
+  }
+}

--- a/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/BackendsTest.java
+++ b/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/BackendsTest.java
@@ -67,6 +67,25 @@ public class BackendsTest {
   }
 
   @Test
+  public void getLocationsTest() throws IOException {
+    List<Backend> backends = readBackends("backends-location-test.json");
+
+    BackendDatabase db = new BackendDatabase();
+    db.update(backends);
+
+    List<String> locations = db.getLocations();
+    assertEquals(10, locations.size());
+    assert(locations.contains("test.global"));
+    assert(locations.contains("prod.global"));
+    assert(locations.contains("test.us-east-1"));
+    assert(locations.contains("prod.us-east-1"));
+    assert(locations.contains("test.us-west-2"));
+    assert(locations.contains("prod.us-west-2"));
+    assert(locations.contains("test.eu-west-1"));
+    assert(locations.contains("prod.eu-west-1"));
+  }
+
+  @Test
   public void formattingReplacesAllTheThings() {
     Backend backend = Backend.builder()
       .cname("deployment=$(deployment).region=$(region).env=$(env).dataset=$(dataset).envAgain=$(env)")

--- a/kayenta-atlas/src/test/resources/com/netflix/kayenta/atlas/backends-location-test.json
+++ b/kayenta-atlas/src/test/resources/com/netflix/kayenta/atlas/backends-location-test.json
@@ -1,0 +1,49 @@
+[
+  {
+    "cname": "atlas-global.$(env).example.com",
+    "target": "$(env).$(dataset)",
+    "vip": "atlas_global-main:7001",
+    "deployment": "main",
+    "dataset": "global",
+    "port": 7001,
+    "environments": [
+      "test",
+      "prod"
+    ],
+    "accounts": [
+      "12345",
+      "23456"
+    ],
+    "regions": null,
+    "step": "PT1M",
+    "publishLatency": "PT5M",
+    "retention": "P2W",
+    "description": "Global endpoint that aggregates data from all supported regions."
+  },
+  {
+    "cname": "atlas-main.$(region).$(env).example.com",
+    "target": "$(env).$(region)",
+    "vip": "atlas_regional-$(deployment):7001",
+    "deployment": "main",
+    "dataset": "regional",
+    "port": 7001,
+    "environments": [
+      "test",
+      "prod"
+    ],
+    "accounts": [
+      "34567",
+      "45678"
+    ],
+    "regions": [
+      "us-west-1",
+      "us-west-2",
+      "us-east-1",
+      "eu-west-1"
+    ],
+    "step": "PT1M",
+    "publishLatency": "PT5M",
+    "retention": "P2W",
+    "description": "Main regional endpoint for the primary account with data for $(env).$(region)."
+  }
+]

--- a/kayenta-core/src/main/java/com/netflix/kayenta/security/AccountCredentials.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/security/AccountCredentials.java
@@ -18,6 +18,7 @@ package com.netflix.kayenta.security;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import java.util.Collections;
 import java.util.List;
 
 public interface AccountCredentials<T> {
@@ -26,6 +27,25 @@ public interface AccountCredentials<T> {
   String getType();
 
   List<Type> getSupportedTypes();
+
+  /*
+   * If this account provides a metrics service, return a list of valid "location" values for the metric
+   * scope.  This is used as a UI hint.  If the service cannot enumerate the locations, it should return
+   * an empty list, and the UI may provide an input field rather than a selection.
+   */
+  default List<String> getLocations() {
+    return Collections.emptyList();
+  }
+
+  /*
+   * If this account provides a recommended list of locations, this can also be used by the UI to limit
+   * the initially presented list to something shorter than "everything."  Note that this list may be
+   * present even if locations() returns an empty list; this would imply that there are commonly
+   * used locations, but the full list is unknown by the metrics service.
+   */
+  default List<String> getRecommendedLocations() {
+    return Collections.emptyList();
+  }
 
   @JsonIgnore
   T getCredentials();

--- a/kayenta-datadog/src/main/java/com/netflix/kayenta/datadog/metrics/DatadogMetricsService.java
+++ b/kayenta-datadog/src/main/java/com/netflix/kayenta/datadog/metrics/DatadogMetricsService.java
@@ -35,7 +35,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.validation.constraints.NotNull;
-import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -66,7 +65,7 @@ public class DatadogMetricsService implements MetricsService {
   }
 
   @Override
-  public List<MetricSet> queryMetrics(String accountName, CanaryConfig canaryConfig, CanaryMetricConfig canaryMetricConfig, CanaryScope canaryScope) throws IOException {
+  public List<MetricSet> queryMetrics(String accountName, CanaryConfig canaryConfig, CanaryMetricConfig canaryMetricConfig, CanaryScope canaryScope) {
     DatadogNamedAccountCredentials accountCredentials = (DatadogNamedAccountCredentials)accountCredentialsRepository
       .getOne(accountName)
       .orElseThrow(() -> new IllegalArgumentException("Unable to resolve account " + accountName + "."));

--- a/kayenta-influxdb/src/main/java/com/netflix/kayenta/influxdb/metrics/InfluxDbMetricsService.java
+++ b/kayenta-influxdb/src/main/java/com/netflix/kayenta/influxdb/metrics/InfluxDbMetricsService.java
@@ -16,7 +16,6 @@
 
 package com.netflix.kayenta.influxdb.metrics;
 
-import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -74,7 +73,7 @@ public class InfluxDbMetricsService implements MetricsService {
   }
 
   @Override
-  public List<MetricSet> queryMetrics(String accountName, CanaryConfig canaryConfig, CanaryMetricConfig canaryMetricConfig, CanaryScope canaryScope) throws IOException {
+  public List<MetricSet> queryMetrics(String accountName, CanaryConfig canaryConfig, CanaryMetricConfig canaryMetricConfig, CanaryScope canaryScope) {
 	  
     InfluxDbNamedAccountCredentials accountCredentials = (InfluxDbNamedAccountCredentials)accountCredentialsRepository
       .getOne(accountName)

--- a/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/metrics/PrometheusMetricsService.java
+++ b/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/metrics/PrometheusMetricsService.java
@@ -284,7 +284,7 @@ public class PrometheusMetricsService implements MetricsService {
   }
 
   @Override
-  public List<Map> getMetadata(String metricsAccountName, String filter) throws IOException {
+  public List<Map> getMetadata(String metricsAccountName, String filter) {
     if (!StringUtils.isEmpty(filter)) {
       String lowerCaseFilter = filter.toLowerCase();
 
@@ -302,7 +302,7 @@ public class PrometheusMetricsService implements MetricsService {
   }
 
   @Scheduled(fixedDelayString = "#{@prometheusConfigurationProperties.metadataCachingIntervalMS}")
-  public void updateMetricDescriptorsCache() throws IOException {
+  public void updateMetricDescriptorsCache() {
     Set<AccountCredentials> accountCredentialsSet =
       CredentialsHelper.getAllAccountsOfType(AccountCredentials.Type.METRICS_STORE, accountCredentialsRepository);
 

--- a/kayenta-stackdriver/src/main/java/com/netflix/kayenta/stackdriver/metrics/StackdriverMetricsService.java
+++ b/kayenta-stackdriver/src/main/java/com/netflix/kayenta/stackdriver/metrics/StackdriverMetricsService.java
@@ -349,7 +349,7 @@ public class StackdriverMetricsService implements MetricsService {
 
 
   @Override
-  public List<Map> getMetadata(String metricsAccountName, String filter) throws IOException {
+  public List<Map> getMetadata(String metricsAccountName, String filter) {
     if (!StringUtils.isEmpty(filter)) {
       String lowerCaseFilter = filter.toLowerCase();
 

--- a/kayenta-web/config/kayenta.yml
+++ b/kayenta-web/config/kayenta.yml
@@ -110,5 +110,5 @@ swagger:
     - /metadata.*
     - /metricSetList.*
     - /metricSetPairList.*
-    - /metricSources.*
+    - /metricServices.*
     - /pipeline.*

--- a/kayenta-web/config/kayenta.yml
+++ b/kayenta-web/config/kayenta.yml
@@ -110,4 +110,5 @@ swagger:
     - /metadata.*
     - /metricSetList.*
     - /metricSetPairList.*
+    - /metricSources.*
     - /pipeline.*

--- a/kayenta-web/src/main/java/com/netflix/kayenta/controllers/MetricSourceDetail.java
+++ b/kayenta-web/src/main/java/com/netflix/kayenta/controllers/MetricSourceDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google, Inc.
+ * Copyright 2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -14,26 +14,34 @@
  * limitations under the License.
  */
 
-package com.netflix.kayenta.atlas.config;
+package com.netflix.kayenta.controllers;
 
-import com.netflix.kayenta.security.AccountCredentials;
-import lombok.Data;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.*;
 
-import javax.validation.constraints.NotNull;
 import java.util.List;
 
-@Data
-public class AtlasManagedAccount {
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MetricSourceDetail {
+  @Getter
+  @NonNull
+  String name;
 
-  @NotNull
-  private String name;
+  @Getter
+  @NonNull
+  String type;
 
-  private List<AccountCredentials.Type> supportedTypes;
+  // See comment in kayenta-core AccountCredentials
+  @Getter
+  @NonNull
+  List<String> recommendedLocations;
 
-  @NotNull
-  private String backendsJsonBaseUrl;
-
-  private String fetchId;
-
-  private List<String> recommendedLocations;
+  // See comment in kayenta-core AccountCredentials
+  @Getter
+  @NonNull
+  List<String> locations;
 }

--- a/kayenta-web/src/main/java/com/netflix/kayenta/controllers/MetricSourcesController.java
+++ b/kayenta-web/src/main/java/com/netflix/kayenta/controllers/MetricSourcesController.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.controllers;
+
+import com.netflix.kayenta.security.AccountCredentials;
+import com.netflix.kayenta.security.AccountCredentialsRepository;
+import com.netflix.kayenta.security.CredentialsHelper;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.netflix.kayenta.security.AccountCredentials.Type.METRICS_STORE;
+
+@RestController
+@RequestMapping("/metricSources")
+public class MetricSourcesController {
+
+  private final AccountCredentialsRepository accountCredentialsRepository;
+
+  @Autowired
+  public MetricSourcesController(AccountCredentialsRepository accountCredentialsRepository) {
+    this.accountCredentialsRepository = accountCredentialsRepository;
+  }
+
+  @ApiOperation(value = "Retrieve a list of all configured metrics sources")
+  @RequestMapping(method = RequestMethod.GET)
+  List<MetricSourceDetail> list() {
+    Set<AccountCredentials> metricAccountCredentials = CredentialsHelper.getAllAccountsOfType(METRICS_STORE, accountCredentialsRepository);
+
+    return metricAccountCredentials
+      .stream()
+      .map(account ->
+        MetricSourceDetail
+          .builder()
+          .name(account.getName())
+          .type(account.getType())
+          .locations(account.getLocations())
+          .recommendedLocations(account.getRecommendedLocations())
+          .build())
+      .collect(Collectors.toList());
+  }
+}

--- a/kayenta-web/src/main/java/com/netflix/kayenta/controllers/MetricsServiceDetail.java
+++ b/kayenta-web/src/main/java/com/netflix/kayenta/controllers/MetricsServiceDetail.java
@@ -26,7 +26,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class MetricSourceDetail {
+public class MetricsServiceDetail {
   @Getter
   @NonNull
   String name;

--- a/kayenta-web/src/main/java/com/netflix/kayenta/controllers/MetricsServicesController.java
+++ b/kayenta-web/src/main/java/com/netflix/kayenta/controllers/MetricsServicesController.java
@@ -32,25 +32,25 @@ import java.util.stream.Collectors;
 import static com.netflix.kayenta.security.AccountCredentials.Type.METRICS_STORE;
 
 @RestController
-@RequestMapping("/metricSources")
-public class MetricSourcesController {
+@RequestMapping("/metricsServices")
+public class MetricsServicesController {
 
   private final AccountCredentialsRepository accountCredentialsRepository;
 
   @Autowired
-  public MetricSourcesController(AccountCredentialsRepository accountCredentialsRepository) {
+  public MetricsServicesController(AccountCredentialsRepository accountCredentialsRepository) {
     this.accountCredentialsRepository = accountCredentialsRepository;
   }
 
-  @ApiOperation(value = "Retrieve a list of all configured metrics sources")
+  @ApiOperation(value = "Retrieve a list of all configured metrics services")
   @RequestMapping(method = RequestMethod.GET)
-  List<MetricSourceDetail> list() {
+  List<MetricsServiceDetail> list() {
     Set<AccountCredentials> metricAccountCredentials = CredentialsHelper.getAllAccountsOfType(METRICS_STORE, accountCredentialsRepository);
 
     return metricAccountCredentials
       .stream()
       .map(account ->
-        MetricSourceDetail
+        MetricsServiceDetail
           .builder()
           .name(account.getName())
           .type(account.getType())


### PR DESCRIPTION
This is a partial fix for some Atlas complexity reduction.

This adds an ability to provide UI hints about locations.  For Atlas, Netflix has many deployment, environment, and datacenter combinations to choose from.  We have started changing to a model where these magic location strings will be sufficient to provide all these details, as they are unique across all our atlas deployments.

With this change, most of the special Atlas scope parameters will be replaced by the single location, which will greatly simplify the code.

Optionally, a recommended list may be provided in the kayenta config YAML file. If provided, it will be inserted into the `recommendedLocations` list; otherwise, the list should be empty.

I recommend the UI to present a text input box if `locations` is empty, otherwise present a pull-down with the `recommendedLocations` first, with options to switch to `locations` for the full list.  For Atlas, it makes little sense to allow arbitrary text input here, but it may also be useful for other metric sources to have a text field option as well even with locations provided if they cannot all be discovered.