### PR TITLE
feat(signalfx): Add SignalFx integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ out/
 .classpath
 .settings/
 bin/
+/dump.rdb

--- a/json-formats.md
+++ b/json-formats.md
@@ -203,6 +203,76 @@ Atlas, Stackdriver and Prometheus are used.
   }
 }
 ```
+
+```JSON
+{
+  "name": "SignalFxIntegrationTestCanaryConfig",
+  "description": "A very simple config for integration testing the SignalFx metric source Kayenta module.",
+  "judge": {
+    "judgeConfigurations": {},
+    "name": "NetflixACAJudge-v1.0"
+  },
+  "metrics": [
+    {
+      "name": "Cpu Usage Percentage",
+      "query": {
+        "metricName": "kayenta.integration-test.cpu.avg",
+        "aggregationMethod": "avg",
+        "serviceType": "signalfx",
+        "type": "signalfx"
+      },
+      "analysisConfigurations": {
+        "canary": {
+          "direction": "increase"
+        }
+      },
+      "groups": [
+        "Integration Test Group"
+      ],
+      "scopeName": "default"
+    },
+    {
+      "name": "Bad Request Rate for /v1/some-endpoint",
+      "query": {
+        "metricName": "kayenta.integration-test.request.count",
+        "queryPairs": [
+          {
+            "key": "uri",
+            "value": "/v1/some-endpoint"
+          },
+          {
+            "key": "status_code",
+            "value": "4*"
+          }
+        ],
+        "aggregationMethod": "sum",
+        "serviceType": "signalfx",
+        "type": "signalfx"
+      },
+      "analysisConfigurations": {
+        "canary": {
+          "direction": "increase",
+          "critical": true
+        }
+      },
+      "groups": [
+        "Integration Test Group"
+      ],
+      "scopeName": "default"
+    }
+  ],
+  "classifier": {
+    "groupWeights": {
+      "Integration Test Group": 100
+    },
+    "scoreThresholds": {
+      "marginal": 50,
+      "pass": 75
+    }
+  }
+}
+```
+
 ## Canary Data Archival Format
 
 This format is used to store the results from a specific canary run.

--- a/kayenta-signalfx/README.md
+++ b/kayenta-signalfx/README.md
@@ -1,0 +1,36 @@
+# Kayenta SignalFx
+This module adds support to Kayenta to use SignalFx as a metric source.
+
+## Configuration
+
+### Kayenta
+```yaml
+  signalfx:
+    enabled: true
+    accounts:
+    - name: sfx-integration-test-account
+      accessToken: ${kayenta.signalfx.apiKey}
+      supportedTypes:
+      - METRICS_STORE
+```
+
+### Canary Config
+See [The metric query config](metric-query-config.md) page.
+
+## Development
+
+### Integration Tests
+This module has an End to End test that starts Kayenta with an in-memory config store and embedded Redis.
+It spawns threads that act like mock services that report metrics to SignalFx, there are three mock clusters.
+
+- Control - the control cluster
+- Healthy Experiment - a healthy experiment
+- Unhealthy Experiment - a unhealthy experiment
+
+The data flowing through SignalFx from these clusters can then be used for end to end testing.
+
+Running the end to end integration tests.
+
+```bash
+./gradlew kayenta-signalfx:integrationTest -Dkayenta.signalfx.apiKey=${SIGNALFX_API_TOKEN}
+```

--- a/kayenta-signalfx/README.md
+++ b/kayenta-signalfx/README.md
@@ -30,7 +30,8 @@ It spawns threads that act like mock services that report metrics to SignalFx, t
 The data flowing through SignalFx from these clusters can then be used for end to end testing.
 
 Running the end to end integration tests.
+Requires that you have a local redis-server installation compatible with Kayenta.
 
 ```bash
-./gradlew kayenta-signalfx:integrationTest -Dkayenta.signalfx.apiKey=${SIGNALFX_API_TOKEN}
+./gradlew kayenta-signalfx:integrationTest -Dkayenta.signalfx.apiKey=${SIGNALFX_API_TOKEN} -Dredis.path=$(which redis-server)
 ```

--- a/kayenta-signalfx/kayenta-signalfx.gradle
+++ b/kayenta-signalfx/kayenta-signalfx.gradle
@@ -28,9 +28,6 @@ configurations {
   integrationTestRuntime.extendsFrom testRuntime
 }
 
-def redisPort = getOpenPort()
-def redisServer = new RedisServer(redisPort)
-
 int getOpenPort() {
   ServerSocket socket
   try {
@@ -38,6 +35,7 @@ int getOpenPort() {
     socket.setReuseAddress(true)
     def port = socket.getLocalPort()
     logger.lifecycle("Using port: ${port} for Redis")
+    socket.close()
     return port
   } catch (Exception e) {
     logger.lifecycle("Failed to find open port for Redis", e)
@@ -54,24 +52,46 @@ task startEmbeddedRedis() {
   description 'Starts an embedded Redis server on an open port.'
 
   doLast {
+    def redisPort = getOpenPort()
+    String redisBinPath = getRequiredSystemProp('redis.path')
+    File redisBin = new File(redisBinPath)
+    if (!redisBin.exists()) {
+      //noinspection GroovyAssignabilityCheck
+      throw new GradleScriptException("The redis executable at '${redisBinPath}' did not exist")
+    }
+    def redisServer = new RedisServer(redisBin, redisPort)
     redisServer.start()
+    startEmbeddedRedis.ext.redisServer = redisServer
+    startEmbeddedRedis.ext.redisPort = redisPort
   }
 }
 
 //noinspection GroovyAssignabilityCheck
 task stopEmbeddedRedis() {
+  dependsOn startEmbeddedRedis
   group 'Application'
   description 'Stops the embedded Redis server.'
 
   doLast {
-    redisServer.stop()
+    startEmbeddedRedis.ext.redisServer.stop()
   }
+}
+
+@SuppressWarnings("GrMethodMayBeStatic")
+String getRequiredSystemProp(String key) {
+  String value = System.getProperty(key)
+  if (value == null || value == "") {
+    throw new IllegalStateException("The system property ${key} was not supplied to the gradle script via a -D prarm".toString())
+  }
+  return value
 }
 
 //noinspection GroovyAssignabilityCheck
 task integrationTest(type: Test) {
-  systemProperty("redis.port", redisPort)
-  systemProperty("kayenta.signalfx.apiKey", System.getProperty("kayenta.signalfx.apiKey"))
+  doFirst {
+    systemProperty("redis.port", startEmbeddedRedis.ext.redisPort)
+    systemProperty("kayenta.signalfx.apiKey", getRequiredSystemProp('kayenta.signalfx.apiKey'))
+  }
   systemProperty("spring.application.name", "kayenta")
   systemProperty('spring.config.name', "spinnaker,kayenta")
   systemProperty('spring.config.location', "file:${project.rootDir}/kayenta-signalfx/src/integration-test/resources/config/")

--- a/kayenta-signalfx/kayenta-signalfx.gradle
+++ b/kayenta-signalfx/kayenta-signalfx.gradle
@@ -1,0 +1,117 @@
+buildscript {
+  repositories {
+    jcenter()
+    maven { url "http://spinnaker.bintray.com/gradle" }
+    maven { url "https://plugins.gradle.org/m2/" }
+  }
+  dependencies {
+    // Apache 2.0, https://github.com/ozimov/embedded-redis#license
+    classpath 'it.ozimov:embedded-redis:0.7.2'
+  }
+}
+
+import redis.embedded.RedisServer
+
+sourceSets {
+  integrationTest {
+    java {
+      compileClasspath += main.output + test.output
+      runtimeClasspath += main.output + test.output
+      srcDir file('src/integration-test/java')
+    }
+    resources.srcDir file('src/integration-test/resources')
+  }
+}
+
+configurations {
+  integrationTestCompile.extendsFrom testCompile
+  integrationTestRuntime.extendsFrom testRuntime
+}
+
+def redisPort = getOpenPort()
+def redisServer = new RedisServer(redisPort)
+
+int getOpenPort() {
+  ServerSocket socket
+  try {
+    socket = new ServerSocket(0)
+    socket.setReuseAddress(true)
+    def port = socket.getLocalPort()
+    logger.lifecycle("Using port: ${port} for Redis")
+    return port
+  } catch (Exception e) {
+    logger.lifecycle("Failed to find open port for Redis", e)
+    if (socket != null) {
+      socket.close()
+    }
+    throw new RuntimeException(e)
+  }
+}
+
+//noinspection GroovyAssignabilityCheck
+task startEmbeddedRedis() {
+  group 'Application'
+  description 'Starts an embedded Redis server on an open port.'
+
+  doLast {
+    redisServer.start()
+  }
+}
+
+//noinspection GroovyAssignabilityCheck
+task stopEmbeddedRedis() {
+  group 'Application'
+  description 'Stops the embedded Redis server.'
+
+  doLast {
+    redisServer.stop()
+  }
+}
+
+//noinspection GroovyAssignabilityCheck
+task integrationTest(type: Test) {
+  systemProperty("redis.port", redisPort)
+  systemProperty("kayenta.signalfx.apiKey", System.getProperty("kayenta.signalfx.apiKey"))
+  systemProperty("spring.application.name", "kayenta")
+  systemProperty('spring.config.name', "spinnaker,kayenta")
+  systemProperty('spring.config.location', "file:${project.rootDir}/kayenta-signalfx/src/integration-test/resources/config/")
+  testClassesDirs = sourceSets.integrationTest.output.classesDirs
+  classpath = sourceSets.integrationTest.runtimeClasspath
+}
+
+tasks.integrationTest.dependsOn 'startEmbeddedRedis'
+tasks.integrationTest.finalizedBy 'stopEmbeddedRedis'
+
+integrationTest {
+  testLogging {
+    showStandardStreams = true
+  }
+}
+
+dependencies {
+  compile project(":kayenta-core")
+
+  compile spinnaker.dependency('bootWeb')
+  compile spinnaker.dependency("korkSwagger")
+  compile spinnaker.dependency('lombok')
+
+  compile "com.netflix.spinnaker.orca:orca-core:$orcaVersion"
+
+  compile group: 'com.signalfx.public', name: 'signalfx-java', version: '0.0.48'
+
+  // Integration Test dependencies
+  integrationTestCompile sourceSets.main.output
+  integrationTestCompile configurations.testCompile
+  integrationTestCompile sourceSets.test.output
+  integrationTestRuntime configurations.testRuntime
+  integrationTestCompile project(':kayenta-web')
+
+  // Apache 2.0 https://github.com/rest-assured/rest-assured/blob/master/LICENSE
+  integrationTestCompile 'io.rest-assured:rest-assured:3.1.1'
+}
+
+test {
+  testLogging {
+    events "passed", "skipped", "failed"
+  }
+}

--- a/kayenta-signalfx/metric-query-config.md
+++ b/kayenta-signalfx/metric-query-config.md
@@ -1,0 +1,27 @@
+Example metric configuration for a canary config, in yaml for readability.
+
+See [The integration test canary-config json](src/integration-test/resources/integration-test-canary-config.json) for a real example.
+
+```yaml
+name: Error Rate for /v1/some-endpoint
+query:
+  metricName: kayenta.integration-test.internal-server-errors
+  queryPairs: # [Optional] Can be dimensions, properties, or tags (Use tag as key for tags).
+  - key: uri
+    value: /v1/some-endpoint
+  - key: status_code
+    value: "5*"
+  # Aggregate the N time series across each instance in a cluster to a single series, this gets used in the SignalFlow program
+  # Supported options are the stream method that support aggregation see: https://developers.signalfx.com/reference#signalflow-stream-methods-1
+  aggregationMethod: sum # [Optional] Defaults to mean
+  serviceType: signalfx
+  type: signalfx
+analysisConfigurations:
+  canary:
+    direction: increase
+    # Fail the canary if server errors increase.
+    critical: true
+groups:
+- Integration Test Group
+scopeName: default
+```

--- a/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/config/SignalFxMockServiceReportingConfig.java
+++ b/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/config/SignalFxMockServiceReportingConfig.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2018 Nike, inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.kayenta.config;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.restassured.http.Header;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static com.netflix.kayenta.signalfx.EndToEndIntegrationTests.CANARY_WINDOW_IN_MINUTES;
+import static io.restassured.RestAssured.given;
+
+/**
+ * Spring Test Config for the SignalFx Integration Tests.
+ * Creates NUMBER_OF_INSTANCES_PER_MOCK_CLUSTER number of threads for a mock service with three clusters (control, healthy experiment and a unhealthy experiment)
+ * These mock clusters will report metrics in their background threads to SignalFx for the IntegrationTest suite to integrate with.
+ * <p>
+ * The metrics that get sent from this config, should align with what is defined in integration-test-canary-config.json in the integration source set resources dir.
+ */
+@TestConfiguration
+@Slf4j
+public class SignalFxMockServiceReportingConfig {
+
+  private static final int NUMBER_OF_INSTANCES_PER_MOCK_CLUSTER = 3;
+  private static final String INGEST_ENDPOINT = "https://ingest.signalfx.com/v2/datapoint";
+  private static final int MOCK_SERVICE_REPORTING_INTERVAL_IN_MILLISECONDS = 1000;
+
+  public static final String SIGNAL_FX_SCOPE_IDENTIFYING_DIMENSION_NAME = "canary-scope";
+  public static final String KAYENTA_INTEGRATION_TEST_CPU_AVG_METRIC_NAME = "kayenta.integration-test.cpu.avg";
+  public static final String KAYENTA_INTEGRATION_TEST_REQUEST_COUNT_METRIC_NAME = "kayenta.integration-test.request.count";
+  public static final String CONTROL_SCOPE_NAME = "control";
+  public static final String HEALTHY_EXPERIMENT_SCOPE_NAME = "healthy-experiment";
+  public static final String UNHEALTHY_EXPERIMENT_SCOPE_NAME = "unhealthy-experiment";
+
+  private final ExecutorService executorService;
+  private final String signalFxApiToken;
+
+  private String testId;
+  private Instant metricsReportingStartTime;
+
+  public SignalFxMockServiceReportingConfig(@Value("${kayenta.signalfx.apiKey}") final String signalFxApiToken) {
+    executorService = Executors.newFixedThreadPool(9);
+    this.signalFxApiToken = signalFxApiToken;
+  }
+
+  @Bean
+  public String testId() {
+    return testId;
+  }
+
+  @Bean
+  public Instant metricsReportingStartTime() {
+    return metricsReportingStartTime;
+  }
+
+  @PostConstruct
+  public void start() {
+    testId = UUID.randomUUID().toString();
+
+    ImmutableList.of(CONTROL_SCOPE_NAME, HEALTHY_EXPERIMENT_SCOPE_NAME).forEach(scope -> {
+      for (int i = 0; i < NUMBER_OF_INSTANCES_PER_MOCK_CLUSTER; i++) {
+        executorService.submit(createMetricReportingMockService(scope, ImmutableMap.of(
+            KAYENTA_INTEGRATION_TEST_CPU_AVG_METRIC_NAME, new Metric(10),
+            KAYENTA_INTEGRATION_TEST_REQUEST_COUNT_METRIC_NAME, new Metric(0,
+                ImmutableMap.of(
+                    "uri", "/v1/some-endpoint",
+                    "status_code", "400"
+                )
+            )
+        ), UUID.randomUUID().toString()));
+      }
+    });
+
+    ImmutableList.of(UNHEALTHY_EXPERIMENT_SCOPE_NAME).forEach(scope -> {
+      for (int i = 0; i < NUMBER_OF_INSTANCES_PER_MOCK_CLUSTER; i++) {
+        executorService.submit(createMetricReportingMockService(scope, ImmutableMap.of(
+            KAYENTA_INTEGRATION_TEST_CPU_AVG_METRIC_NAME, new Metric(12),
+            KAYENTA_INTEGRATION_TEST_REQUEST_COUNT_METRIC_NAME, new Metric(50,
+                ImmutableMap.of(
+                    "uri", "/v1/some-endpoint",
+                    "status_code", "400"
+                )
+            )
+        ), UUID.randomUUID().toString()));
+      }
+    });
+
+    metricsReportingStartTime = Instant.now();
+
+    // Wait for the mock services to send data, before allowing the tests to run
+    try {
+      long pause = TimeUnit.MINUTES.toMillis(CANARY_WINDOW_IN_MINUTES) + TimeUnit.SECONDS.toMillis(15);
+      log.info("Waiting for {} milliseconds for mock data to flow through SignalFx, before letting the integration tests run", pause);
+      Thread.sleep(pause);
+    } catch (InterruptedException e) {
+      log.error("Failed to wait to send metrics", e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  @PreDestroy
+  public void stop() {
+    executorService.shutdownNow();
+  }
+
+  private Runnable createMetricReportingMockService(String scopeName, Map<String, Metric> metrics, String uuid) {
+    return () -> {
+      while (!Thread.currentThread().isInterrupted()) {
+        try {
+          List<Map<String, Object>> signalfxMetrics = new LinkedList<>();
+          metrics.forEach((metricName, metric) -> signalfxMetrics.add(
+              ImmutableMap.of(
+                  "metric", metricName,
+                  "dimensions", ImmutableMap.builder()
+                      .putAll(metric.getDimensions())
+                      .put(SIGNAL_FX_SCOPE_IDENTIFYING_DIMENSION_NAME, scopeName)
+                      .put("env", "integration")
+                      .put("test-id", testId)
+                      .put("uuid", uuid)
+                      .build(),
+                  "value", metric.getValue() + new Random().nextInt(6)
+              )
+          ));
+          Map<String, List<Map<String, Object>>> signalfxRequest = ImmutableMap.of(
+              "gauge", signalfxMetrics
+          );
+
+          given()
+              .header(new Header("X-SF-TOKEN", signalFxApiToken))
+              .contentType("application/json")
+              .body(signalfxRequest)
+              .when()
+              .post(INGEST_ENDPOINT)
+              .then()
+              .statusCode(200);
+
+          try {
+            Thread.sleep(MOCK_SERVICE_REPORTING_INTERVAL_IN_MILLISECONDS);
+          } catch (InterruptedException e) {
+            log.debug("Thread interrupted", e);
+          }
+        } catch (Throwable t) {
+          log.error("FAILED TO REPORT METRICS TO SIGNALFX, SHUTTING DOWN JVM", t);
+          System.exit(1);
+        }
+      }
+    };
+  }
+
+  @Data
+  private class Metric {
+
+    public Metric(Integer value, Map<String, String> dimensions) {
+      this.dimensions = dimensions;
+      this.value = value;
+    }
+
+    public Metric(Integer value) {
+      this.value = value;
+      this.dimensions = new HashMap<>();
+    }
+
+    private Map<String, String> dimensions;
+    private Integer value;
+  }
+}

--- a/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/EndToEndIntegrationTests.java
+++ b/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/EndToEndIntegrationTests.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2018 Nike, inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.kayenta.signalfx;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.netflix.kayenta.Main;
+import com.netflix.kayenta.canary.CanaryAdhocExecutionRequest;
+import com.netflix.kayenta.canary.CanaryClassifierThresholdsConfig;
+import com.netflix.kayenta.canary.CanaryConfig;
+import com.netflix.kayenta.canary.CanaryExecutionRequest;
+import com.netflix.kayenta.canary.CanaryScope;
+import com.netflix.kayenta.canary.CanaryScopePair;
+import io.restassured.response.ValidatableResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.embedded.LocalServerPort;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.IOException;
+import java.time.Instant;
+
+import static com.netflix.kayenta.config.SignalFxMockServiceReportingConfig.CONTROL_SCOPE_NAME;
+import static com.netflix.kayenta.config.SignalFxMockServiceReportingConfig.HEALTHY_EXPERIMENT_SCOPE_NAME;
+import static com.netflix.kayenta.config.SignalFxMockServiceReportingConfig.SIGNAL_FX_SCOPE_IDENTIFYING_DIMENSION_NAME;
+import static com.netflix.kayenta.config.SignalFxMockServiceReportingConfig.UNHEALTHY_EXPERIMENT_SCOPE_NAME;
+import static com.netflix.kayenta.signalfx.canary.SignalFxCanaryScopeFactory.SCOPE_KEY_KEY;
+import static io.restassured.RestAssured.*;
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * End to end integration tests
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = Main.class
+)
+@Slf4j
+public class EndToEndIntegrationTests {
+
+  public static final int CANARY_WINDOW_IN_MINUTES = 1;
+
+  @Autowired
+  private ObjectMapper objectMapper = new ObjectMapper();
+
+  @Autowired
+  private String testId;
+
+  @Autowired
+  private Instant metricsReportingStartTime;
+
+  @LocalServerPort
+  protected int serverPort;
+
+  private String getUriTemplate() {
+    return "http://localhost:" + serverPort + "%s";
+  }
+
+  @Test
+  public void test_that_signalfx_can_be_used_as_a_data_source_for_a_canary_execution_healthy() throws IOException {
+    ValidatableResponse response = doCanaryExec(HEALTHY_EXPERIMENT_SCOPE_NAME);
+    response.body("result.judgeResult.score.classification", is("Pass"));
+  }
+
+  @Test
+  public void test_that_signalfx_can_be_used_as_a_data_source_for_a_canary_execution_unhealthy() throws IOException {
+    ValidatableResponse response = doCanaryExec(UNHEALTHY_EXPERIMENT_SCOPE_NAME);
+    response.body("result.judgeResult.score.classification", is("Fail"));
+    response.body("result.judgeResult.score.classificationReason", containsString("Bad Request Rate for /v1/some-endpoint"));
+  }
+
+  private ValidatableResponse doCanaryExec(String expScope) throws IOException {
+    // Build the Canary Adhoc Execution Request for our test
+    CanaryAdhocExecutionRequest request = new CanaryAdhocExecutionRequest();
+
+    CanaryConfig canaryConfig = objectMapper.readValue(getClass().getClassLoader()
+        .getResourceAsStream("integration-test-canary-config.json"), CanaryConfig.class);
+
+    request.setCanaryConfig(canaryConfig);
+
+    CanaryExecutionRequest executionRequest = new CanaryExecutionRequest();
+    CanaryClassifierThresholdsConfig canaryClassifierThresholdsConfig = CanaryClassifierThresholdsConfig.builder()
+        .marginal(50D).pass(75D).build();
+    executionRequest.setThresholds(canaryClassifierThresholdsConfig);
+
+    Instant end = metricsReportingStartTime.plus(CANARY_WINDOW_IN_MINUTES, MINUTES);
+
+    CanaryScope control = new CanaryScope()
+        .setScope(CONTROL_SCOPE_NAME)
+        .setExtendedScopeParams(ImmutableMap.of(
+            SCOPE_KEY_KEY, SIGNAL_FX_SCOPE_IDENTIFYING_DIMENSION_NAME,
+            "test-id", testId
+        ))
+        .setLocation("us-west-2")
+        .setStep(1l)
+        .setStart(metricsReportingStartTime)
+        .setEnd(end);
+
+    CanaryScope experiment = new CanaryScope()
+        .setScope(expScope)
+        .setExtendedScopeParams(ImmutableMap.of(
+            SCOPE_KEY_KEY, SIGNAL_FX_SCOPE_IDENTIFYING_DIMENSION_NAME,
+            "test-id", testId
+        ))
+        .setLocation("us-west-2")
+        .setStep(1l)
+        .setStart(metricsReportingStartTime)
+        .setEnd(end);
+
+    CanaryScopePair canaryScopePair = new CanaryScopePair();
+    canaryScopePair.setControlScope(control);
+    canaryScopePair.setExperimentScope(experiment);
+    executionRequest.setScopes(ImmutableMap.of("default", canaryScopePair));
+    request.setExecutionRequest(executionRequest);
+
+    // trigger a canary stage execution with the request
+    ValidatableResponse canaryExRes =
+        given()
+            .contentType("application/json")
+            .queryParam("metricsAccountName", "sfx-integration-test-account")
+            .queryParam("storageAccountName", "in-memory-store")
+            .body(request)
+        .when()
+            .post(String.format(getUriTemplate(), "/canary"))
+        .then()
+            .log().ifValidationFails()
+            .statusCode(200);
+
+    String canaryExecutionId = canaryExRes.extract().body().jsonPath().getString("canaryExecutionId");
+
+    // poll for the stage to complete
+    ValidatableResponse response;
+    do {
+      response = when().get(String.format(getUriTemplate(), "/canary/" + canaryExecutionId))
+          .then().statusCode(200);
+    } while (!response.extract().body().jsonPath().getBoolean("complete"));
+
+    // verify the results are as expected
+    return response.log().everything(true).body("status", is("succeeded"));
+  }
+}

--- a/kayenta-signalfx/src/integration-test/resources/config/kayenta.yml
+++ b/kayenta-signalfx/src/integration-test/resources/config/kayenta.yml
@@ -1,0 +1,83 @@
+redis:
+  connection: redis://localhost:${redis.port}
+
+#retrofit:
+#  logLevel: FULL
+
+kayenta:
+  atlas:
+    enabled: false
+
+  google:
+    enabled: false
+
+  aws:
+    enabled: false
+
+  datadog:
+    enabled: false
+
+  prometheus:
+    enabled: false
+
+  influxdb:
+    enabled: false
+
+  gcs:
+    enabled: false
+
+  s3:
+    enabled: false
+
+  signalfx:
+    enabled: true
+    accounts:
+    - name: sfx-integration-test-account
+      accessToken: ${kayenta.signalfx.apiKey}
+      supportedTypes:
+      - METRICS_STORE
+
+  stackdriver:
+    enabled: false
+
+  memory:
+    enabled: true
+    accounts:
+    - name: in-memory-store
+      supportedTypes:
+      - OBJECT_STORE
+
+  configbin:
+    enabled: false
+
+management.security.enabled: false
+
+keiko:
+  queue:
+    redis:
+      queueName: kayenta.keiko.queue
+      deadLetterQueueName: kayenta.keiko.queue.deadLetters
+
+spectator:
+  applicationName: ${spring.application.name}
+  webEndpoint:
+    enabled: true
+
+swagger:
+  enabled: true
+  title: Kayenta API
+  description:
+  contact:
+  patterns:
+  - /admin.*
+  - /canary.*
+  - /canaryConfig.*
+  - /canaryJudgeResult.*
+  - /credentials.*
+  - /fetch.*
+  - /health
+  - /judges.*
+  - /metadata.*
+  - /metricSetList.*
+  - /metricSetPairList.*
+  - /pipeline.*

--- a/kayenta-signalfx/src/integration-test/resources/integration-test-canary-config.json
+++ b/kayenta-signalfx/src/integration-test/resources/integration-test-canary-config.json
@@ -1,0 +1,65 @@
+{
+  "name": "integration-test-canary-config",
+  "description": "A very simple config for integration testing the SignalFx metric source Kayenta module.",
+  "judge": {
+    "judgeConfigurations": {},
+    "name": "NetflixACAJudge-v1.0"
+  },
+  "metrics": [
+    {
+      "name": "Cpu Usage Percentage",
+      "query": {
+        "metricName": "kayenta.integration-test.cpu.avg",
+        "serviceType": "signalfx",
+        "type": "signalfx"
+      },
+      "analysisConfigurations": {
+        "canary": {
+          "direction": "increase"
+        }
+      },
+      "groups": [
+        "Integration Test Group"
+      ],
+      "scopeName": "default"
+    },
+    {
+      "name": "Bad Request Rate for /v1/some-endpoint",
+      "query": {
+        "metricName": "kayenta.integration-test.request.count",
+        "queryPairs": [
+          {
+            "key": "uri",
+            "value": "/v1/some-endpoint"
+          },
+          {
+            "key": "status_code",
+            "value": "4*"
+          }
+        ],
+        "aggregationMethod": "sum",
+        "serviceType": "signalfx",
+        "type": "signalfx"
+      },
+      "analysisConfigurations": {
+        "canary": {
+          "direction": "increase",
+          "critical": true
+        }
+      },
+      "groups": [
+        "Integration Test Group"
+      ],
+      "scopeName": "default"
+    }
+  ],
+  "classifier": {
+    "groupWeights": {
+      "Integration Test Group": 100
+    },
+    "scoreThresholds": {
+      "marginal": 50,
+      "pass": 75
+    }
+  }
+}

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/canary/providers/metrics/QueryPair.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/canary/providers/metrics/QueryPair.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018 Nike, inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.kayenta.canary.providers.metrics;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Can be used for Dimensions, Tags or Properties.
+ * For Tags, use 'tag' as the key.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class QueryPair {
+
+  private String key;
+  private String value;
+}

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/canary/providers/metrics/SignalFxCanaryMetricSetQueryConfig.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/canary/providers/metrics/SignalFxCanaryMetricSetQueryConfig.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2018 Nike, inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.kayenta.canary.providers.metrics;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.netflix.kayenta.canary.CanaryMetricSetQueryConfig;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonTypeName("signalfx")
+public class SignalFxCanaryMetricSetQueryConfig implements CanaryMetricSetQueryConfig {
+
+  public static final String SERVICE_TYPE = "signalfx";
+
+  @NotNull
+  @Getter
+  private String metricName;
+
+  @Getter
+  private List<QueryPair> queryPairs;
+
+  @Getter
+  private String aggregationMethod;
+
+  @Override
+  public String getServiceType() {
+    return SERVICE_TYPE;
+  }
+}

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/canary/SignalFxCanaryScope.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/canary/SignalFxCanaryScope.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018 Nike, inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.kayenta.signalfx.canary;
+
+import com.netflix.kayenta.canary.CanaryScope;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class SignalFxCanaryScope extends CanaryScope {
+
+  @NotNull
+  private String scopeKey;
+
+}

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/canary/SignalFxCanaryScopeFactory.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/canary/SignalFxCanaryScopeFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2018 Nike, inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.kayenta.signalfx.canary;
+
+import com.netflix.kayenta.canary.CanaryScope;
+import com.netflix.kayenta.canary.CanaryScopeFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.netflix.kayenta.canary.providers.metrics.SignalFxCanaryMetricSetQueryConfig.SERVICE_TYPE;
+
+@Component
+public class SignalFxCanaryScopeFactory implements CanaryScopeFactory {
+
+  public static String SCOPE_KEY_KEY = "_scope_key";
+
+  @Override
+  public boolean handles(String serviceType) {
+    return SERVICE_TYPE.equals(serviceType);
+  }
+
+  @Override
+  public CanaryScope buildCanaryScope(CanaryScope canaryScope) {
+
+    Map<String, String> extendedParameters = Optional.ofNullable(canaryScope.getExtendedScopeParams())
+        .orElseThrow(() -> new IllegalArgumentException("SignalFx requires extended parameters"));
+
+    SignalFxCanaryScope signalFxCanaryScope = new SignalFxCanaryScope();
+    signalFxCanaryScope.setScope(canaryScope.getScope());
+    signalFxCanaryScope.setLocation(canaryScope.getLocation());
+    signalFxCanaryScope.setStart(canaryScope.getStart());
+    signalFxCanaryScope.setEnd(canaryScope.getEnd());
+    signalFxCanaryScope.setStep(canaryScope.getStep());
+    signalFxCanaryScope.setScopeKey(getRequiredExtendedParam(SCOPE_KEY_KEY, extendedParameters));
+    signalFxCanaryScope.setExtendedScopeParams(extendedParameters);
+
+    return signalFxCanaryScope;
+  }
+
+  private String getRequiredExtendedParam(String key, Map<String, String> extendedParameters) {
+    if (! extendedParameters.containsKey(key)) {
+      throw new IllegalArgumentException(String.format("SignalFx requires that %s is set in the extended scope params", key));
+    }
+    return extendedParameters.get(key);
+  }
+}

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/config/SignalFxConfiguration.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/config/SignalFxConfiguration.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2018 Nike, inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.kayenta.signalfx.config;
+
+import com.netflix.kayenta.metrics.MetricsService;
+import com.netflix.kayenta.retrofit.config.RemoteService;
+import com.netflix.kayenta.retrofit.config.RetrofitClientFactory;
+import com.netflix.kayenta.security.AccountCredentials;
+import com.netflix.kayenta.security.AccountCredentialsRepository;
+import com.netflix.kayenta.signalfx.metrics.SignalFxMetricsService;
+import com.netflix.kayenta.signalfx.security.SignalFxCredentials;
+import com.netflix.kayenta.signalfx.security.SignalFxNamedAccountCredentials;
+import com.netflix.kayenta.signalfx.service.SignalFxConverter;
+import com.netflix.kayenta.signalfx.service.SignalFxSignalFlowRemoteService;
+import com.squareup.okhttp.OkHttpClient;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.CollectionUtils;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Configuration
+@EnableConfigurationProperties
+@ConditionalOnProperty("kayenta.signalfx.enabled")
+@ComponentScan({"com.netflix.kayenta.signalfx"})
+@Slf4j
+public class SignalFxConfiguration {
+
+  private static final String SIGNAL_FX_SIGNAL_FLOW_ENDPOINT_URI = "https://stream.signalfx.com";
+
+  @Bean
+  @ConfigurationProperties("kayenta.signalfx")
+  SignalFxConfigurationProperties signalFxConfigurationProperties() {
+    return new SignalFxConfigurationProperties();
+  }
+
+  @Bean
+  MetricsService signalFxMetricService(SignalFxConfigurationProperties signalFxConfigurationProperties,
+                                       RetrofitClientFactory retrofitClientFactory,
+                                       OkHttpClient okHttpClient,
+                                       AccountCredentialsRepository accountCredentialsRepository) {
+
+    SignalFxMetricsService.SignalFxMetricsServiceBuilder metricsServiceBuilder = SignalFxMetricsService.builder();
+
+    for (SignalFxManagedAccount signalFxManagedAccount : signalFxConfigurationProperties.getAccounts()) {
+      String name = signalFxManagedAccount.getName();
+      List<AccountCredentials.Type> supportedTypes = signalFxManagedAccount.getSupportedTypes();
+      SignalFxCredentials signalFxCredentials = new SignalFxCredentials(signalFxManagedAccount.getAccessToken());
+
+      final RemoteService signalFxSignalFlowEndpoint = new RemoteService()
+          .setBaseUrl(SIGNAL_FX_SIGNAL_FLOW_ENDPOINT_URI);
+
+      SignalFxNamedAccountCredentials.SignalFxNamedAccountCredentialsBuilder accountCredentialsBuilder =
+          SignalFxNamedAccountCredentials
+              .builder()
+              .name(name)
+              .endpoint(signalFxSignalFlowEndpoint)
+              .credentials(signalFxCredentials);
+
+      if (!CollectionUtils.isEmpty(supportedTypes)) {
+        if (supportedTypes.contains(AccountCredentials.Type.METRICS_STORE)) {
+          accountCredentialsBuilder.signalFlowService(retrofitClientFactory.createClient(
+              SignalFxSignalFlowRemoteService.class,
+              new SignalFxConverter(),
+              signalFxSignalFlowEndpoint,
+              okHttpClient
+          ));
+        }
+        accountCredentialsBuilder.supportedTypes(supportedTypes);
+      }
+
+      accountCredentialsRepository.save(name, accountCredentialsBuilder.build());
+      metricsServiceBuilder.accountName(name);
+    }
+
+    log.info("Configured the SignalFx Metrics Service with the following accounts: {}",
+        String.join(",", signalFxConfigurationProperties.getAccounts().stream()
+            .map(SignalFxManagedAccount::getName).collect(Collectors.toList())));
+
+    return metricsServiceBuilder.build();
+  }
+}

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/config/SignalFxConfigurationProperties.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/config/SignalFxConfigurationProperties.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2018 Nike, inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.kayenta.signalfx.config;
+
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SignalFxConfigurationProperties {
+
+  @Getter
+  private List<SignalFxManagedAccount> accounts = new ArrayList<>();
+}

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/config/SignalFxManagedAccount.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/config/SignalFxManagedAccount.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018 Nike, inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.kayenta.signalfx.config;
+
+import com.netflix.kayenta.security.AccountCredentials;
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Data
+public class SignalFxManagedAccount {
+
+  @NotNull
+  private String name;
+
+  private String accessToken;
+
+  private List<AccountCredentials.Type> supportedTypes;
+}

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/metrics/SignalFxMetricsService.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/metrics/SignalFxMetricsService.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2018 Nike, inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.kayenta.signalfx.metrics;
+
+import com.netflix.kayenta.canary.CanaryConfig;
+import com.netflix.kayenta.canary.CanaryMetricConfig;
+import com.netflix.kayenta.canary.CanaryScope;
+import com.netflix.kayenta.canary.providers.metrics.QueryPair;
+import com.netflix.kayenta.canary.providers.metrics.SignalFxCanaryMetricSetQueryConfig;
+import com.netflix.kayenta.metrics.MetricSet;
+import com.netflix.kayenta.metrics.MetricsService;
+import com.netflix.kayenta.security.AccountCredentialsRepository;
+import com.netflix.kayenta.signalfx.canary.SignalFxCanaryScope;
+import com.netflix.kayenta.signalfx.security.SignalFxNamedAccountCredentials;
+import com.netflix.kayenta.signalfx.service.ErrorResponse;
+import com.netflix.kayenta.signalfx.service.SignalFlowExecutionResult;
+import com.netflix.kayenta.signalfx.service.SignalFxRequestError;
+import com.netflix.kayenta.signalfx.service.SignalFxSignalFlowRemoteService;
+import com.signalfx.signalflow.ChannelMessage;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Singular;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import retrofit.RetrofitError;
+
+import javax.validation.constraints.NotNull;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.signalfx.signalflow.ChannelMessage.Type.DATA_MESSAGE;
+import static com.signalfx.signalflow.ChannelMessage.Type.ERROR_MESSAGE;
+
+@Builder
+@Slf4j
+public class SignalFxMetricsService implements MetricsService {
+
+  @NotNull
+  @Singular
+  @Getter
+  private List<String> accountNames;
+
+  @Autowired
+  private final AccountCredentialsRepository accountCredentialsRepository;
+
+  @Override
+  public String getType() {
+    return "signalfx";
+  }
+
+  @Override
+  public boolean servicesAccount(String accountName) {
+    return accountNames.contains(accountName);
+  }
+
+  @Override
+  public List<MetricSet> queryMetrics(String accountName,
+                                      CanaryConfig canaryConfig,
+                                      CanaryMetricConfig canaryMetricConfig,
+                                      CanaryScope canaryScope) {
+
+    if (!(canaryScope instanceof SignalFxCanaryScope)) {
+      throw new IllegalArgumentException("Canary scope not instance of SignalFxCanaryScope: " + canaryScope +
+          ". One common cause is having multiple METRICS_STORE accounts configured but " +
+          "neglecting to explicitly specify which account to use for a given request.");
+    }
+
+    SignalFxCanaryScope signalFxCanaryScope = (SignalFxCanaryScope)canaryScope;
+
+    SignalFxNamedAccountCredentials accountCredentials =
+        (SignalFxNamedAccountCredentials) accountCredentialsRepository.getOne(accountName)
+            .orElseThrow(() -> new IllegalArgumentException("Unable to resolve account " + accountName + "."));
+
+    String accessToken = accountCredentials.getCredentials().getAccessToken();
+    SignalFxSignalFlowRemoteService signalFlowService = accountCredentials.getSignalFlowService();
+    SignalFxCanaryMetricSetQueryConfig queryConfig = (SignalFxCanaryMetricSetQueryConfig) canaryMetricConfig.getQuery();
+
+    long startEpochMilli = signalFxCanaryScope.getStart().toEpochMilli();
+    long endEpochMilli = signalFxCanaryScope.getEnd().toEpochMilli();
+    long canaryStepLengthInSeconds = signalFxCanaryScope.getStep();
+    // Determine and validate the data resolution to use for the query
+    long stepMilli = Duration.ofSeconds(canaryStepLengthInSeconds).toMillis();
+
+    String aggregationMethod = Optional.ofNullable(queryConfig.getAggregationMethod()).orElse("mean");
+    List<QueryPair> queryPairs = Optional.ofNullable(queryConfig.getQueryPairs()).orElse(new LinkedList<>());
+
+    // Fetch the user override or build the simple SignalFlow program.
+    String program = SimpleSignalFlowProgramBuilder
+        .create(queryConfig.getMetricName(), aggregationMethod)
+        .withQueryPairs(queryPairs)
+        .withScope(signalFxCanaryScope)
+        .build();
+
+    SignalFlowExecutionResult signalFlowExecutionResult;
+    try {
+      signalFlowExecutionResult = signalFlowService
+          .executeSignalFlowProgram(accessToken, startEpochMilli, endEpochMilli,
+              stepMilli, 0, true, program);
+    } catch (RetrofitError e) {
+      ErrorResponse errorResponse = (ErrorResponse) e.getBodyAs(ErrorResponse.class);
+      throw new SignalFxRequestError(errorResponse, program, startEpochMilli,
+          endEpochMilli, stepMilli, accountName);
+    }
+
+    // Return a Metric set of the reduced and aggregated data
+    MetricSet metricSet = MetricSet.builder()
+        .name(canaryMetricConfig.getName())
+        .startTimeMillis(startEpochMilli)
+        .startTimeIso(Instant.ofEpochMilli(startEpochMilli).toString())
+        .endTimeMillis(endEpochMilli)
+        .endTimeIso(Instant.ofEpochMilli(endEpochMilli).toString())
+        .stepMillis(stepMilli)
+        .values(getTimeSeriesDataFromChannelMessages(signalFlowExecutionResult.getChannelMessages()))
+        .tags(queryPairs.stream().collect(Collectors.toMap(QueryPair::getKey, QueryPair::getValue)))
+        .attribute("signal-flow-program", program)
+        .build();
+
+    return Collections.singletonList(metricSet);
+  }
+
+  /**
+   * Parses the data out of the SignalFx Signal Flow messages to build the data Kayenta needs to make judgements.
+   *
+   * @param channelMessages The list of messages from the signal flow execution.
+   * @return The list of values with missing data filled with NaNs
+   */
+  protected List<Double> getTimeSeriesDataFromChannelMessages(List<ChannelMessage> channelMessages) {
+    channelMessages.parallelStream().filter(channelMessage -> channelMessage.getType().equals(ERROR_MESSAGE))
+        .findAny()
+        .ifPresent(error -> {
+
+          // This error message is terrible, and I am not sure how to add more context to it.
+          // error.getErrors() returns a List<Object>, and it is unclear what to do with those.
+          throw new RuntimeException("Some sort of error occurred, when executing the signal flow program");
+        });
+
+    return channelMessages.parallelStream()
+        .filter(channelMessage -> channelMessage.getType().equals(DATA_MESSAGE))
+        .map(message -> {
+          ChannelMessage.DataMessage dataMessage = (ChannelMessage.DataMessage) message;
+          Map<String, Number> data = dataMessage.getData();
+          if (data.size() > 1) {
+            throw new IllegalStateException("There was more than one value for a given timestamp, a " +
+                "SignalFlow stream method that can aggregate should have been applied to the data in " +
+                "the SignalFlow program");
+          }
+          //noinspection OptionalGetWithoutIsPresent
+          return data.size() == 1 ? data.values().stream().findFirst().get().doubleValue() : Double.NaN;
+        }).collect(Collectors.toList());
+  }
+}

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/metrics/SimpleSignalFlowProgramBuilder.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/metrics/SimpleSignalFlowProgramBuilder.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2018 Nike, inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.kayenta.signalfx.metrics;
+
+import com.netflix.kayenta.canary.providers.metrics.QueryPair;
+import com.netflix.kayenta.signalfx.canary.SignalFxCanaryScope;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Builds simple signal flow programs.
+ */
+public class SimpleSignalFlowProgramBuilder {
+
+  public static final String FILTER_TEMPLATE = "filter('%s', '%s')";
+  private final String metricName;
+  private final String aggregationMethod;
+
+  private List<QueryPair> queryPairs;
+  private List<String> filterSegments;
+  private List<String> scopeKeys;
+
+  private SimpleSignalFlowProgramBuilder(String metricName, String aggregationMethod) {
+    this.metricName = metricName;
+    this.aggregationMethod = aggregationMethod;
+    queryPairs = new LinkedList<>();
+    filterSegments = new LinkedList<>();
+    scopeKeys = new LinkedList<>();
+  }
+
+  public static SimpleSignalFlowProgramBuilder create(String metricName,
+                                                      String aggregationMethod) {
+
+    return new SimpleSignalFlowProgramBuilder(metricName, aggregationMethod);
+  }
+
+  public SimpleSignalFlowProgramBuilder withQueryPair(QueryPair queryPair) {
+    queryPairs.add(queryPair);
+    return this;
+  }
+
+  public SimpleSignalFlowProgramBuilder withQueryPairs(Collection<QueryPair> queryPairs) {
+    this.queryPairs.addAll(queryPairs);
+    return this;
+  }
+
+  public SimpleSignalFlowProgramBuilder withScope(SignalFxCanaryScope canaryScope) {
+    scopeKeys.addAll(canaryScope.getExtendedScopeParams().keySet().stream()
+        .filter(key -> !key.startsWith("_")).collect(Collectors.toList()));
+    scopeKeys.add(canaryScope.getScopeKey());
+    filterSegments.add(buildFilterSegmentFromScope(canaryScope));
+    return this;
+  }
+
+  private String buildFilterSegmentFromScope(SignalFxCanaryScope canaryScope) {
+
+    List<String> filters = new LinkedList<>();
+
+    filters.add(String.format(FILTER_TEMPLATE, canaryScope.getScopeKey(), canaryScope.getScope()));
+
+    if (canaryScope.getExtendedScopeParams().size() > 0) {
+      filters.add(canaryScope.getExtendedScopeParams().entrySet().stream()
+          .filter(entry -> !entry.getKey().startsWith("_")) // filter out keys that start with _
+          .map(entry -> String.format(FILTER_TEMPLATE, entry.getKey(), entry.getValue()))
+          .collect(Collectors.joining(" and ")));
+    }
+
+    return String.join(" and ", filters);
+  }
+
+  public String build() {
+
+    StringBuilder program = new StringBuilder("data('").append(metricName).append("', filter=");
+    List<String> filters = new LinkedList<>();
+
+    if (queryPairs.size() > 0) {
+      filters.add(queryPairs.stream()
+          .map(qp -> String.format(FILTER_TEMPLATE, qp.getKey(), qp.getValue()))
+          .collect(Collectors.joining(" and ")));
+    }
+    filters.addAll(filterSegments);
+
+    program.append(String.join(" and ", filters)).append(")");
+
+    program.append('.').append(aggregationMethod)
+        .append("(by=['")
+        .append(String.join("', '", scopeKeys))
+        .append("'])");
+
+    program.append(".publish()");
+    return program.toString();
+  }
+}

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/orca/SignalFxFetchStage.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/orca/SignalFxFetchStage.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018 Nike, inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.kayenta.signalfx.orca;
+
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
+import com.netflix.spinnaker.orca.pipeline.TaskNode;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nonnull;
+
+@Component
+public class SignalFxFetchStage {
+
+  @Bean
+  StageDefinitionBuilder signalFxFetchStageBuilder() {
+    return new StageDefinitionBuilder() {
+      @Override
+      public void taskGraph(@Nonnull Stage stage, @Nonnull TaskNode.Builder builder) {
+        builder.withTask("signalfxFetch", SignalFxFetchTask.class);
+      }
+
+      @Nonnull
+      @Override
+      public String getType() {
+        return "signalfxFetch";
+      }
+    };
+  }
+}

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/orca/SignalFxFetchTask.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/orca/SignalFxFetchTask.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2018 Nike, inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.kayenta.signalfx.orca;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.kayenta.canary.CanaryConfig;
+import com.netflix.kayenta.metrics.SynchronousQueryProcessor;
+import com.netflix.kayenta.security.AccountCredentials;
+import com.netflix.kayenta.security.AccountCredentialsRepository;
+import com.netflix.kayenta.security.CredentialsHelper;
+import com.netflix.kayenta.signalfx.canary.SignalFxCanaryScope;
+import com.netflix.spinnaker.orca.RetryableTask;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Map;
+
+@Component
+@Slf4j
+public class SignalFxFetchTask implements RetryableTask {
+
+  private final ObjectMapper kayentaObjectMapper;
+  private final AccountCredentialsRepository accountCredentialsRepository;
+  private final SynchronousQueryProcessor synchronousQueryProcessor;
+
+  @Autowired
+  public SignalFxFetchTask(ObjectMapper kayentaObjectMapper,
+                           AccountCredentialsRepository accountCredentialsRepository,
+                           SynchronousQueryProcessor synchronousQueryProcessor) {
+
+    this.kayentaObjectMapper = kayentaObjectMapper;
+    this.accountCredentialsRepository = accountCredentialsRepository;
+    this.synchronousQueryProcessor = synchronousQueryProcessor;
+  }
+
+  @Override
+  public long getBackoffPeriod() {
+    return Duration.ofSeconds(2).toMillis();
+  }
+
+  @Override
+  public long getTimeout() {
+    return Duration.ofMinutes(2).toMillis();
+  }
+
+  @SuppressWarnings("Duplicates")
+  // Seems to be the pattern in the code base to have this code duplicated, I assume to prevent independent implementations from being tightly coupled,
+  @Nonnull
+  @Override
+  public TaskResult execute(@Nonnull Stage stage) {
+    Map<String, Object> context = stage.getContext();
+    SignalFxCanaryScope canaryScope;
+    try {
+      canaryScope = kayentaObjectMapper.readValue((String) stage.getContext().get("canaryScope"), SignalFxCanaryScope.class);
+    } catch (IOException e) {
+      log.warn("Unable to parse JSON scope", e);
+      throw new RuntimeException(e);
+    }
+
+    String resolvedMetricsAccountName = CredentialsHelper.resolveAccountByNameOrType(
+        (String) context.get("metricsAccountName"),
+        AccountCredentials.Type.METRICS_STORE,
+        accountCredentialsRepository
+    );
+
+    String resolvedStorageAccountName = CredentialsHelper.resolveAccountByNameOrType(
+        (String) context.get("storageAccountName"),
+        AccountCredentials.Type.OBJECT_STORE,
+        accountCredentialsRepository
+    );
+
+    return synchronousQueryProcessor.processQueryAndProduceTaskResult(
+        resolvedMetricsAccountName,
+        resolvedStorageAccountName,
+        kayentaObjectMapper.convertValue(context.get("canaryConfig"), CanaryConfig.class),
+        (Integer) stage.getContext().get("metricIndex"),
+        canaryScope
+    );
+  }
+}

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/security/SignalFxCredentials.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/security/SignalFxCredentials.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2018 Nike, inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.kayenta.signalfx.security;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class SignalFxCredentials {
+
+  private String accessToken;
+}

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/security/SignalFxNamedAccountCredentials.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/security/SignalFxNamedAccountCredentials.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2018 Nike, inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.kayenta.signalfx.security;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.netflix.kayenta.retrofit.config.RemoteService;
+import com.netflix.kayenta.security.AccountCredentials;
+import com.netflix.kayenta.signalfx.service.SignalFxSignalFlowRemoteService;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Singular;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Builder
+@Data
+public class SignalFxNamedAccountCredentials implements AccountCredentials<SignalFxCredentials> {
+
+  @NotNull
+  private String name;
+
+  @NotNull
+  @Singular
+  private List<Type> supportedTypes;
+
+  @NotNull
+  private SignalFxCredentials credentials;
+
+  @NotNull
+  private RemoteService endpoint;
+
+  @Override
+  public String getType() {
+    return "signalfx";
+  }
+
+  @JsonIgnore
+  SignalFxSignalFlowRemoteService signalFlowService;
+}

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/service/ErrorResponse.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/service/ErrorResponse.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018 Nike, inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.kayenta.signalfx.service;
+
+import lombok.Data;
+
+import java.util.Map;
+
+@Data
+public class ErrorResponse {
+
+  private int code;
+  private Map<String, Object> context;
+  private String errorType;
+  private String message;
+}

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/service/SignalFlowExecutionResult.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/service/SignalFlowExecutionResult.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018 Nike, inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.kayenta.signalfx.service;
+
+import com.signalfx.signalflow.ChannelMessage;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class SignalFlowExecutionResult {
+
+  private List<ChannelMessage> channelMessages;
+}

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/service/SignalFxConverter.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/service/SignalFxConverter.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2018 Nike, inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.kayenta.signalfx.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.signalfx.signalflow.ChannelMessage;
+import com.signalfx.signalflow.ServerSentEventsTransport;
+import com.signalfx.signalflow.StreamMessage;
+import lombok.extern.slf4j.Slf4j;
+import retrofit.converter.ConversionException;
+import retrofit.converter.Converter;
+import retrofit.mime.TypedInput;
+import retrofit.mime.TypedOutput;
+import retrofit.mime.TypedString;
+
+import java.lang.reflect.Type;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * The SignalFx SignalFlow api returns Mime-Type: "text/plain" with a custom body with messages in it.
+ * This Converter knows how to parse those responses and return typed Objects
+ */
+@Slf4j
+public class SignalFxConverter implements Converter {
+
+  private ObjectMapper objectMapper = new ObjectMapper();
+
+  private static final List<Type> CONVERTIBLE_TYPES = ImmutableList.of(
+      SignalFlowExecutionResult.class,
+      ErrorResponse.class
+  );
+
+  @Override
+  public Object fromBody(TypedInput body, Type type) throws ConversionException {
+
+    if (!CONVERTIBLE_TYPES.contains(type)) {
+      throw new ConversionException(
+          String.format("The SignalFxConverter Retrofit converter can only handle Types: [ %s ], received: %s",
+              CONVERTIBLE_TYPES.stream().map(Type::getTypeName).collect(Collectors.joining(", ")),
+              type.getTypeName()));
+    }
+
+    if (type.getTypeName().equals(SignalFlowExecutionResult.class.getTypeName())) {
+      return getSignalFlowExecutionResultFromBody(body);
+    } else {
+      return getErrorResponseFromBody(body);
+    }
+  }
+
+  private ErrorResponse getErrorResponseFromBody(TypedInput body) throws ConversionException {
+    try {
+      return objectMapper.readValue(body.in(), ErrorResponse.class);
+    } catch (Exception e) {
+      throw new ConversionException("Failed to parse error response", e);
+    }
+
+  }
+
+  private SignalFlowExecutionResult getSignalFlowExecutionResultFromBody(TypedInput body) throws ConversionException {
+    List<ChannelMessage> messages = new LinkedList<>();
+    try (ServerSentEventsTransport.TransportEventStreamParser parser =
+             new ServerSentEventsTransport.TransportEventStreamParser(body.in())) {
+
+      while (parser.hasNext()) {
+        StreamMessage streamMessage = parser.next();
+        ChannelMessage channelMessage = ChannelMessage.decodeStreamMessage(streamMessage);
+        messages.add(channelMessage);
+      }
+    } catch (Exception e) {
+      throw new ConversionException("There was an issue parsing the SignalFlow response", e);
+    }
+    return new SignalFlowExecutionResult(messages);
+  }
+
+  @Override
+  public TypedOutput toBody(Object object) {
+    String string = (String) object;
+    return new TypedString(string);
+  }
+}

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/service/SignalFxRequestError.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/service/SignalFxRequestError.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018 Nike, inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.kayenta.signalfx.service;
+
+public class SignalFxRequestError extends RuntimeException {
+
+  private static final String MSG_TEMPLATE =
+      "An error occurred when trying to execute a SignalFlow program " +
+          "with program='%s', startMs='%s', endMs='%s', resolution='%s' for accountName: %s. Received error response: %s";
+
+  public SignalFxRequestError(ErrorResponse errorResponse, String program, long start, long end,
+                              long resolution, String accountName) {
+
+    super(String.format(MSG_TEMPLATE, program, start, end, resolution, accountName, errorResponse.toString()));
+  }
+}

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/service/SignalFxSignalFlowRemoteService.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/service/SignalFxSignalFlowRemoteService.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2018 Nike, inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.kayenta.signalfx.service;
+
+import retrofit.http.Body;
+import retrofit.http.Header;
+import retrofit.http.POST;
+import retrofit.http.Query;
+
+/**
+ * Retrofit interface for SignalFx API calls.
+ */
+public interface SignalFxSignalFlowRemoteService {
+
+  /**
+   * Executes a signal flow program.
+   *
+   * @param accessToken     The SignalFx API Access token associated with the organization that you are querying.
+   * @param startEpochMilli (Optional) start timestamp in milliseconds since epoch
+   * @param endEpochMilli   (Optional) stop timestamp in milliseconds since epoch
+   * @param resolution      (Optional) the minimum desired data resolution, in milliseconds
+   * @param maxDelay        (Optional) desired maximum data delay, in milliseconds between 0 (for automatic maximum delay) and 900000
+   * @param immediate       (Optional) whether to adjust the stop timestamp so that the computation doesn't wait for future data to be available
+   * @param program         The signal flow program to execute
+   * @return The list of channel messages from the signal flow output
+   */
+  @POST("/v2/signalflow/execute")
+  SignalFlowExecutionResult executeSignalFlowProgram(@Header("X-SF-TOKEN") String accessToken,
+                                                     @Query("start") long startEpochMilli,
+                                                     @Query("stop") long endEpochMilli,
+                                                     @Query("resolution") long resolution,
+                                                     @Query("maxDelay") long maxDelay,
+                                                     @Query("immediate") boolean immediate,
+                                                     @Body String program);
+}

--- a/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/metrics/SimpleSignalFlowProgramBuilderTest.java
+++ b/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/metrics/SimpleSignalFlowProgramBuilderTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2018 Nike, inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.kayenta.signalfx.metrics;
+
+import com.google.common.collect.ImmutableMap;
+import com.netflix.kayenta.canary.providers.metrics.QueryPair;
+import com.netflix.kayenta.signalfx.canary.SignalFxCanaryScope;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SimpleSignalFlowProgramBuilderTest {
+
+  @Test
+  public void test_that_the_program_builder_builds_the_expected_program() {
+
+    String metricName = "request.count";
+    String aggregationMethod = "mean";
+
+    SignalFxCanaryScope scope = new SignalFxCanaryScope();
+    scope.setScope("1.0.0");
+    scope.setScopeKey("version");
+    scope.setExtendedScopeParams(ImmutableMap.of("env", "production"));
+
+    SimpleSignalFlowProgramBuilder builder = SimpleSignalFlowProgramBuilder
+        .create(metricName, aggregationMethod);
+
+    builder.withQueryPair(new QueryPair("app", "cms"));
+    builder.withQueryPair(new QueryPair("response_code", "400"));
+    builder.withQueryPair(new QueryPair("uri", "/v2/auth/iam-principal"));
+    builder.withScope(scope);
+
+    String expected = "data('request.count', filter=" +
+        "filter('app', 'cms') " +
+        "and filter('response_code', '400') " +
+        "and filter('uri', '/v2/auth/iam-principal') " +
+        "and filter('version', '1.0.0') " +
+        "and filter('env', 'production'))" +
+        ".mean(by=['env', 'version']).publish()";
+
+    assertEquals(expected, builder.build());
+  }
+
+  @Test
+  public void test_that_the_program_builder_builds_the_expected_program_1_qp() {
+
+    String metricName = "request.count";
+    String aggregationMethod = "mean";
+
+    SignalFxCanaryScope scope = new SignalFxCanaryScope();
+    scope.setScope("1.0.0");
+    scope.setScopeKey("version");
+    scope.setExtendedScopeParams(ImmutableMap.of("env", "production"));
+
+    SimpleSignalFlowProgramBuilder builder = SimpleSignalFlowProgramBuilder
+        .create(metricName, aggregationMethod);
+
+    builder.withQueryPair(new QueryPair("app", "cms"));
+    builder.withScope(scope);
+
+    String expected = "data('request.count', filter=" +
+        "filter('app', 'cms') " +
+        "and filter('version', '1.0.0') " +
+        "and filter('env', 'production'))" +
+        ".mean(by=['env', 'version']).publish()";
+
+    assertEquals(expected, builder.build());
+  }
+
+  @Test
+  public void test_that_the_program_builder_builds_the_expected_program_with_no_query_pairs() {
+
+    String metricName = "request.count";
+    String aggregationMethod = "mean";
+
+    SignalFxCanaryScope scope = new SignalFxCanaryScope();
+    scope.setScope("1.0.0");
+    scope.setScopeKey("version");
+    scope.setExtendedScopeParams(ImmutableMap.of("env", "production"));
+
+    SimpleSignalFlowProgramBuilder builder = SimpleSignalFlowProgramBuilder
+        .create(metricName, aggregationMethod);
+
+    builder.withScope(scope);
+
+    String expected = "data('request.count', filter=" +
+        "filter('version', '1.0.0') " +
+        "and filter('env', 'production'))" +
+        ".mean(by=['env', 'version']).publish()";
+
+    assertEquals(expected, builder.build());
+  }
+}

--- a/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/service/SignalFxRemoteServiceTest.java
+++ b/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/service/SignalFxRemoteServiceTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2018 Nike, inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.kayenta.signalfx.service;
+
+import com.google.common.io.ByteStreams;
+import org.junit.Test;
+import retrofit.mime.TypedByteArray;
+import retrofit.mime.TypedInput;
+
+import java.io.InputStream;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+public class SignalFxRemoteServiceTest {
+
+  @Test
+  public void test_that_a_signalfx_signal_flow_response_can_be_parsed() throws Exception {
+    InputStream response = getClass().getClassLoader().getResourceAsStream("signalfx-signalflow-response.text");
+    SignalFxConverter converter = new SignalFxConverter();
+    TypedInput typedInput = new TypedByteArray("text/plain", ByteStreams.toByteArray(response));
+    SignalFlowExecutionResult signalFlowExecutionResult = (SignalFlowExecutionResult) converter.fromBody(typedInput, SignalFlowExecutionResult.class);
+
+    assertNotNull(signalFlowExecutionResult);
+    assertThat("The signalFlowExecutionResult contains the channel messages",
+        signalFlowExecutionResult.getChannelMessages().size(), greaterThan(1));
+  }
+}

--- a/kayenta-signalfx/src/test/resources/signalfx-signalflow-response.text
+++ b/kayenta-signalfx/src/test/resources/signalfx-signalflow-response.text
@@ -1,0 +1,896 @@
+event: control-message
+data: {
+data:   "event" : "STREAM_START",
+data:   "timestampMs" : 1537567314915
+data: }
+
+event: control-message
+data: {
+data:   "event" : "JOB_START",
+data:   "handle" : "Dnpkj7dAYAA",
+data:   "timestampMs" : 1537567315267
+data: }
+
+event: metadata
+data: {
+data:   "properties" : {
+data:     "canary-scope" : "control",
+data:     "computationId" : "Dnpkj7dAYAA",
+data:     "env" : "integration",
+data:     "sf_createdOnMs" : 1537140753712,
+data:     "sf_isPreQuantized" : true,
+data:     "sf_key" : [ "test-id", "canary-scope", "sf_metric", "env", "sf_originatingMetric", "computationId" ],
+data:     "sf_metric" : "_SF_COMP_Dnpkj7dAYAA_02-PUBLISH_METRIC",
+data:     "sf_organizationID" : "Chi3pifAcAc",
+data:     "sf_originatingMetric" : "kayenta.integration-test.some-gauge",
+data:     "sf_resolutionMs" : 1000,
+data:     "sf_singletonFixedDimensions" : [ "test-id", "canary-scope", "sf_metric" ],
+data:     "sf_type" : "MetricTimeSeries",
+data:     "test-id" : "3e9c6e4a-e9fd-4ed3-ae1b-a362831e0a29"
+data:   },
+data:   "tsId" : "AAAAAFOJhJg"
+data: }
+
+event: data
+id: data-1537140751000
+data: {
+data:   "data" : [ ],
+data:   "logicalTimestampMs" : 1537140751000,
+data:   "maxDelayMs" : 3438
+data: }
+
+event: message
+data: {
+data:   "logicalTimestampMs" : 1537140751000,
+data:   "message" : {
+data:     "blockContexts" : [ ],
+data:     "blockSerialNumbers" : [ ],
+data:     "contents" : {
+data:       "resolutionMs" : 1000
+data:     },
+data:     "messageCode" : "JOB_RUNNING_RESOLUTION",
+data:     "messageLevel" : "INFO",
+data:     "numInputTimeSeries" : 0,
+data:     "timestampMs" : 1537140750000
+data:   }
+data: }
+
+event: message
+data: {
+data:   "logicalTimestampMs" : 1537140751000,
+data:   "message" : {
+data:     "blockContexts" : [ ],
+data:     "blockSerialNumbers" : [ ],
+data:     "contents" : {
+data:       "deadlineType" : "AUTOMATIC",
+data:       "maxDelayMs" : 2000
+data:     },
+data:     "messageCode" : "JOB_INITIAL_MAX_DELAY",
+data:     "messageLevel" : "INFO",
+data:     "numInputTimeSeries" : 0,
+data:     "timestampMs" : 1537140750000
+data:   }
+data: }
+
+event: message
+data: {
+data:   "logicalTimestampMs" : 1537140751000,
+data:   "message" : {
+data:     "blockContexts" : [ {
+data:       "column" : 1,
+data:       "line" : 1
+data:     } ],
+data:     "blockSerialNumbers" : [ 0 ],
+data:     "contents" : {
+data:       "dimensionCounts" : [ {
+data:         "count" : 1,
+data:         "dimensions" : [ "test-id", "canary-scope", "sf_metric", "env" ]
+data:       } ]
+data:     },
+data:     "messageCode" : "FIND_MATCHED_DIMENSIONS",
+data:     "messageLevel" : "INFO",
+data:     "numInputTimeSeries" : 1,
+data:     "timestampMs" : 1537140751000
+data:   }
+data: }
+
+event: message
+data: {
+data:   "logicalTimestampMs" : 1537140751000,
+data:   "message" : {
+data:     "blockContexts" : [ {
+data:       "column" : 1,
+data:       "line" : 1
+data:     } ],
+data:     "blockSerialNumbers" : [ 0 ],
+data:     "messageCode" : "FETCH_NUM_TIMESERIES",
+data:     "messageLevel" : "INFO",
+data:     "numInputTimeSeries" : 1,
+data:     "timestampMs" : 1537140751000
+data:   }
+data: }
+
+event: message
+data: {
+data:   "logicalTimestampMs" : 1537140751000,
+data:   "message" : {
+data:     "blockContexts" : [ {
+data:       "column" : 1,
+data:       "line" : 1
+data:     } ],
+data:     "blockSerialNumbers" : [ 0 ],
+data:     "contents" : {
+data:       "maxExtrapolations" : -1,
+data:       "numInactiveMembers" : 1
+data:     },
+data:     "messageCode" : "FETCH_INACTIVE_EMITTERS",
+data:     "messageLevel" : "WARNING",
+data:     "numInputTimeSeries" : 1,
+data:     "timestampMs" : 1537140751000
+data:   }
+data: }
+
+event: message
+data: {
+data:   "logicalTimestampMs" : 1537140751000,
+data:   "message" : {
+data:     "blockContexts" : [ {
+data:       "column" : 165,
+data:       "line" : 1
+data:     } ],
+data:     "blockSerialNumbers" : [ 2 ],
+data:     "messageCode" : "ID_NUM_TIMESERIES",
+data:     "messageLevel" : "INFO",
+data:     "numInputTimeSeries" : 1,
+data:     "timestampMs" : 1537140751000
+data:   }
+data: }
+
+event: data
+id: data-1537140752000
+data: {
+data:   "data" : [ ],
+data:   "logicalTimestampMs" : 1537140752000,
+data:   "maxDelayMs" : 3438
+data: }
+
+event: data
+id: data-1537140753000
+data: {
+data:   "data" : [ ],
+data:   "logicalTimestampMs" : 1537140753000,
+data:   "maxDelayMs" : 3438
+data: }
+
+event: data
+id: data-1537140754000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 53.333333333333336
+data:   } ],
+data:   "logicalTimestampMs" : 1537140754000,
+data:   "maxDelayMs" : 3438
+data: }
+
+event: data
+id: data-1537140755000
+data: {
+data:   "data" : [ ],
+data:   "logicalTimestampMs" : 1537140755000,
+data:   "maxDelayMs" : 3438
+data: }
+
+event: data
+id: data-1537140756000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 52.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140756000,
+data:   "maxDelayMs" : 3438
+data: }
+
+event: data
+id: data-1537140757000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 53.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140757000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140758000
+data: {
+data:   "data" : [ ],
+data:   "logicalTimestampMs" : 1537140758000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140759000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 54.333333333333336
+data:   } ],
+data:   "logicalTimestampMs" : 1537140759000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140760000
+data: {
+data:   "data" : [ ],
+data:   "logicalTimestampMs" : 1537140760000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140761000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 52.333333333333336
+data:   } ],
+data:   "logicalTimestampMs" : 1537140761000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140762000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 52.666666666666664
+data:   } ],
+data:   "logicalTimestampMs" : 1537140762000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140763000
+data: {
+data:   "data" : [ ],
+data:   "logicalTimestampMs" : 1537140763000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140764000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 52.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140764000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140765000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 51.333333333333336
+data:   } ],
+data:   "logicalTimestampMs" : 1537140765000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140766000
+data: {
+data:   "data" : [ ],
+data:   "logicalTimestampMs" : 1537140766000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140767000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 52.333333333333336
+data:   } ],
+data:   "logicalTimestampMs" : 1537140767000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140768000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 53.666666666666664
+data:   } ],
+data:   "logicalTimestampMs" : 1537140768000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140769000
+data: {
+data:   "data" : [ ],
+data:   "logicalTimestampMs" : 1537140769000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140770000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 53.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140770000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140771000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 53.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140771000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140772000
+data: {
+data:   "data" : [ ],
+data:   "logicalTimestampMs" : 1537140772000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140773000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 51.666666666666664
+data:   } ],
+data:   "logicalTimestampMs" : 1537140773000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140774000
+data: {
+data:   "data" : [ ],
+data:   "logicalTimestampMs" : 1537140774000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140775000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 53.333333333333336
+data:   } ],
+data:   "logicalTimestampMs" : 1537140775000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140776000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 52.666666666666664
+data:   } ],
+data:   "logicalTimestampMs" : 1537140776000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140777000
+data: {
+data:   "data" : [ ],
+data:   "logicalTimestampMs" : 1537140777000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140778000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 53.333333333333336
+data:   } ],
+data:   "logicalTimestampMs" : 1537140778000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140779000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 53.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140779000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140780000
+data: {
+data:   "data" : [ ],
+data:   "logicalTimestampMs" : 1537140780000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140781000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 51.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140781000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140782000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 53.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140782000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140783000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 52.5
+data:   } ],
+data:   "logicalTimestampMs" : 1537140783000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140784000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 52.333333333333336
+data:   } ],
+data:   "logicalTimestampMs" : 1537140784000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140785000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 52.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140785000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140786000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 53.5
+data:   } ],
+data:   "logicalTimestampMs" : 1537140786000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140787000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 54.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140787000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140788000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 55.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140788000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140789000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 50.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140789000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140790000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 52.5
+data:   } ],
+data:   "logicalTimestampMs" : 1537140790000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140791000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 53.5
+data:   } ],
+data:   "logicalTimestampMs" : 1537140791000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140792000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 53.5
+data:   } ],
+data:   "logicalTimestampMs" : 1537140792000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140793000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 50.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140793000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140794000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 52.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140794000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140795000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 53.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140795000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140796000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 52.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140796000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140797000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 52.5
+data:   } ],
+data:   "logicalTimestampMs" : 1537140797000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140798000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 53.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140798000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140799000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 55.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140799000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140800000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 51.5
+data:   } ],
+data:   "logicalTimestampMs" : 1537140800000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140801000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 53.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140801000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140802000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 51.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140802000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140803000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 55.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140803000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140804000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 51.333333333333336
+data:   } ],
+data:   "logicalTimestampMs" : 1537140804000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140805000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 52.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140805000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140806000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 54.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140806000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140807000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 51.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140807000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140808000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 50.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140808000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140809000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 52.5
+data:   } ],
+data:   "logicalTimestampMs" : 1537140809000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140810000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 51.666666666666664
+data:   } ],
+data:   "logicalTimestampMs" : 1537140810000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140811000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 55.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140811000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: data
+id: data-1537140812000
+data: {
+data:   "data" : [ {
+data:     "tsId" : "AAAAAFOJhJg",
+data:     "value" : 52.0
+data:   } ],
+data:   "logicalTimestampMs" : 1537140812000,
+data:   "maxDelayMs" : 3491
+data: }
+
+event: message
+data: {
+data:   "logicalTimestampMs" : 1537140812000,
+data:   "message" : {
+data:     "blockContexts" : [ ],
+data:     "blockSerialNumbers" : [ ],
+data:     "contents" : {
+data:       "resolutionMs" : 1000
+data:     },
+data:     "messageCode" : "JOB_RUNNING_RESOLUTION",
+data:     "messageLevel" : "INFO",
+data:     "numInputTimeSeries" : 0,
+data:     "timestampMs" : 1537140750000
+data:   }
+data: }
+
+event: message
+data: {
+data:   "logicalTimestampMs" : 1537140812000,
+data:   "message" : {
+data:     "blockContexts" : [ ],
+data:     "blockSerialNumbers" : [ ],
+data:     "contents" : {
+data:       "deadlineType" : "AUTOMATIC",
+data:       "maxDelayMs" : 2000
+data:     },
+data:     "messageCode" : "JOB_INITIAL_MAX_DELAY",
+data:     "messageLevel" : "INFO",
+data:     "numInputTimeSeries" : 0,
+data:     "timestampMs" : 1537140750000
+data:   }
+data: }
+
+event: message
+data: {
+data:   "logicalTimestampMs" : 1537140812000,
+data:   "message" : {
+data:     "blockContexts" : [ {
+data:       "column" : 1,
+data:       "line" : 1
+data:     } ],
+data:     "blockSerialNumbers" : [ 0 ],
+data:     "contents" : {
+data:       "dimensionCounts" : [ {
+data:         "count" : 1,
+data:         "dimensions" : [ "test-id", "canary-scope", "sf_metric", "env" ]
+data:       } ]
+data:     },
+data:     "messageCode" : "FIND_MATCHED_DIMENSIONS",
+data:     "messageLevel" : "INFO",
+data:     "numInputTimeSeries" : 1,
+data:     "timestampMs" : 1537140751000
+data:   }
+data: }
+
+event: message
+data: {
+data:   "logicalTimestampMs" : 1537140812000,
+data:   "message" : {
+data:     "blockContexts" : [ {
+data:       "column" : 1,
+data:       "line" : 1
+data:     } ],
+data:     "blockSerialNumbers" : [ 0 ],
+data:     "messageCode" : "FETCH_NUM_TIMESERIES",
+data:     "messageLevel" : "INFO",
+data:     "numInputTimeSeries" : 1,
+data:     "timestampMs" : 1537140751000
+data:   }
+data: }
+
+event: message
+data: {
+data:   "logicalTimestampMs" : 1537140812000,
+data:   "message" : {
+data:     "blockContexts" : [ {
+data:       "column" : 1,
+data:       "line" : 1
+data:     } ],
+data:     "blockSerialNumbers" : [ 0 ],
+data:     "contents" : {
+data:       "maxExtrapolations" : -1,
+data:       "numInactiveMembers" : 1
+data:     },
+data:     "messageCode" : "FETCH_INACTIVE_EMITTERS",
+data:     "messageLevel" : "WARNING",
+data:     "numInputTimeSeries" : 1,
+data:     "timestampMs" : 1537140751000
+data:   }
+data: }
+
+event: message
+data: {
+data:   "logicalTimestampMs" : 1537140812000,
+data:   "message" : {
+data:     "blockContexts" : [ {
+data:       "column" : 165,
+data:       "line" : 1
+data:     } ],
+data:     "blockSerialNumbers" : [ 2 ],
+data:     "messageCode" : "ID_NUM_TIMESERIES",
+data:     "messageLevel" : "INFO",
+data:     "numInputTimeSeries" : 1,
+data:     "timestampMs" : 1537140812000
+data:   }
+data: }
+
+event: control-message
+data: {
+data:   "event" : "END_OF_CHANNEL",
+data:   "timestampMs" : 1537567316609
+data: }
+

--- a/kayenta-web/kayenta-web.gradle
+++ b/kayenta-web/kayenta-web.gradle
@@ -29,6 +29,7 @@ dependencies {
   compile project(':kayenta-orca')
   compile project(':kayenta-prometheus')
   compile project(':kayenta-s3')
+  compile project(':kayenta-signalfx')
   compile project(':kayenta-stackdriver')
 
   compile spinnaker.dependency('bootActuator')

--- a/kayenta-web/src/main/java/com/netflix/kayenta/Main.java
+++ b/kayenta-web/src/main/java/com/netflix/kayenta/Main.java
@@ -42,6 +42,7 @@ import com.netflix.kayenta.judge.config.NetflixJudgeConfiguration;
 import com.netflix.kayenta.memory.config.MemoryConfiguration;
 import com.netflix.kayenta.prometheus.config.PrometheusConfiguration;
 import com.netflix.kayenta.s3.config.S3Configuration;
+import com.netflix.kayenta.signalfx.config.SignalFxConfiguration;
 import com.netflix.kayenta.stackdriver.config.StackdriverConfiguration;
 
 @Configuration
@@ -57,6 +58,7 @@ import com.netflix.kayenta.stackdriver.config.StackdriverConfiguration;
   MemoryConfiguration.class,
   PrometheusConfiguration.class,
   S3Configuration.class,
+  SignalFxConfiguration.class,
   StackdriverConfiguration.class,
   WebConfiguration.class,
   NetflixJudgeConfiguration.class,

--- a/settings.gradle
+++ b/settings.gradle
@@ -30,6 +30,7 @@ include 'kayenta-objectstore-memory'
 include 'kayenta-orca'
 include 'kayenta-prometheus'
 include 'kayenta-s3'
+include 'kayenta-signalfx'
 include 'kayenta-stackdriver'
 include 'kayenta-web'
 


### PR DESCRIPTION
This pull request adds support for using [SignalFx](https://signalfx.com/) as a metric source.

Configuration and metric query conf can be found in the [README](https://github.com/Nike-Inc/kayenta/blob/feature/signalfx_metric_source/kayenta-signalfx/README.md)

**Testing**
I wrote an unit tests and an end to end integration test, that tests a Pass and Fail canary execution.
They can be ran via

```bash
./gradlew clean kayenta-signalfx:test kayenta-signalfx:integrationTest -Dkayenta.signalfx.apiKey=${SIGNALFX_API_TOKEN}
```

If you would like to sanity check the integration test, I can get you an API Key.

I tried my best to follow https://github.com/spinnaker/kayenta/pull/248 and in place patterns in the code base.