### PR TITLE
Refactor: Add additional constructors to CanaryExecutionResponse

### DIFF
--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryExecutionResponse.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryExecutionResponse.java
@@ -15,13 +15,17 @@
  */
 package com.netflix.kayenta.canary;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class CanaryExecutionResponse {
 
   @NotNull

--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryExecutionStatusResponse.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryExecutionStatusResponse.java
@@ -16,14 +16,18 @@
 package com.netflix.kayenta.canary;
 
 import com.netflix.kayenta.canary.results.CanaryResult;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 import java.util.Map;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class CanaryExecutionStatusResponse {
   protected String application;
 


### PR DESCRIPTION
Add additional constructors to CanaryExecutionResponse and CanaryExecutionStatusResponse, so that they can be deserialized by Jackson in a retrofit service, externally to Kayenta if kayenta-core is imported for model re-use.