### PR TITLE
feat(signalfx): add optional default scope and location keys when configuring accounts

### DIFF
--- a/kayenta-signalfx/kayenta-signalfx.gradle
+++ b/kayenta-signalfx/kayenta-signalfx.gradle
@@ -119,6 +119,8 @@ dependencies {
 
   compile group: 'com.signalfx.public', name: 'signalfx-java', version: '0.0.48'
 
+  testCompile group: 'com.tngtech.java', name: 'junit-dataprovider', version: '1.13.1'
+
   // Integration Test dependencies
   integrationTestCompile sourceSets.main.output
   integrationTestCompile configurations.testCompile

--- a/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/config/SignalFxMockServiceReportingConfig.java
+++ b/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/config/SignalFxMockServiceReportingConfig.java
@@ -58,6 +58,7 @@ public class SignalFxMockServiceReportingConfig {
   private static final int MOCK_SERVICE_REPORTING_INTERVAL_IN_MILLISECONDS = 1000;
 
   public static final String SIGNAL_FX_SCOPE_IDENTIFYING_DIMENSION_NAME = "canary-scope";
+  public static final String SIGNAL_FX_LOCATION_IDENTIFYING_DIMENSION_NAME = "location";
   public static final String KAYENTA_INTEGRATION_TEST_CPU_AVG_METRIC_NAME = "kayenta.integration-test.cpu.avg";
   public static final String KAYENTA_INTEGRATION_TEST_REQUEST_COUNT_METRIC_NAME = "kayenta.integration-test.request.count";
   public static final String CONTROL_SCOPE_NAME = "control";
@@ -148,6 +149,7 @@ public class SignalFxMockServiceReportingConfig {
                   "dimensions", ImmutableMap.builder()
                       .putAll(metric.getDimensions())
                       .put(SIGNAL_FX_SCOPE_IDENTIFYING_DIMENSION_NAME, scopeName)
+                      .put(SIGNAL_FX_LOCATION_IDENTIFYING_DIMENSION_NAME, "us-west-2")
                       .put("env", "integration")
                       .put("test-id", testId)
                       .put("uuid", uuid)

--- a/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/EndToEndCanaryIntegrationTests.java
+++ b/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/EndToEndCanaryIntegrationTests.java
@@ -82,10 +82,9 @@ public class EndToEndCanaryIntegrationTests extends BaseSignalFxIntegrationTest 
     CanaryScope control = new CanaryScope()
         .setScope(CONTROL_SCOPE_NAME)
         .setExtendedScopeParams(ImmutableMap.of(
-            SCOPE_KEY_KEY, SIGNAL_FX_SCOPE_IDENTIFYING_DIMENSION_NAME,
             "test-id", testId
         ))
-        .setLocation("us-west-2")
+        .setLocation(LOCATION)
         .setStep(1l)
         .setStart(metricsReportingStartTime)
         .setEnd(end);
@@ -93,7 +92,6 @@ public class EndToEndCanaryIntegrationTests extends BaseSignalFxIntegrationTest 
     CanaryScope experiment = new CanaryScope()
         .setScope(expScope)
         .setExtendedScopeParams(ImmutableMap.of(
-            SCOPE_KEY_KEY, SIGNAL_FX_SCOPE_IDENTIFYING_DIMENSION_NAME,
             TEST_ID, testId
         ))
         .setLocation(LOCATION)

--- a/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/EndToEndStandaloneCanaryAnalysisIntegrationTests.java
+++ b/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/EndToEndStandaloneCanaryAnalysisIntegrationTests.java
@@ -59,7 +59,6 @@ public class EndToEndStandaloneCanaryAnalysisIntegrationTests extends BaseSignal
                 .experimentScope(HEALTHY_EXPERIMENT_SCOPE_NAME)
                 .experimentLocation(LOCATION)
                 .extendedScopeParams(ImmutableMap.of(
-                    SCOPE_KEY_KEY, SIGNAL_FX_SCOPE_IDENTIFYING_DIMENSION_NAME,
                     TEST_ID, testId
                 ))
                 .startTimeIso(metricsReportingStartTime.toString())

--- a/kayenta-signalfx/src/integration-test/resources/config/kayenta.yml
+++ b/kayenta-signalfx/src/integration-test/resources/config/kayenta.yml
@@ -36,6 +36,8 @@ kayenta:
       accessToken: ${kayenta.signalfx.apiKey}
       supportedTypes:
       - METRICS_STORE
+      defaultScopeKey: canary-scope
+      defaultLocationKey: location
 
   stackdriver:
     enabled: false

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/canary/SignalFxCanaryScope.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/canary/SignalFxCanaryScope.java
@@ -22,14 +22,11 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import javax.validation.constraints.NotNull;
-
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class SignalFxCanaryScope extends CanaryScope {
 
-  @NotNull
   private String scopeKey;
-
+  private String locationKey;
 }

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/config/SignalFxConfiguration.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/config/SignalFxConfiguration.java
@@ -38,6 +38,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.util.CollectionUtils;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Configuration
@@ -53,6 +54,16 @@ public class SignalFxConfiguration {
   @ConfigurationProperties("kayenta.signalfx")
   SignalFxConfigurationProperties signalFxConfigurationProperties() {
     return new SignalFxConfigurationProperties();
+  }
+
+  @Bean
+  Map<String, SignalFxScopeConfiguration> signalFxScopeConfigurationMap(SignalFxConfigurationProperties signalFxConfigurationProperties) {
+    return signalFxConfigurationProperties.getAccounts().stream()
+        .collect(Collectors.toMap(SignalFxManagedAccount::getName,
+            accountConfig -> SignalFxScopeConfiguration.builder()
+                .defaultScopeKey(accountConfig.getDefaultScopeKey())
+                .defaultLocationKey(accountConfig.getDefaultLocationKey())
+                .build()));
   }
 
   @Bean

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/config/SignalFxManagedAccount.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/config/SignalFxManagedAccount.java
@@ -20,6 +20,7 @@ package com.netflix.kayenta.signalfx.config;
 import com.netflix.kayenta.security.AccountCredentials;
 import lombok.Data;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import java.util.List;
 
@@ -32,4 +33,10 @@ public class SignalFxManagedAccount {
   private String accessToken;
 
   private List<AccountCredentials.Type> supportedTypes;
+
+  @Nullable
+  private String defaultScopeKey;
+
+  @Nullable
+  private String defaultLocationKey;
 }

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/config/SignalFxScopeConfiguration.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/config/SignalFxScopeConfiguration.java
@@ -1,0 +1,17 @@
+package com.netflix.kayenta.signalfx.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignalFxScopeConfiguration {
+
+  private String defaultScopeKey;
+  private String defaultLocationKey;
+
+}

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/config/SignalFxScopeConfiguration.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/config/SignalFxScopeConfiguration.java
@@ -13,5 +13,4 @@ public class SignalFxScopeConfiguration {
 
   private String defaultScopeKey;
   private String defaultLocationKey;
-
 }

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/metrics/SignalFxMetricsService.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/metrics/SignalFxMetricsService.java
@@ -85,7 +85,6 @@ public class SignalFxMetricsService implements MetricsService {
                            CanaryScope canaryScope) {
 
     SignalFxScopeConfiguration scopeConfiguration = signalFxScopeConfigurationMap.get(metricsAccountName);
-
     SignalFxCanaryScope signalFxCanaryScope = (SignalFxCanaryScope) canaryScope;
     SignalFxCanaryMetricSetQueryConfig queryConfig = (SignalFxCanaryMetricSetQueryConfig) canaryMetricConfig.getQuery();
     String aggregationMethod = Optional.ofNullable(queryConfig.getAggregationMethod()).orElse("mean");

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/metrics/SignalFxMetricsService.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/metrics/SignalFxMetricsService.java
@@ -26,6 +26,7 @@ import com.netflix.kayenta.metrics.MetricSet;
 import com.netflix.kayenta.metrics.MetricsService;
 import com.netflix.kayenta.security.AccountCredentialsRepository;
 import com.netflix.kayenta.signalfx.canary.SignalFxCanaryScope;
+import com.netflix.kayenta.signalfx.config.SignalFxScopeConfiguration;
 import com.netflix.kayenta.signalfx.security.SignalFxNamedAccountCredentials;
 import com.netflix.kayenta.signalfx.service.ErrorResponse;
 import com.netflix.kayenta.signalfx.service.SignalFlowExecutionResult;
@@ -64,6 +65,9 @@ public class SignalFxMetricsService implements MetricsService {
   @Autowired
   private final AccountCredentialsRepository accountCredentialsRepository;
 
+  @Autowired
+  private final Map<String, SignalFxScopeConfiguration> signalFxScopeConfigurationMap;
+
   @Override
   public String getType() {
     return "signalfx";
@@ -80,13 +84,15 @@ public class SignalFxMetricsService implements MetricsService {
                            CanaryMetricConfig canaryMetricConfig,
                            CanaryScope canaryScope) {
 
-    SignalFxCanaryScope signalFxCanaryScope = (SignalFxCanaryScope)canaryScope;
+    SignalFxScopeConfiguration scopeConfiguration = signalFxScopeConfigurationMap.get(metricsAccountName);
+
+    SignalFxCanaryScope signalFxCanaryScope = (SignalFxCanaryScope) canaryScope;
     SignalFxCanaryMetricSetQueryConfig queryConfig = (SignalFxCanaryMetricSetQueryConfig) canaryMetricConfig.getQuery();
     String aggregationMethod = Optional.ofNullable(queryConfig.getAggregationMethod()).orElse("mean");
     List<QueryPair> queryPairs = Optional.ofNullable(queryConfig.getQueryPairs()).orElse(new LinkedList<>());
 
     return SimpleSignalFlowProgramBuilder
-        .create(queryConfig.getMetricName(), aggregationMethod)
+        .create(queryConfig.getMetricName(), aggregationMethod, scopeConfiguration)
         .withQueryPairs(queryPairs)
         .withScope(signalFxCanaryScope)
         .build();

--- a/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/metrics/SimpleSignalFlowProgramBuilderTest.java
+++ b/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/metrics/SimpleSignalFlowProgramBuilderTest.java
@@ -21,10 +21,15 @@ import com.google.common.collect.ImmutableMap;
 import com.netflix.kayenta.canary.providers.metrics.QueryPair;
 import com.netflix.kayenta.signalfx.canary.SignalFxCanaryScope;
 import com.netflix.kayenta.signalfx.config.SignalFxScopeConfiguration;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 
+@RunWith(DataProviderRunner.class)
 public class SimpleSignalFlowProgramBuilderTest {
 
   @Test
@@ -60,59 +65,41 @@ public class SimpleSignalFlowProgramBuilderTest {
     assertEquals(expected, builder.build());
   }
 
-  @Test
-  public void test_that_the_program_builder_builds_the_expected_program_when_location_is_provided_via_default() {
-
-    String metricName = "request.count";
-    String aggregationMethod = "mean";
-
-    SignalFxCanaryScope scope = new SignalFxCanaryScope();
-    SignalFxScopeConfiguration scopeConfiguration = SignalFxScopeConfiguration.builder()
-        .defaultLocationKey("region")
-        .build();
-    scope.setScope("1.0.0");
-    scope.setScopeKey("version");
-    scope.setLocation("us-west-2");
-    scope.setExtendedScopeParams(ImmutableMap.of(
-        "env", "production",
-        "_scope_key", "version"));
-
-    SimpleSignalFlowProgramBuilder builder = SimpleSignalFlowProgramBuilder
-        .create(metricName, aggregationMethod, scopeConfiguration);
-
-    builder.withQueryPair(new QueryPair("app", "cms"));
-    builder.withQueryPair(new QueryPair("response_code", "400"));
-    builder.withQueryPair(new QueryPair("uri", "/v2/auth/iam-principal"));
-    builder.withScope(scope);
-
-    String expected = "data('request.count', filter=" +
-        "filter('app', 'cms') " +
-        "and filter('response_code', '400') " +
-        "and filter('uri', '/v2/auth/iam-principal') " +
-        "and filter('version', '1.0.0') " +
-        "and filter('region', 'us-west-2') " +
-        "and filter('env', 'production'))" +
-        ".mean(by=['env', 'region', 'version']).publish()";
-
-    assertEquals(expected, builder.build());
+  @DataProvider
+  public static Object[][] locationScopeProvider() {
+    return new Object[][]{
+        {
+          new SignalFxCanaryScope()
+            .setScopeKey("version")
+            .setLocationKey("region")
+            .setScope("1.0.0")
+            .setLocation("us-west-2")
+            .setExtendedScopeParams(ImmutableMap.of(
+              "env", "production",
+              "_scope_key", "version",
+              "_location_key", "region")),
+          SignalFxScopeConfiguration.builder().build()
+        },
+        {
+          new SignalFxCanaryScope()
+            .setScopeKey("version")
+            .setScope("1.0.0")
+            .setLocation("us-west-2")
+            .setExtendedScopeParams(ImmutableMap.of("env", "production")),
+          SignalFxScopeConfiguration.builder()
+                .defaultLocationKey("region")
+                .build()
+        }
+    };
   }
-
   @Test
-  public void test_that_the_program_builder_builds_the_expected_program_when_location_is_provided_via_request() {
+  @UseDataProvider("locationScopeProvider")
+  public void test_that_the_program_builder_builds_the_expected_program_when_location_is_provided(
+      SignalFxCanaryScope scope,
+      SignalFxScopeConfiguration scopeConfiguration) {
 
     String metricName = "request.count";
     String aggregationMethod = "mean";
-
-    SignalFxCanaryScope scope = new SignalFxCanaryScope();
-    SignalFxScopeConfiguration scopeConfiguration = SignalFxScopeConfiguration.builder().build();
-    scope.setScope("1.0.0");
-    scope.setScopeKey("version");
-    scope.setLocation("us-west-2");
-    scope.setLocationKey("region");
-    scope.setExtendedScopeParams(ImmutableMap.of(
-        "env", "production",
-        "_scope_key", "version",
-        "_location_key", "region"));
 
     SimpleSignalFlowProgramBuilder builder = SimpleSignalFlowProgramBuilder
         .create(metricName, aggregationMethod, scopeConfiguration);


### PR DESCRIPTION
This PR makes including `_scope_key` in the extendedScopeParameters optional and allows operators to define account / org wide defaults.

This PR also adds the location to the query if it is supplied as an account default or in the extendedScopeParameters as `_location_key`.

Both changes are backwards compatible.