### PR TITLE
feat(canary-results): archive exactly what we return via HTTP

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,6 @@ org.gradle.parallel=true
 spinnakerDependenciesVersion=1.2.2
 
 springBootVersion=1.5.10.RELEASE
-kotlinVersion=1.2.71
+kotlinVersion=1.3.20
 orcaVersion=6.119.0
 mathCommonsVersion=3.6.1

--- a/kayenta-core/kayenta-core.gradle
+++ b/kayenta-core/kayenta-core.gradle
@@ -16,6 +16,9 @@ dependencies {
   compile "net.lariverosc:jesque-spring:1.0.1"
   compile "net.greghaines:jesque:1.3.1"
 
+  compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
+  compile "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
+
   spinnaker.group('bootWeb')
   compile spinnaker.dependency('bootFreemarker')
 

--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryArchiveResultUpdateResponse.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryArchiveResultUpdateResponse.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.canary;
+
+import lombok.Builder;
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+@Builder
+public class CanaryArchiveResultUpdateResponse {
+
+  @NotNull
+  protected String pipelineId;
+}

--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryExecutionStatusResponse.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryExecutionStatusResponse.java
@@ -16,14 +16,12 @@
 package com.netflix.kayenta.canary;
 
 import com.netflix.kayenta.canary.results.CanaryResult;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.validation.constraints.NotNull;
 import java.util.Map;
 
+@Getter
 @Data
 @Builder
 @NoArgsConstructor
@@ -34,7 +32,7 @@ public class CanaryExecutionStatusResponse {
   protected String parentPipelineExecutionId;
 
   @NotNull
-  protected String pipelineId;
+  public String pipelineId;
 
   @NotNull
   protected Map<String, String> stageStatus;
@@ -66,14 +64,22 @@ public class CanaryExecutionStatusResponse {
   // (endTime - buildTime) should indicate the total time it took from request to result.
   // (endTime - startTime) should be the amount of time the canary was actually running.
   //
+
   protected Long buildTimeMillis;
+
   protected String buildTimeIso;
+
   protected Long startTimeMillis;
+
   protected String startTimeIso;
+
   protected Long endTimeMillis;
+
   protected String endTimeIso;
 
   // If set, these are the account names used for this run.
+
   protected String storageAccountName;
+
   protected String configurationAccountName;
 }

--- a/kayenta-core/src/main/java/com/netflix/kayenta/events/CanaryExecutionCompletedEvent.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/events/CanaryExecutionCompletedEvent.java
@@ -18,10 +18,13 @@ package com.netflix.kayenta.events;
 import com.netflix.kayenta.canary.CanaryExecutionStatusResponse;
 import org.springframework.context.ApplicationEvent;
 
+import javax.validation.constraints.NotNull;
+
 public class CanaryExecutionCompletedEvent extends ApplicationEvent {
   private final CanaryExecutionStatusResponse canaryExecutionStatusResponse;
 
-  public CanaryExecutionCompletedEvent(Object source, CanaryExecutionStatusResponse canaryExecutionStatusResponse) {
+  public CanaryExecutionCompletedEvent(Object source,
+                                       @NotNull CanaryExecutionStatusResponse canaryExecutionStatusResponse) {
     super(source);
     this.canaryExecutionStatusResponse = canaryExecutionStatusResponse;
   }

--- a/kayenta-core/src/main/java/com/netflix/kayenta/events/listeners/ExecutionArchivalListener.kt
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/events/listeners/ExecutionArchivalListener.kt
@@ -1,0 +1,45 @@
+package com.netflix.kayenta.events.listeners
+
+import com.netflix.kayenta.canary.CanaryExecutionStatusResponse
+import com.netflix.kayenta.events.CanaryExecutionCompletedEvent
+import com.netflix.kayenta.security.AccountCredentials
+import com.netflix.kayenta.security.AccountCredentialsRepository
+import com.netflix.kayenta.security.CredentialsHelper
+import com.netflix.kayenta.storage.ObjectType
+import com.netflix.kayenta.storage.StorageServiceRepository
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory.getLogger
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationListener
+import org.springframework.stereotype.Component
+
+@Component
+class ExecutionArchivalListener @Autowired
+constructor(private val accountCredentialsRepository: AccountCredentialsRepository,
+            private val storageServiceRepository: StorageServiceRepository)
+    : ApplicationListener<CanaryExecutionCompletedEvent> {
+
+    init {
+        log.info("Loaded ExecutionArchivalListener")
+    }
+
+    override fun onApplicationEvent(event: CanaryExecutionCompletedEvent) {
+        val response = event.canaryExecutionStatusResponse
+        val storageAccountName = response.storageAccountName
+        if (storageAccountName != null) {
+            val resolvedStorageAccountName = CredentialsHelper.resolveAccountByNameOrType(storageAccountName,
+                    AccountCredentials.Type.OBJECT_STORE,
+                    accountCredentialsRepository)
+
+            val storageService = storageServiceRepository
+                    .getOne(resolvedStorageAccountName)
+                    .orElseThrow { IllegalArgumentException("No storage service was configured; unable to archive results.") }
+
+            storageService.storeObject<CanaryExecutionStatusResponse>(resolvedStorageAccountName, ObjectType.CANARY_RESULT_ARCHIVE, response.pipelineId, response)
+        }
+    }
+
+    companion object {
+        private val log: Logger = getLogger(ExecutionArchivalListener::class.java)
+    }
+}

--- a/kayenta-core/src/main/java/com/netflix/kayenta/storage/ObjectType.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/storage/ObjectType.java
@@ -18,6 +18,7 @@ package com.netflix.kayenta.storage;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.netflix.kayenta.canary.CanaryConfig;
+import com.netflix.kayenta.canary.CanaryExecutionStatusResponse;
 import com.netflix.kayenta.canary.results.CanaryResult;
 import com.netflix.kayenta.metrics.MetricSet;
 import com.netflix.kayenta.metrics.MetricSetPair;
@@ -31,7 +32,8 @@ public enum ObjectType {
   CANARY_CONFIG(new TypeReference<CanaryConfig>() {}, "canary_config", "canary_config.json"),
   METRIC_SET_LIST(new TypeReference<List<MetricSet>>() {}, "metrics", "metric_sets.json"),
   METRIC_SET_PAIR_LIST(new TypeReference<List<MetricSetPair>>() {}, "metric_pairs", "metric_set_pairs.json"),
-  CANARY_RESULT(new TypeReference<CanaryResult>() {}, "canary_results", "canary_results.json");
+  CANARY_RESULT(new TypeReference<CanaryResult>() {}, "judge_results", "judge_results.json"),
+  CANARY_RESULT_ARCHIVE(new TypeReference<CanaryExecutionStatusResponse>() {}, "canary_archive", "canary_archive.json");
 
   @Getter
   final TypeReference typeReference;

--- a/kayenta-web/src/main/java/com/netflix/kayenta/controllers/CanaryResultArchiveController.java
+++ b/kayenta-web/src/main/java/com/netflix/kayenta/controllers/CanaryResultArchiveController.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.controllers;
+
+import com.netflix.kayenta.canary.CanaryArchiveResultUpdateResponse;
+import com.netflix.kayenta.canary.CanaryConfig;
+import com.netflix.kayenta.canary.CanaryExecutionStatusResponse;
+import com.netflix.kayenta.security.AccountCredentials;
+import com.netflix.kayenta.security.AccountCredentialsRepository;
+import com.netflix.kayenta.security.CredentialsHelper;
+import com.netflix.kayenta.storage.ObjectType;
+import com.netflix.kayenta.storage.StorageService;
+import com.netflix.kayenta.storage.StorageServiceRepository;
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/canaryResultArchive")
+@Api(value = "/canaryResultArchive", description = "Manipulate the archived canary result object store.  This should be used only for Kayenta maintenance.  Use the /canary endpoints for canary results.")
+@Slf4j
+public class CanaryResultArchiveController {
+  
+  private final AccountCredentialsRepository accountCredentialsRepository;
+  private final StorageServiceRepository storageServiceRepository;
+
+  @Autowired
+  public CanaryResultArchiveController(AccountCredentialsRepository accountCredentialsRepository, StorageServiceRepository storageServiceRepository) {
+    this.accountCredentialsRepository = accountCredentialsRepository;
+    this.storageServiceRepository = storageServiceRepository;
+  }
+
+  @ApiOperation(value = "Retrieve an archived canary result from object storage")
+  @RequestMapping(value = "/{pipelineId:.+}", method = RequestMethod.GET)
+  public CanaryExecutionStatusResponse loadArchivedCanaryResult(@RequestParam(required = false) final String configurationAccountName,
+                                                                @PathVariable String pipelineId) {
+    String resolvedConfigurationAccountName = resolveConfigurationAccountName(configurationAccountName);
+    StorageService storageService = getStorageService(resolvedConfigurationAccountName, "retrieve archived canary result");
+
+    return storageService.loadObject(resolvedConfigurationAccountName, ObjectType.CANARY_RESULT_ARCHIVE, pipelineId);
+  }
+
+  @ApiOperation(value = "Create an archived canary result to object storage")
+  @RequestMapping(consumes = "application/json", method = RequestMethod.POST)
+  public CanaryArchiveResultUpdateResponse storeArchivedCanaryResult(@RequestParam(required = false) final String configurationAccountName,
+                                                                     @RequestParam(required = false) String pipelineId,
+                                                                     @RequestBody CanaryConfig canaryConfig) throws IOException {
+    String resolvedConfigurationAccountName = resolveConfigurationAccountName(configurationAccountName);
+    StorageService storageService = getStorageService(resolvedConfigurationAccountName, "create archived canary result");
+    
+    if (pipelineId == null) {
+      pipelineId = UUID.randomUUID() + "";
+    }
+    
+    try {
+      storageService.loadObject(resolvedConfigurationAccountName, ObjectType.CANARY_RESULT_ARCHIVE, pipelineId);
+    } catch (NotFoundException e) {
+      storageService.storeObject(resolvedConfigurationAccountName, ObjectType.CANARY_RESULT_ARCHIVE, pipelineId, canaryConfig, canaryConfig.getName() + ".json", false);
+
+      return CanaryArchiveResultUpdateResponse.builder().pipelineId(pipelineId).build();
+    }
+
+    throw new IllegalArgumentException("Archived canary result '" + pipelineId + "' already exists.");
+  }
+
+  @ApiOperation(value = "Update an archived canary result in object storage")
+  @RequestMapping(value = "/{pipelineId:.+}", consumes = "application/json", method = RequestMethod.PUT)
+  public CanaryArchiveResultUpdateResponse updateArchivedCanaryResult(@RequestParam(required = false) final String configurationAccountName,
+                                                                      @PathVariable String pipelineId,
+                                                                      @RequestBody CanaryConfig canaryConfig) throws IOException {
+    String resolvedConfigurationAccountName = resolveConfigurationAccountName(configurationAccountName);
+    StorageService storageService = getStorageService(resolvedConfigurationAccountName, "update archived canary result");
+
+    try {
+      storageService.loadObject(resolvedConfigurationAccountName, ObjectType.CANARY_RESULT_ARCHIVE, pipelineId);
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Archived canary result '" + pipelineId + "' does not exist.");
+    }
+
+    storageService.storeObject(resolvedConfigurationAccountName, ObjectType.CANARY_RESULT_ARCHIVE, pipelineId, canaryConfig, canaryConfig.getName() + ".json", true);
+
+    return CanaryArchiveResultUpdateResponse.builder().pipelineId(pipelineId).build();
+  }
+
+  @ApiOperation(value = "Delete an archived canary result from object storage")
+  @RequestMapping(value = "/{pipelineId:.+}", method = RequestMethod.DELETE)
+  public void deleteArchivedCanaryResult(@RequestParam(required = false) final String configurationAccountName,
+                                         @PathVariable String pipelineId,
+                                         HttpServletResponse response) {
+    String resolvedConfigurationAccountName = resolveConfigurationAccountName(configurationAccountName);
+    StorageService storageService = getStorageService(resolvedConfigurationAccountName, "delete archived canary result.");
+
+    storageService.deleteObject(resolvedConfigurationAccountName, ObjectType.CANARY_RESULT_ARCHIVE, pipelineId);
+
+    response.setStatus(HttpStatus.NO_CONTENT.value());
+  }
+
+  @ApiOperation(value = "Retrieve a list of archived canary result ids in object storage")
+  @RequestMapping(method = RequestMethod.GET)
+  public List<Map<String, Object>> listAllCanaryArchivedResults(@RequestParam(required = false) final String configurationAccountName) {
+    String resolvedConfigurationAccountName = resolveConfigurationAccountName(configurationAccountName);
+    StorageService storageService = getStorageService(resolvedConfigurationAccountName, "list all archived canary results");
+
+    return storageService.listObjectKeys(resolvedConfigurationAccountName, ObjectType.CANARY_RESULT_ARCHIVE);
+  }
+
+  private String resolveConfigurationAccountName(String configurationAccountName) {
+    return CredentialsHelper.resolveAccountByNameOrType(configurationAccountName,
+                                                        AccountCredentials.Type.OBJECT_STORE,
+                                                        accountCredentialsRepository);
+  }
+
+  private StorageService getStorageService(String resolvedConfigurationAccountName, String contextMessage) {
+    return storageServiceRepository
+      .getOne(resolvedConfigurationAccountName)
+      .orElseThrow(() -> new IllegalArgumentException("No configuration service was configured; unable to " + contextMessage + "."));
+  }
+}


### PR DESCRIPTION
This change allows execution details to be removed from the Redis-backed execution repository, yet still return JSON data from object storage.  This makes the redis footprint smaller while still maintaining long-lived links to canary reports or raw data.

Use object storage to archive the same response we'd give back for `GET /canary/:id`.  Add a controller to manipulate these archive objects.  The controller is documented as not intended to be used directly.

In the CanaryController, first look in redis for the execution information, and if found return it as usual.  If not found, look in the archive and return what we have from that.