### PR TITLE
fix(orca): Update Orca to 6.139.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ spinnakerDependenciesVersion=1.2.2
 
 springBootVersion=1.5.10.RELEASE
 kotlinVersion=1.3.20
-orcaVersion=6.119.0
+orcaVersion=6.139.0
 mathCommonsVersion=3.6.1

--- a/kayenta-web/src/main/java/com/netflix/kayenta/controllers/CanaryController.java
+++ b/kayenta-web/src/main/java/com/netflix/kayenta/controllers/CanaryController.java
@@ -187,7 +187,7 @@ public class CanaryController {
       .filter(s -> !StringUtils.isEmpty(s))
       .collect(Collectors.toList());
     ExecutionRepository.ExecutionCriteria executionCriteria = new ExecutionRepository.ExecutionCriteria()
-      .setLimit(limit)
+      .setPageSize(limit)
       .setStatuses(statusesList);
 
     // Users of the ad-hoc endpoint can either omit application or pass 'ad-hoc' explicitly.


### PR DESCRIPTION
* chore(orca): Bump Orca to 6.139.0
* fix(canary/orca): Replace limit with pageSize 
The `limit` parameter was replaced with `pageSize` in
spinnaker/orca#2593