### PR TITLE
feat(prometheus): add customInlineTemplate logic to enable metric-spec…

### DIFF
--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryMetricSetQueryConfig.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryMetricSetQueryConfig.java
@@ -24,8 +24,17 @@ import lombok.NonNull;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public interface CanaryMetricSetQueryConfig {
 
-  // Optionally defines an explicit filter to be used when composing the query. Takes precedence over customFilterTemplate.
+  /**
+   * @deprecated Use getCustomInlineTemplate instead.
+   */
+  @Deprecated
   default String getCustomFilter() {
+    return null;
+  }
+
+  // Optionally defines a metric-specific query template. Takes precedence over customFilterTemplate.
+  // It is expanded by using the key/value pairs in extendedScopeParams as the variable bindings.
+  default String getCustomInlineTemplate() {
     return null;
   }
 

--- a/kayenta-prometheus/src/main/java/com/netflix/kayenta/canary/providers/metrics/PrometheusCanaryMetricSetQueryConfig.java
+++ b/kayenta-prometheus/src/main/java/com/netflix/kayenta/canary/providers/metrics/PrometheusCanaryMetricSetQueryConfig.java
@@ -45,8 +45,15 @@ public class PrometheusCanaryMetricSetQueryConfig implements CanaryMetricSetQuer
   @Getter
   private List<String> groupByFields;
 
+  /**
+   * @deprecated Use customInlineTemplate instead.
+   */
+  @Deprecated
   @Getter
   private String customFilter;
+
+  @Getter
+  private String customInlineTemplate;
 
   @Getter
   private String customFilterTemplate;

--- a/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/controllers/PrometheusFetchController.java
+++ b/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/controllers/PrometheusFetchController.java
@@ -111,7 +111,7 @@ public class PrometheusFetchController {
     }
 
     if (!StringUtils.isEmpty(customFilter)) {
-      prometheusCanaryMetricSetQueryConfigBuilder.customFilter(customFilter);
+      prometheusCanaryMetricSetQueryConfigBuilder.customInlineTemplate(customFilter);
     }
 
     CanaryMetricConfig canaryMetricConfig =

--- a/kayenta-prometheus/src/test/groovy/com/netflix/kayenta/prometheus/metrics/PrometheusMetricsServiceSpec.groovy
+++ b/kayenta-prometheus/src/test/groovy/com/netflix/kayenta/prometheus/metrics/PrometheusMetricsServiceSpec.groovy
@@ -29,9 +29,7 @@ class PrometheusMetricsServiceSpec extends Specification {
   @Shared
   Map<String, String> templates = [
     someTemplate: 'some-label=${scope}',
-    anotherTemplate: 'my-server-group=${scope}',
-    someCompletePromQlTemplate: 'PromQL:histogram_quantile(0.5, prometheus_http_response_size_bytes_bucket{instance="localhost:9090",handler="${scope}"})',
-    anotherPromQlTemplate: 'PromQL:histogram_quantile(${quantile}, prometheus_http_response_size_bytes_bucket{instance="localhost:9090",handler="${scope}"})'
+    anotherTemplate: 'my-server-group=${scope}'
   ]
 
   @Shared
@@ -46,7 +44,7 @@ class PrometheusMetricsServiceSpec extends Specification {
         .metricName("some-metric-name")
         .labelBindings(labelBindings)
         .customFilterTemplate(customFilterTemplate)
-        .customFilter(customFilter)
+        .customInlineTemplate(customInlineTemplate)
         .build()
     CanaryMetricConfig canaryMetricConfig =
       CanaryMetricConfig.builder()
@@ -70,25 +68,25 @@ class PrometheusMetricsServiceSpec extends Specification {
     query == expectedQuery
 
     where:
-    labelBindings | customFilterTemplate         | customFilter                                                                                                             | resourceType       | scope               | extendedScopeParams || expectedQuery
+    labelBindings | customFilterTemplate         | customInlineTemplate                                                                                                               | resourceType       | scope               | extendedScopeParams || expectedQuery
     // Rely on paved-road composition of queries.
-    ["a=b"]       | null                         | null                                                                                                                     | "gce_instance"     | "some-server-group" | null                || 'avg(some-metric-name{a=b,instance=~"some-server-group-.{4}",zone=~".+/zones/us-central1-.{1}"})'
-    ["a=b"]       | null                         | ""                                                                                                                       | "gce_instance"     | "some-server-group" | null                || 'avg(some-metric-name{a=b,instance=~"some-server-group-.{4}\",zone=~".+/zones/us-central1-.{1}"})'
-    ["a=b"]       | null                         | null                                                                                                                     | "aws_ec2_instance" | "some-server-group" | null                || 'avg(some-metric-name{a=b,asg_groupName="some-server-group",zone=~"us-central1.{1}"})'
-    ["a=b"]       | null                         | ""                                                                                                                       | "aws_ec2_instance" | "some-server-group" | null                || 'avg(some-metric-name{a=b,asg_groupName="some-server-group",zone=~"us-central1.{1}"})'
+    ["a=b"]       | null                         | null                                                                                                                               | "gce_instance"     | "some-server-group" | null                || 'avg(some-metric-name{a=b,instance=~"some-server-group-.{4}",zone=~".+/zones/us-central1-.{1}"})'
+    ["a=b"]       | null                         | ""                                                                                                                                 | "gce_instance"     | "some-server-group" | null                || 'avg(some-metric-name{a=b,instance=~"some-server-group-.{4}\",zone=~".+/zones/us-central1-.{1}"})'
+    ["a=b"]       | null                         | null                                                                                                                               | "aws_ec2_instance" | "some-server-group" | null                || 'avg(some-metric-name{a=b,asg_groupName="some-server-group",zone=~"us-central1.{1}"})'
+    ["a=b"]       | null                         | ""                                                                                                                                 | "aws_ec2_instance" | "some-server-group" | null                || 'avg(some-metric-name{a=b,asg_groupName="some-server-group",zone=~"us-central1.{1}"})'
 
     // Rely on custom filters and custom filter templates.
-    ["a=b"]       | "someTemplate"               | null                                                                                                                     | "gce_instance"     | "some-app-canary"   | null                || "avg(some-metric-name{some-label=some-app-canary,a=b})"
-    ["a=b"]       | "someTemplate"               | "customFilter=something,andSomething=else"                                                                               | "gce_instance"     | null                | null                || "avg(some-metric-name{customFilter=something,andSomething=else,a=b})"
-    ["a=b"]       | null                         | "customFilter=something,andSomething=else"                                                                               | "gce_instance"     | null                | null                || "avg(some-metric-name{customFilter=something,andSomething=else,a=b})"
-    ["a=b"]       | null                         | "customFilter=something,andSomething=else"                                                                               | "aws_ec2_instance" | null                | null                || "avg(some-metric-name{customFilter=something,andSomething=else,a=b})"
-    ["a=b"]       | null                         | "customFilter=something,andSomething=else"                                                                               | "anything_else"    | null                | null                || "avg(some-metric-name{customFilter=something,andSomething=else,a=b})"
-    ["a=b"]       | "anotherTemplate"            | null                                                                                                                     | null               | "some-baseline"     | null                || "avg(some-metric-name{my-server-group=some-baseline,a=b})"
-    ["a=b"]       | "anotherTemplate"            | null                                                                                                                     | ""                 | "some-canary"       | null                || "avg(some-metric-name{my-server-group=some-canary,a=b})"
+    ["a=b"]       | "someTemplate"               | null                                                                                                                               | "gce_instance"     | "some-app-canary"   | null                || "avg(some-metric-name{some-label=some-app-canary,a=b})"
+    ["a=b"]       | "someTemplate"               | "customFilter=something,andSomething=else"                                                                                         | "gce_instance"     | null                | null                || "avg(some-metric-name{customFilter=something,andSomething=else,a=b})"
+    ["a=b"]       | null                         | "customFilter=something,andSomething=else"                                                                                         | "gce_instance"     | null                | null                || "avg(some-metric-name{customFilter=something,andSomething=else,a=b})"
+    ["a=b"]       | null                         | "customFilter=something,andSomething=else"                                                                                         | "aws_ec2_instance" | null                | null                || "avg(some-metric-name{customFilter=something,andSomething=else,a=b})"
+    ["a=b"]       | null                         | "customFilter=something,andSomething=else"                                                                                         | "anything_else"    | null                | null                || "avg(some-metric-name{customFilter=something,andSomething=else,a=b})"
+    ["a=b"]       | "anotherTemplate"            | null                                                                                                                               | null               | "some-baseline"     | null                || "avg(some-metric-name{my-server-group=some-baseline,a=b})"
+    ["a=b"]       | "anotherTemplate"            | null                                                                                                                               | ""                 | "some-canary"       | null                || "avg(some-metric-name{my-server-group=some-canary,a=b})"
 
     // Provide fully-specified PromQl expressions (including template expansion).
-    null          | null                         | 'PromQL:histogram_quantile(0.5, prometheus_http_response_size_bytes_bucket{instance="localhost:9090",handler="/graph"})' | null               | null                | null                || 'histogram_quantile(0.5, prometheus_http_response_size_bytes_bucket{instance="localhost:9090",handler="/graph"})'
-    null          | "someCompletePromQlTemplate" | null                                                                                                                     | null               | "/graph"            | null                || 'histogram_quantile(0.5, prometheus_http_response_size_bytes_bucket{instance="localhost:9090",handler="/graph"})'
-    null          | "anotherPromQlTemplate"      | null                                                                                                                     | null               | "/graph"            | [quantile: 0.99]    || 'histogram_quantile(0.99, prometheus_http_response_size_bytes_bucket{instance="localhost:9090",handler="/graph"})'
+    null          | null                         | 'PromQL:histogram_quantile(0.5, prometheus_http_response_size_bytes_bucket{instance="localhost:9090",handler="/graph"})'           | null               | null                | null                || 'histogram_quantile(0.5, prometheus_http_response_size_bytes_bucket{instance="localhost:9090",handler="/graph"})'
+    null          | null                         | 'PromQL:histogram_quantile(0.5, prometheus_http_response_size_bytes_bucket{instance="localhost:9090",handler="${scope}"})'         | null               | "/graph"            | null                || 'histogram_quantile(0.5, prometheus_http_response_size_bytes_bucket{instance="localhost:9090",handler="/graph"})'
+    null          | null                         | 'PromQL:histogram_quantile(${quantile}, prometheus_http_response_size_bytes_bucket{instance="localhost:9090",handler="${scope}"})' | null               | "/graph"            | [quantile: 0.99]    || 'histogram_quantile(0.99, prometheus_http_response_size_bytes_bucket{instance="localhost:9090",handler="/graph"})'
   }
 }

--- a/kayenta-stackdriver/src/main/java/com/netflix/kayenta/canary/providers/metrics/StackdriverCanaryMetricSetQueryConfig.java
+++ b/kayenta-stackdriver/src/main/java/com/netflix/kayenta/canary/providers/metrics/StackdriverCanaryMetricSetQueryConfig.java
@@ -49,8 +49,15 @@ public class StackdriverCanaryMetricSetQueryConfig implements CanaryMetricSetQue
   @Getter
   private List<String> groupByFields;
 
+  /**
+   * @deprecated Use customInlineTemplate instead.
+   */
+  @Deprecated
   @Getter
   private String customFilter;
+
+  @Getter
+  private String customInlineTemplate;
 
   @Getter
   private String customFilterTemplate;

--- a/kayenta-stackdriver/src/main/java/com/netflix/kayenta/stackdriver/controllers/StackdriverFetchController.java
+++ b/kayenta-stackdriver/src/main/java/com/netflix/kayenta/stackdriver/controllers/StackdriverFetchController.java
@@ -117,7 +117,7 @@ public class StackdriverFetchController {
     }
 
     if (!StringUtils.isEmpty(customFilter)) {
-      stackdriverCanaryMetricSetQueryConfigBuilder.customFilter(customFilter);
+      stackdriverCanaryMetricSetQueryConfigBuilder.customInlineTemplate(customFilter);
     }
 
     CanaryMetricConfig canaryMetricConfig =

--- a/kayenta-stackdriver/src/test/groovy/com/netflix/kayenta/providers/metrics/StackdriverCanaryMetricSetQueryConfigSpec.groovy
+++ b/kayenta-stackdriver/src/test/groovy/com/netflix/kayenta/providers/metrics/StackdriverCanaryMetricSetQueryConfigSpec.groovy
@@ -54,23 +54,23 @@ class StackdriverCanaryMetricSetQueryConfigSpec extends Specification {
     given:
     CanaryConfig canaryConfig = CanaryConfig.builder().templates(templates).build()
     StackdriverCanaryMetricSetQueryConfig stackdriverCanaryMetricSetQueryConfig =
-      StackdriverCanaryMetricSetQueryConfig.builder().customFilterTemplate(customFilterTemplate).customFilter(customFilter).build()
+      StackdriverCanaryMetricSetQueryConfig.builder().customFilterTemplate(customFilterTemplate).customInlineTemplate(customInlineTemplate).build()
     StackdriverCanaryScope stackdriverCanaryScope = new StackdriverCanaryScope(extendedScopeParams: scopeParams)
 
     expect:
     QueryConfigUtils.expandCustomFilter(canaryConfig, stackdriverCanaryMetricSetQueryConfig, stackdriverCanaryScope) == expectedExpandedTemplate
 
     where:
-    templates                                             | customFilterTemplate | customFilter          | scopeParams       || expectedExpandedTemplate
-    ["my-template": 'A test: key1=${key1}.']              | "my-template"        | "An explicit filter." | [key1: "value-1"] || "An explicit filter."
+    templates                                             | customFilterTemplate | customInlineTemplate           | scopeParams       || expectedExpandedTemplate
+    ["my-template": 'A test: key1=${key1}.']              | "my-template"        | 'An inline template: ${key1}.' | [key1: "value-1"] || "An inline template: value-1."
     ["my-template-1": 'A test: key1=${key1}.',
-     "my-template-2": 'A test: key2=${key2}.']            | "my-template-2"      | "An explicit filter." | [key2: "value-2"] || "An explicit filter."
+     "my-template-2": 'A test: key2=${key2}.']            | "my-template-2"      | 'An inline template: ${key2}.' | [key2: "value-2"] || "An inline template: value-2."
     ["my-template-1": 'A test: key1=${key1}.',
-     "my-template-2": 'A test: key2=${key2}.']            | "my-template-1"      | "An explicit filter." | [key1: "value-1"] || "An explicit filter."
-    ["my-template": 'A test: key1=${key1} key2=${key2}.'] | "my-template"        | "An explicit filter." | [key1: "value-1",
-                                                                                                            key2: "value-2"] || "An explicit filter."
-    ["my-template": 'A test: key1=something1.']           | "my-template"        | "An explicit filter." | null              || "An explicit filter."
-    ["my-template": 'A test: key1=something1.']           | "my-template"        | "An explicit filter." | [:]               || "An explicit filter."
+     "my-template-2": 'A test: key2=${key2}.']            | "my-template-1"      | "An inline template."          | [key1: "value-1"] || "An inline template."
+    ["my-template": 'A test: key1=${key1} key2=${key2}.'] | "my-template"        | "An inline template."          | [key1: "value-1",
+                                                                                                                     key2: "value-2"] || "An inline template."
+    ["my-template": 'A test: key1=something1.']           | "my-template"        | "An inline template."          | null              || "An inline template."
+    ["my-template": 'A test: key1=something1.']           | "my-template"        | "An inline template."          | [:]               || "An inline template."
   }
 
   @Unroll
@@ -90,13 +90,15 @@ class StackdriverCanaryMetricSetQueryConfigSpec extends Specification {
     where:
     templates                                                 | customFilterTemplate | scopeParams
     ["my-template-1": 'A test: key1=${key1}.',
-     "my-template-2": 'A test: key2=${key2}.']                | "my-template-x"      | null
-    [:]                                                       | "my-template-x"      | null
-    null                                                      | "my-template-x"      | null
-    ["my-template": 'A test: key1=${key1} key2=${key2}.']     | "my-template"        | [key3: "value-3",
-                                                                                        key4: "value-4"]
-    ["my-template": 'A test: key1=$\\{key1} key2=$\\{key2}.'] | "my-template"        | [key3: "value-3",
-                                                                                        key4: "value-4"]
+     "my-template-2": 'A test: key2=${key2}.']                | "my-template-x"        | null
+    [:]                                                       | "my-template-x"        | null
+    null                                                      | "my-template-x"        | null
+    ["my-template": 'A test: key1=${key1} key2=${key2}.']     | "my-template"          | [key3: "value-3",
+                                                                                          key4: "value-4"]
+    ["my-template": 'A test: key1=$\\{key1} key2=$\\{key2}.'] | "my-template"          | [key3: "value-3",
+                                                                                          key4: "value-4"]
+    ["my-template": 'A test: key1=$\\{key1} key2=$\\{key2}.'] | 'my-template: ${key1}' | [key3: "value-3",
+                                                                                          key4: "value-4"]
   }
 
   @Unroll


### PR DESCRIPTION
…ific PromQL queries

- Rename `CanaryMetricSetQueryConfig.customFilter` to `customInlineTemplate` to clarify that this template belongs to a single metric within a canary config (vs. `customFilterTemplate`, which is a key that references a template shared across metrics within a canary config). Although technically a breaking change, this field had not previously been exposed in the UI. [This PR](https://github.com/spinnaker/deck-kayenta/pull/387) adds UI support for editing full PromQL queries inline as `customInlineTemplate`.
- Adjust `QueryConfigUtils.expandCustomFilter` to apply the same template expansion logic to `customInlineTemplate` and `customFilterTemplate`. This will allow users to hydrate PromQL query templates with custom and implicitly available parameters.
