### PR TITLE
fix(judge): Return a reason when a metric is classified as Nodata

### DIFF
--- a/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/classifiers/metric/MannWhitneyClassifier.scala
+++ b/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/classifiers/metric/MannWhitneyClassifier.scala
@@ -133,7 +133,8 @@ class MannWhitneyClassifier(tolerance: Double=0.25,
     //Check if there is no-data for the experiment or control
     if (experiment.values.isEmpty || control.values.isEmpty) {
       if (nanStrategy == NaNStrategy.Remove) {
-        return MetricClassification(Nodata, None, 1.0, isCriticalMetric)
+        val reason = s"Missing data for ${experiment.name}"
+        return MetricClassification(Nodata, Some(reason), 1.0, isCriticalMetric)
       } else {
         return MetricClassification(Pass, None, 1.0, critical = false)
       }

--- a/kayenta-judge/src/test/scala/com/netflix/kayenta/judge/ClassifierSuite.scala
+++ b/kayenta-judge/src/test/scala/com/netflix/kayenta/judge/ClassifierSuite.scala
@@ -18,6 +18,7 @@ package com.netflix.kayenta.judge
 
 import com.netflix.kayenta.judge.classifiers.metric._
 import org.scalatest.FunSuite
+import org.scalatest.Matchers._
 
 
 class ClassifierSuite extends FunSuite{
@@ -583,6 +584,19 @@ class ClassifierSuite extends FunSuite{
     val result = classifier.classify(controlMetric, experimentMetric, MetricDirection.Decrease, NaNStrategy.Replace)
 
     assert(result.classification == Pass)
+  }
+
+  test("Mann-Whitney Missing Data: Reason String") {
+    val experimentData = Array[Double]()
+    val controlData = Array[Double]()
+
+    val experimentMetric = Metric("test-critical-metric", experimentData, "canary")
+    val controlMetric = Metric("test-critical-metric", controlData, "baseline")
+
+    val classifier = new MannWhitneyClassifier(tolerance = 0.10, confLevel = 0.95)
+    val result = classifier.classify(controlMetric, experimentMetric, MetricDirection.Decrease, isCriticalMetric = true)
+
+    result.reason should not be empty
   }
 
   test("Mann-Whitney Majority Tied Observations"){


### PR DESCRIPTION
Return a reason string when a metric is classified as Nodata.