### PR TITLE
feat(atlas): Map locations forward to a specific back-end

### DIFF
--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/backends/BackendDatabase.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/backends/BackendDatabase.java
@@ -64,4 +64,13 @@ public class BackendDatabase {
     }
     return locations.stream().distinct().collect(Collectors.toList());
   }
+
+  public synchronized String getUriForLocation(String scheme, String location) {
+    for (Backend backend : backends) {
+      String cname = backend.getUriForLocation(scheme, location);
+      if (cname != null)
+        return cname;
+    }
+    return null;
+  }
 }

--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/model/Backend.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/model/Backend.java
@@ -35,6 +35,7 @@ import lombok.*;
 
 import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -114,5 +115,42 @@ public class Backend {
       .replace("$(env)", environment);
 
     return scheme + "://" + relativeReference;
+  }
+
+  public String getUriForLocation(String scheme, String location) {
+    String base = target.replace("$(deployment)", deployment).replace("$(dataset)", dataset);
+    boolean hasRegions = (regions != null && regions.size() > 0);
+    boolean hasEnvironments = (environments != null && environments.size() > 0);
+
+    if (!hasRegions && !hasEnvironments) {
+      if (base.equals(location)) {
+        return getUri(scheme, deployment, dataset, "", "");
+      }
+    } else if (!hasRegions && hasEnvironments) {
+      for (String environment : environments) {
+        String potential = base.replace("$(env)", environment);
+        if (potential.equals(location)) {
+          return getUri(scheme, deployment, dataset, "", environment);
+        }
+      }
+    } else if (hasRegions && !hasEnvironments) {
+      for (String region : regions) {
+        String potential = base.replace("$(region)", region);
+        if (potential.equals(location)) {
+          return getUri(scheme, deployment, dataset, region, "");
+        }
+      }
+    } else { // has both regions and environments
+      for (String region : regions) {
+        for (String environment : environments) {
+          String potential = base.replace("$(region)", region).replace("$(env)", environment);
+          if (potential.equals(location)) {
+            return getUri(scheme, deployment, dataset, region, environment);
+          }
+        }
+      }
+    }
+
+    return null;
   }
 }

--- a/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/BackendTest.java
+++ b/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/BackendTest.java
@@ -4,6 +4,7 @@ import com.netflix.kayenta.atlas.model.Backend;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.*;
@@ -40,4 +41,87 @@ public class BackendTest {
     assert(targets.contains("regionOne.myDataset"));
     assert(targets.contains("regionTwo.myDataset"));
   }
+
+  @Test
+  public void testGetUriForLocationWithRegionOnly() {
+    ArrayList regions = new ArrayList<>();
+    regions.add("regionOne");
+    regions.add("regionTwo");
+
+    Backend backend = Backend.builder()
+      .target("$(region).$(dataset)")
+      .cname("atlas.$(region)-$(dataset).example.com")
+      .dataset("myDataset")
+      .deployment("myDeployment")
+      .environments(null)
+      .regions(regions)
+      .build();
+
+    assertNull(backend.getUriForLocation("http", "notgonnabethere"));
+    assertNull(backend.getUriForLocation("http", "regionNotThere.myDataset"));
+    assertEquals("http://atlas.regionOne-myDataset.example.com", backend.getUriForLocation("http", "regionOne.myDataset"));
+  }
+
+  @Test
+  public void testGetUriForLocationWithEnvironmentOnly() {
+    ArrayList environments = new ArrayList<>();
+    environments.add("test");
+    environments.add("prod");
+
+    Backend backend = Backend.builder()
+      .target("$(env).$(dataset)")
+      .cname("atlas.$(env)-$(dataset).example.com")
+      .dataset("myDataset")
+      .deployment("myDeployment")
+      .environments(environments)
+      .regions(Collections.emptyList())
+      .build();
+
+    assertNull(backend.getUriForLocation("http", "notgonnabethere"));
+    assertNull(backend.getUriForLocation("http", "regionNotThere.myDataset"));
+    assertEquals("http://atlas.test-myDataset.example.com", backend.getUriForLocation("http", "test.myDataset"));
+  }
+
+  @Test
+  public void testGetUriForLocationWithBothEnvironmentsAndRegions() {
+    ArrayList environments = new ArrayList<>();
+    environments.add("test");
+    environments.add("prod");
+
+    ArrayList regions = new ArrayList<>();
+    regions.add("regionOne");
+    regions.add("regionTwo");
+
+    Backend backend = Backend.builder()
+      .target("$(region).$(env).$(dataset)")
+      .cname("atlas.$(region).$(env).example.com")
+      .dataset("myDataset")
+      .deployment("myDeployment")
+      .environments(environments)
+      .regions(regions)
+      .build();
+
+    assertNull(backend.getUriForLocation("http", "notgonnabethere"));
+    assertNull(backend.getUriForLocation("http", "regionNotThere.myDataset"));
+    assertEquals("http://atlas.regionOne.test.example.com",
+                 backend.getUriForLocation("http", "regionOne.test.myDataset"));
+  }
+
+  @Test
+  public void testGetUriForLocationWithoutEnvironmentsOrRegions() {
+    Backend backend = Backend.builder()
+      .target("$(deployment).$(dataset)")
+      .cname("atlas.$(dataset).$(deployment).example.com")
+      .dataset("myDataset")
+      .deployment("myDeployment")
+      .environments(Collections.emptyList())
+      .regions(Collections.emptyList())
+      .build();
+
+    assertNull(backend.getUriForLocation("http", "notgonnabethere"));
+    assertNull(backend.getUriForLocation("http", "regionNotThere.myDataset"));
+    assertEquals("http://atlas.myDataset.myDeployment.example.com",
+                 backend.getUriForLocation("http", "myDeployment.myDataset"));
+  }
+
 }

--- a/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/BackendsTest.java
+++ b/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/BackendsTest.java
@@ -93,4 +93,19 @@ public class BackendsTest {
     assertEquals("http://deployment=xmain.region=xregion.env=xtest.dataset=xglobal.envAgain=xtest",
                  backend.getUri("http", "xmain", "xglobal", "xregion", "xtest"));
   }
+  @Test
+  public void getUriForlocationTest() throws IOException {
+    List<Backend> backends = readBackends("backends-location-test.json");
+
+    BackendDatabase db = new BackendDatabase();
+    db.update(backends);
+
+    assertEquals("http://atlas-global.test.example.com",
+                 db.getUriForLocation("http", "test.global"));
+    assertEquals("http://atlas-global.prod.example.com",
+                 db.getUriForLocation("http", "prod.global"));
+    assertEquals("http://atlas-main.us-east-1.prod.example.com",
+                 db.getUriForLocation("http", "prod.us-east-1"));
+  }
+
 }


### PR DESCRIPTION
A previous change was able to generate a list of potential location values to be used by back-ends.  This change uses that in the Atlas code base to look up the specific URI to use for that location string.

This will fall-back to previous behavior if it is not set, and will look in the Atlas-specific context for "dataset", "deployment", and "environment" and use location as the region.

I do not like the big if/else block in Backend.json, but I could not think of a more elegant solution.  I have a test case for all four possibilities, including a no-match for each.