### PR TITLE
chore(google): Clean up google dependencies

### DIFF
--- a/kayenta-gcs/kayenta-gcs.gradle
+++ b/kayenta-gcs/kayenta-gcs.gradle
@@ -3,6 +3,7 @@ dependencies {
   compile project(":kayenta-google")
 
   compile spinnaker.dependency('bootWeb')
+  compile spinnaker.dependency('korkExceptions')
+  compile spinnaker.dependency('googleStorage')
   compile spinnaker.dependency('lombok')
-  spinnaker.group('google')
 }

--- a/kayenta-google/kayenta-google.gradle
+++ b/kayenta-google/kayenta-google.gradle
@@ -3,6 +3,6 @@ dependencies {
 
   compile spinnaker.dependency('bootWeb')
   compile spinnaker.dependency('lombok')
-  spinnaker.group('google')
   compile spinnaker.dependency('googleMonitoring')
+  compile spinnaker.dependency('googleStorage')
 }

--- a/kayenta-stackdriver/kayenta-stackdriver.gradle
+++ b/kayenta-stackdriver/kayenta-stackdriver.gradle
@@ -8,6 +8,5 @@ dependencies {
 
   compile "com.netflix.spinnaker.orca:orca-core:$orcaVersion"
 
-  spinnaker.group('google')
   compile spinnaker.dependency('googleMonitoring')
 }


### PR DESCRIPTION
A few kayenta modules pull in the GCE client library, which is unused. In preparation for bumping the library, remove it from unused places.