### PR TITLE
feat(standalone-canary-analysis): Add siteLocal map to standalone canary analysis request

### DIFF
--- a/kayenta-standalone-canary-analysis/src/main/java/com/netflix/kayenta/canaryanalysis/domain/CanaryAnalysisExecutionRequest.java
+++ b/kayenta-standalone-canary-analysis/src/main/java/com/netflix/kayenta/canaryanalysis/domain/CanaryAnalysisExecutionRequest.java
@@ -30,6 +30,7 @@ import javax.validation.constraints.NotNull;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
 @Data
 @Builder
@@ -79,6 +80,12 @@ public class CanaryAnalysisExecutionRequest {
       "If this field is omitted then it will default to the set lifetime." +
       "If this is set to a value greater than the lifetime, it will be reset to lifetime.")
   private Long analysisIntervalMins;
+
+  @ApiModelProperty(value =
+      "A map of customizable data that among other things can be used in org-specific external modules such as event " +
+      "listeners to handle notifications such as Slack, email, async http callbacks, etc.\n" +
+      "The contents of this field don't have an effect on the actual canary analysis execution.")
+  protected Map<String, Object> siteLocal;
 
   @JsonIgnore
   public Duration getBeginCanaryAnalysisAfterAsDuration() {

--- a/kayenta-standalone-canary-analysis/src/main/java/com/netflix/kayenta/canaryanalysis/domain/RunCanaryContext.java
+++ b/kayenta-standalone-canary-analysis/src/main/java/com/netflix/kayenta/canaryanalysis/domain/RunCanaryContext.java
@@ -46,6 +46,7 @@ public class RunCanaryContext {
   private String user;
   private String metricsAccountName;
   private String storageAccountName;
+  private Map<String, Object> siteLocal;
   @NonNull
   private CanaryConfig canaryConfig;
   @NonNull

--- a/kayenta-standalone-canary-analysis/src/main/java/com/netflix/kayenta/canaryanalysis/orca/stage/SetupAndExecuteCanariesStage.java
+++ b/kayenta-standalone-canary-analysis/src/main/java/com/netflix/kayenta/canaryanalysis/orca/stage/SetupAndExecuteCanariesStage.java
@@ -122,6 +122,7 @@ public class SetupAndExecuteCanariesStage implements StageDefinitionBuilder {
           .canaryConfig(canaryAnalysisConfig.getCanaryConfig())
           .scopes(buildRequestScopes(canaryAnalysisExecutionRequest, i, analysisInterval))
           .scoreThresholds(canaryAnalysisExecutionRequest.getThresholds())
+          .siteLocal(canaryAnalysisExecutionRequest.getSiteLocal())
           .build();
 
       graph.append(stage -> {

--- a/kayenta-standalone-canary-analysis/src/main/java/com/netflix/kayenta/canaryanalysis/orca/task/RunCanaryTask.java
+++ b/kayenta-standalone-canary-analysis/src/main/java/com/netflix/kayenta/canaryanalysis/orca/task/RunCanaryTask.java
@@ -77,7 +77,8 @@ public class RunCanaryTask implements Task {
 
     CanaryExecutionRequest executionRequest = new CanaryExecutionRequest()
         .setScopes(context.getScopes())
-        .setThresholds(context.getScoreThresholds());
+        .setThresholds(context.getScoreThresholds())
+        .setSiteLocal(context.getSiteLocal());
 
     request.setExecutionRequest(executionRequest);
 


### PR DESCRIPTION
Add siteLocal map to standalone canary analysis request and propagate it to the individual canary executions as well, so that notification metadata can be passed to external event listeners.
