### PR TITLE
fix(s3): re-enable AUTO_DETECT_IS_GETTERS after using Netflix Amazon …

### DIFF
--- a/kayenta-s3/src/main/java/com/netflix/kayenta/s3/config/S3Configuration.java
+++ b/kayenta-s3/src/main/java/com/netflix/kayenta/s3/config/S3Configuration.java
@@ -16,6 +16,7 @@
 
 package com.netflix.kayenta.s3.config;
 
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.awsobjectmapper.AmazonObjectMapperConfigurer;
 import com.netflix.kayenta.aws.security.AwsNamedAccountCredentials;
@@ -43,6 +44,7 @@ public class S3Configuration {
   @DependsOn({"registerAwsCredentials"})
   public S3StorageService s3StorageService(AccountCredentialsRepository accountCredentialsRepository) {
     AmazonObjectMapperConfigurer.configure(kayentaObjectMapper);
+    kayentaObjectMapper.configure(MapperFeature.AUTO_DETECT_IS_GETTERS, true);
     S3StorageService.S3StorageServiceBuilder s3StorageServiceBuilder = S3StorageService.builder();
 
     accountCredentialsRepository


### PR DESCRIPTION
fix(s3): re-enable AUTO_DETECT_IS_GETTERS after using Netflix Amazon Object Mapper Configurer on the Kayenta object mapper.

Either this or https://github.com/spinnaker/kayenta/pull/462 to fix https://github.com/spinnaker/kayenta/issues/464