### PR TITLE
fix: When AWS and S3 are enabled properties of type primitive boolean…

### DIFF
--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/results/CanaryAnalysisResult.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/results/CanaryAnalysisResult.java
@@ -71,5 +71,5 @@ public class CanaryAnalysisResult {
 
   @Getter
   @Builder.Default
-  private boolean critical = false;
+  private Boolean critical = Boolean.FALSE;
 }

--- a/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/scorers/WeightedSumScorer.scala
+++ b/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/scorers/WeightedSumScorer.scala
@@ -78,7 +78,7 @@ class WeightedSumScorer(groupWeights: Map[String, Double]) extends BaseScorer {
   }
 
   def criticalFailures(results: List[CanaryAnalysisResult]): List[CanaryAnalysisResult] = {
-    results.filter { result => result.isCritical && !result.getClassification.equals(Pass.toString) }
+    results.filter { result => result.getCritical && !result.getClassification.equals(Pass.toString) }
   }
 
   def tooManyNodata(results: List[CanaryAnalysisResult]): Boolean = {

--- a/kayenta-standalone-canary-analysis/src/main/java/com/netflix/kayenta/canaryanalysis/domain/CanaryAnalysisExecutionResult.java
+++ b/kayenta-standalone-canary-analysis/src/main/java/com/netflix/kayenta/canaryanalysis/domain/CanaryAnalysisExecutionResult.java
@@ -35,10 +35,12 @@ import java.util.List;
 public class CanaryAnalysisExecutionResult {
 
   @ApiModelProperty(value = "This boolean represents whether the canary passed the defined thresholds.")
-  protected boolean didPassThresholds;
+  @Builder.Default
+  protected Boolean didPassThresholds = Boolean.FALSE;
 
   @ApiModelProperty(value = "This boolean is set to true if any of the judgements had warnings.")
-  protected boolean hasWarnings;
+  @Builder.Default
+  protected Boolean hasWarnings = Boolean.FALSE;
 
   @ApiModelProperty(value = "This string describes the aggregated judgement results.")
   protected String canaryScoreMessage;


### PR DESCRIPTION
@duftler @skandragon ,

I noticed that when I have Kayenta running with AWS and S3 configured that response objects with properties that are of type boolean are being stripped from the responses.

This PR changes a couple booleans to Boolean.

It might be better long term to figure out what is going on with Jackson?