### PR TITLE
Add more retries to more components

### DIFF
--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/metrics/AtlasMetricsService.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/metrics/AtlasMetricsService.java
@@ -57,6 +57,9 @@ public class AtlasMetricsService implements MetricsService {
 
   public final String URI_SCHEME = "http";
 
+  public final int MAX_RETRIES = 10; // maximum number of times we'll retry an Atlas query
+  public final long RETRY_BACKOFF = 1000; // time between retries in millis
+
   @NotNull
   @Singular
   @Getter
@@ -151,7 +154,7 @@ public class AtlasMetricsService implements MetricsService {
       atlasResultsList = retry.retry(() -> atlasRemoteService.fetch(decoratedQuery,
                                                                     atlasCanaryScope.getStart().toEpochMilli(),
                                                                     atlasCanaryScope.getEnd().toEpochMilli(), isoStep, credentials.getFetchId(), UUID.randomUUID() + ""),
-      20, 1000);
+      MAX_RETRIES, RETRY_BACKOFF);
     } finally {
       long end = registry.clock().monotonicTime();
       registry.timer("atlas.fetchTime").record(end - start, TimeUnit.NANOSECONDS);

--- a/kayenta-core/src/main/java/com/netflix/kayenta/util/Retry.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/util/Retry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Netflix, Inc.
+ * Copyright 2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,23 +19,23 @@ package com.netflix.kayenta.util;
 import java.util.function.Supplier;
 
 public class Retry {
-  public void retry(Runnable fn, int maxRetries, long retryBackoff) {
-    retry(fn, maxRetries, retryBackoff, false);
+  public void retry(Runnable fn, int maxRetries, long retryBackoffMillis) {
+    retry(fn, maxRetries, retryBackoffMillis, false);
   }
 
-  public void  exponential(Runnable fn, int maxRetries, long retryBackoff) {
-    retry(fn, maxRetries, retryBackoff, true);
+  public void exponential(Runnable fn, int maxRetries, long retryBackoffMillis) {
+    retry(fn, maxRetries, retryBackoffMillis, true);
   }
 
-  public <T> T retry(Supplier<T> fn, int maxRetries, long retryBackoff) {
-    return retry(fn, maxRetries, retryBackoff, false);
+  public <T> T retry(Supplier<T> fn, int maxRetries, long retryBackoffMillis) {
+    return retry(fn, maxRetries, retryBackoffMillis, false);
   }
 
-  public <T> T exponential(Supplier<T> fn, int maxRetries, long retryBackoff) {
-    return retry(fn, maxRetries, retryBackoff, true);
+  public <T> T exponential(Supplier<T> fn, int maxRetries, long retryBackoffMillis) {
+    return retry(fn, maxRetries, retryBackoffMillis, true);
   }
 
-  public void retry(Runnable fn, int maxRetries, long retryBackoff, boolean exponential) {
+  public void retry(Runnable fn, int maxRetries, long retryBackoffMillis, boolean exponential) {
     int retries = 0;
     while (true) {
       try {
@@ -46,7 +46,7 @@ public class Retry {
           throw e;
         }
 
-        long timeout = !exponential ? retryBackoff : (long) Math.pow(2, retries) * retryBackoff;
+        long timeout = !exponential ? retryBackoffMillis : (long) Math.pow(2, retries) * retryBackoffMillis;
         sleep(timeout);
 
         retries++;
@@ -54,7 +54,7 @@ public class Retry {
     }
   }
 
-  private <T> T retry(Supplier<T> fn, int maxRetries, long retryBackoff, boolean exponential) {
+  private <T> T retry(Supplier<T> fn, int maxRetries, long retryBackoffMillis, boolean exponential) {
     int retries = 0;
     while (true) {
       try {
@@ -64,7 +64,7 @@ public class Retry {
           throw e;
         }
 
-        long timeout = !exponential ? retryBackoff : (long) Math.pow(2, retries) * retryBackoff;
+        long timeout = !exponential ? retryBackoffMillis : (long) Math.pow(2, retries) * retryBackoffMillis;
         sleep(timeout);
 
         retries++;

--- a/kayenta-core/src/main/java/com/netflix/kayenta/util/Retry.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/util/Retry.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.util;
+
+import java.util.function.Supplier;
+
+public class Retry {
+  public void retry(Runnable fn, int maxRetries, long retryBackoff) {
+    retry(fn, maxRetries, retryBackoff, false);
+  }
+
+  public void  exponential(Runnable fn, int maxRetries, long retryBackoff) {
+    retry(fn, maxRetries, retryBackoff, true);
+  }
+
+  public <T> T retry(Supplier<T> fn, int maxRetries, long retryBackoff) {
+    return retry(fn, maxRetries, retryBackoff, false);
+  }
+
+  public <T> T exponential(Supplier<T> fn, int maxRetries, long retryBackoff) {
+    return retry(fn, maxRetries, retryBackoff, true);
+  }
+
+  public void retry(Runnable fn, int maxRetries, long retryBackoff, boolean exponential) {
+    int retries = 0;
+    while (true) {
+      try {
+        fn.run();
+        return;
+      } catch (Exception e) {
+        if (retries >= (maxRetries - 1)) {
+          throw e;
+        }
+
+        long timeout = !exponential ? retryBackoff : (long) Math.pow(2, retries) * retryBackoff;
+        sleep(timeout);
+
+        retries++;
+      }
+    }
+  }
+
+  private <T> T retry(Supplier<T> fn, int maxRetries, long retryBackoff, boolean exponential) {
+    int retries = 0;
+    while (true) {
+      try {
+        return fn.get();
+      } catch (Exception e) {
+        if (retries >= (maxRetries - 1)) {
+          throw e;
+        }
+
+        long timeout = !exponential ? retryBackoff : (long) Math.pow(2, retries) * retryBackoff;
+        sleep(timeout);
+
+        retries++;
+      }
+    }
+  }
+
+  /**
+   * Overridable by test cases to avoid Thread.sleep()
+   */
+  void sleep(long duration) {
+    try {
+      Thread.sleep(duration);
+    } catch (InterruptedException ignored) {
+    }
+  }
+}

--- a/kayenta-core/src/test/groovy/com/netflix/kayenta/util/RetrySpec.groovy
+++ b/kayenta-core/src/test/groovy/com/netflix/kayenta/util/RetrySpec.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.util
+
+import spock.lang.Specification
+import spock.lang.Unroll;
+
+class RetrySpec extends Specification {
+    @Unroll
+    def "should retry until success or #maxRetries attempts is reached"() {
+        given:
+        def retry = Spy(Retry) {
+            Math.min(maxRetries - 1, failures) * sleep(10000) >> { /* do nothing */ }
+        }
+
+        int attemptCounter = 0;
+
+        when:
+        def exceptionMessage
+        try {
+            retry.retry({
+                if (attemptCounter++ < failures) {
+                    throw new IllegalStateException("Failed after " + attemptCounter + " attempts");
+                }
+            }, maxRetries, 10000)
+        } catch (Exception e) {
+            exceptionMessage = e.message
+        }
+
+        then:
+        attemptCounter == expectedAttempts
+        exceptionMessage == expectedExceptionMessage
+
+        where:
+        failures || maxRetries || expectedAttempts || expectedExceptionMessage
+        3        || 10         || 4                || null
+        11       || 10         || 10               || "Failed after 10 attempts"
+    }
+
+    def "should sleep exponentially"() {
+        given:
+        def retry = Spy(Retry) {
+            1 * sleep(10000) >> { /* do nothing */ }
+            1 * sleep(20000) >> { /* do nothing */ }
+            1 * sleep(40000) >> { /* do nothing */ }
+            1 * sleep(80000) >> { /* do nothing */ }
+        }
+
+        int attemptCounter = 0;
+
+        when:
+        retry.exponential({
+            if (attemptCounter++ < failures) {
+                throw new IllegalStateException("Failed after " + attemptCounter + " attempts");
+            }
+        }, maxRetries, 10000)
+
+        then:
+        attemptCounter == expectedAttempts
+
+        where:
+        failures || maxRetries || expectedAttempts
+        4        || 10         || 5
+    }
+}

--- a/kayenta-core/src/test/groovy/com/netflix/kayenta/util/RetrySpec.groovy
+++ b/kayenta-core/src/test/groovy/com/netflix/kayenta/util/RetrySpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Netflix, Inc.
+ * Copyright 2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,60 +20,60 @@ import spock.lang.Specification
 import spock.lang.Unroll;
 
 class RetrySpec extends Specification {
-    @Unroll
-    def "should retry until success or #maxRetries attempts is reached"() {
-        given:
-        def retry = Spy(Retry) {
-            Math.min(maxRetries - 1, failures) * sleep(10000) >> { /* do nothing */ }
-        }
-
-        int attemptCounter = 0;
-
-        when:
-        def exceptionMessage
-        try {
-            retry.retry({
-                if (attemptCounter++ < failures) {
-                    throw new IllegalStateException("Failed after " + attemptCounter + " attempts");
-                }
-            }, maxRetries, 10000)
-        } catch (Exception e) {
-            exceptionMessage = e.message
-        }
-
-        then:
-        attemptCounter == expectedAttempts
-        exceptionMessage == expectedExceptionMessage
-
-        where:
-        failures || maxRetries || expectedAttempts || expectedExceptionMessage
-        3        || 10         || 4                || null
-        11       || 10         || 10               || "Failed after 10 attempts"
+  @Unroll
+  def "should retry until success or #maxRetries attempts is reached"() {
+    given:
+    def retry = Spy(Retry) {
+      Math.min(maxRetries - 1, failures) * sleep(10000) >> { /* do nothing */ }
     }
 
-    def "should sleep exponentially"() {
-        given:
-        def retry = Spy(Retry) {
-            1 * sleep(10000) >> { /* do nothing */ }
-            1 * sleep(20000) >> { /* do nothing */ }
-            1 * sleep(40000) >> { /* do nothing */ }
-            1 * sleep(80000) >> { /* do nothing */ }
+    int attemptCounter = 0;
+
+    when:
+    def exceptionMessage
+    try {
+      retry.retry({
+        if (attemptCounter++ < failures) {
+          throw new IllegalStateException("Failed after " + attemptCounter + " attempts");
         }
-
-        int attemptCounter = 0;
-
-        when:
-        retry.exponential({
-            if (attemptCounter++ < failures) {
-                throw new IllegalStateException("Failed after " + attemptCounter + " attempts");
-            }
-        }, maxRetries, 10000)
-
-        then:
-        attemptCounter == expectedAttempts
-
-        where:
-        failures || maxRetries || expectedAttempts
-        4        || 10         || 5
+      }, maxRetries, 10000)
+    } catch (Exception e) {
+      exceptionMessage = e.message
     }
+
+    then:
+    attemptCounter == expectedAttempts
+    exceptionMessage == expectedExceptionMessage
+
+    where:
+    failures || maxRetries || expectedAttempts || expectedExceptionMessage
+    3        || 10         || 4                || null
+    11       || 10         || 10               || "Failed after 10 attempts"
+  }
+
+  def "should sleep exponentially"() {
+    given:
+    def retry = Spy(Retry) {
+      1 * sleep(10000) >> { /* do nothing */ }
+      1 * sleep(20000) >> { /* do nothing */ }
+      1 * sleep(40000) >> { /* do nothing */ }
+      1 * sleep(80000) >> { /* do nothing */ }
+    }
+
+    int attemptCounter = 0;
+
+    when:
+    retry.exponential({
+      if (attemptCounter++ < failures) {
+        throw new IllegalStateException("Failed after " + attemptCounter + " attempts");
+      }
+    }, maxRetries, 10000)
+
+    then:
+    attemptCounter == expectedAttempts
+
+    where:
+    failures || maxRetries || expectedAttempts
+    4        || 10         || 5
+  }
 }

--- a/kayenta-objectstore-configbin/src/main/java/com/netflix/kayenta/configbin/storage/ConfigBinStorageService.java
+++ b/kayenta-objectstore-configbin/src/main/java/com/netflix/kayenta/configbin/storage/ConfigBinStorageService.java
@@ -29,7 +29,7 @@ import com.netflix.kayenta.index.config.CanaryConfigIndexAction;
 import com.netflix.kayenta.security.AccountCredentialsRepository;
 import com.netflix.kayenta.storage.ObjectType;
 import com.netflix.kayenta.storage.StorageService;
-import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.kayenta.util.Retry;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import com.squareup.okhttp.MediaType;
 import com.squareup.okhttp.RequestBody;
@@ -65,6 +65,8 @@ public class ConfigBinStorageService implements StorageService {
   @Autowired
   CanaryConfigIndex canaryConfigIndex;
 
+  private final Retry retry = new Retry();
+
   @Override
   public boolean servicesAccount(String accountName) {
     return accountNames.contains(accountName);
@@ -80,9 +82,8 @@ public class ConfigBinStorageService implements StorageService {
     ConfigBinRemoteService remoteService = credentials.getRemoteService();
     String json;
 
-    RetrySupport retrySupport = new RetrySupport();
     try {
-      json = retrySupport.retry(() -> remoteService.get(ownerApp, configType, objectKey), 10, 1000, false);
+      json = retry.retry(() -> remoteService.get(ownerApp, configType, objectKey), 10, 1000);
     } catch (RetrofitError e) {
       throw new NotFoundException("No such object named " + objectKey);
     }
@@ -143,7 +144,7 @@ public class ConfigBinStorageService implements StorageService {
     try {
       String json = kayentaObjectMapper.writeValueAsString(obj);
       RequestBody body = RequestBody.create(MediaType.parse("application/json"), json);
-      remoteService.post(ownerApp, configType, objectKey, body);
+      retry.retry(() -> remoteService.post(ownerApp, configType, objectKey, body), 10, 1000);
 
       if (objectType == ObjectType.CANARY_CONFIG) {
         canaryConfigIndex.finishPendingUpdate(credentials, CanaryConfigIndexAction.UPDATE, correlationId);
@@ -228,7 +229,7 @@ public class ConfigBinStorageService implements StorageService {
     // TODO(mgraff): If remoteService.delete() throws an exception when the target config does not exist, we should
     // try/catch it here and then call canaryConfigIndex.removeFailedPendingUpdate() like the other storage service
     // implementations do.
-    remoteService.delete(ownerApp, configType, objectKey);
+    retry.retry(() -> remoteService.delete(ownerApp, configType, objectKey), 10, 1000);
 
     if (correlationId != null) {
       canaryConfigIndex.finishPendingUpdate(credentials, CanaryConfigIndexAction.DELETE, correlationId);
@@ -249,7 +250,7 @@ public class ConfigBinStorageService implements StorageService {
       String ownerApp = credentials.getOwnerApp();
       String configType = credentials.getConfigType();
       ConfigBinRemoteService remoteService = credentials.getRemoteService();
-      String jsonBody = remoteService.list(ownerApp, configType);
+      String jsonBody = retry.retry(() -> remoteService.list(ownerApp, configType), 10, 1000);
 
       try {
         List<String> ids = kayentaObjectMapper.readValue(jsonBody, new TypeReference<List<String>>() {});
@@ -275,7 +276,7 @@ public class ConfigBinStorageService implements StorageService {
     String configType = credentials.getConfigType();
     String json;
     try {
-      json = remoteService.get(ownerApp, configType, id);
+      json = retry.retry(() -> remoteService.get(ownerApp, configType, id), 10, 1000);
     } catch (RetrofitError e) {
       throw new IllegalArgumentException("No such object named " + id);
     }


### PR DESCRIPTION
While I would like a more general approach, and this is not quite as clean as I'd like, it's a step toward getting things closer to sane.

I don't yet have metrics wired up, but will add this eventually; I may also split out the "call this method until it stops throwing exceptions" type of call now into a more sane context (http, atlas) aware retry system.  For now, this will work better than what was there.