### PR TITLE
feat(datadog): Add support for metric name typeahead.

### DIFF
--- a/kayenta-datadog/src/main/java/com/netflix/kayenta/datadog/service/DatadogRemoteService.java
+++ b/kayenta-datadog/src/main/java/com/netflix/kayenta/datadog/service/DatadogRemoteService.java
@@ -16,6 +16,7 @@
 
 package com.netflix.kayenta.datadog.service;
 
+import com.netflix.kayenta.model.DatadogMetricDescriptorsResponse;
 import retrofit.http.GET;
 import retrofit.http.Query;
 
@@ -28,4 +29,9 @@ public interface DatadogRemoteService {
                                   @Query("from") int startTimestamp,
                                   @Query("to") int endTimestamp,
                                   @Query("query") String query);
+
+  @GET("/api/v1/metrics")
+  DatadogMetricDescriptorsResponse getMetrics(@Query("api_key") String apiKey,
+                                              @Query("application_key") String applicationKey,
+                                              @Query("from") long from);
 }

--- a/kayenta-datadog/src/main/java/com/netflix/kayenta/model/DatadogMetricDescriptor.java
+++ b/kayenta-datadog/src/main/java/com/netflix/kayenta/model/DatadogMetricDescriptor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.model;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class DatadogMetricDescriptor {
+
+  private final String name;
+  private final Map<String, String> map;
+
+  public DatadogMetricDescriptor(String name) {
+    this.name = name;
+    this.map = Collections.singletonMap("name", name);
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  // This is so we can efficiently serialize to json without having to construct the intermediate map object on each query.
+  public Map<String, String> getMap() {
+    return map;
+  }
+}

--- a/kayenta-datadog/src/main/java/com/netflix/kayenta/model/DatadogMetricDescriptorsResponse.java
+++ b/kayenta-datadog/src/main/java/com/netflix/kayenta/model/DatadogMetricDescriptorsResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Armory, Inc.
+ * Copyright 2018 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,26 @@
  * limitations under the License.
  */
 
-package com.netflix.kayenta.datadog.config;
+package com.netflix.kayenta.model;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
-import java.time.Duration;
-import java.util.ArrayList;
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
-public class DatadogConfigurationProperties {
+@Builder
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+public class DatadogMetricDescriptorsResponse {
 
+  @NotNull
   @Getter
-  @Setter
-  private long metadataCachingIntervalMS = Duration.ofSeconds(60).toMillis();
-
-  @Getter
-  private List<DatadogManagedAccount> accounts = new ArrayList<>();
+  private List<String> metrics;
 }


### PR DESCRIPTION
We still need to add support to the Datadog metric config ui for using this for typeahead.