### PR TITLE
fix(MixerService): properly handle missing metrics

### DIFF
--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/metrics/AtlasMetricsService.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/metrics/AtlasMetricsService.java
@@ -164,6 +164,7 @@ public class AtlasMetricsService implements MetricsService {
 
     for (AtlasResults atlasResults : idToAtlasResultsMap.values()) {
       Instant responseStartTimeInstant = Instant.ofEpochMilli(atlasResults.getStart());
+      Instant responseEndTimeInstant = Instant.ofEpochMilli(atlasResults.getEnd());
       List<Double> timeSeriesList = atlasResults.getData().getValues();
 
       if (timeSeriesList == null) {
@@ -175,6 +176,8 @@ public class AtlasMetricsService implements MetricsService {
           .name(canaryMetricConfig.getName())
           .startTimeMillis(atlasResults.getStart())
           .startTimeIso(responseStartTimeInstant.toString())
+          .endTimeMillis(atlasResults.getEnd())
+          .endTimeIso(responseEndTimeInstant.toString())
           .stepMillis(atlasResults.getStep())
           .values(timeSeriesList);
 

--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryExecutionRequest.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryExecutionRequest.java
@@ -15,7 +15,7 @@
  */
 package com.netflix.kayenta.canary;
 
-import lombok.Data;
+import lombok.*;
 
 import javax.validation.constraints.NotNull;
 import java.time.Duration;
@@ -25,7 +25,12 @@ import java.util.Map;
 import java.util.Set;
 
 @Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class CanaryExecutionRequest {
+
+  @Singular
   @NotNull
   protected Map<String, CanaryScopePair> scopes;
 

--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryScope.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryScope.java
@@ -16,6 +16,7 @@
 package com.netflix.kayenta.canary;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -25,6 +26,7 @@ import java.time.Instant;
 import java.util.Map;
 
 @Data
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class CanaryScope {

--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryScopePair.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryScopePair.java
@@ -15,11 +15,17 @@
  */
 package com.netflix.kayenta.canary;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 
 @Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class CanaryScopePair {
   @NotNull
   CanaryScope controlScope;

--- a/kayenta-graphite/src/integration-test/java/com/netflix/kayenta/graphite/E2EIntegrationTest.java
+++ b/kayenta-graphite/src/integration-test/java/com/netflix/kayenta/graphite/E2EIntegrationTest.java
@@ -115,9 +115,10 @@ public class E2EIntegrationTest {
             .setStart(metricsReportingStartTime)
             .setEnd(end);
 
-        CanaryScopePair canaryScopePair = new CanaryScopePair();
-        canaryScopePair.setControlScope(control);
-        canaryScopePair.setExperimentScope(experiment);
+        CanaryScopePair canaryScopePair = CanaryScopePair.builder()
+          .controlScope(control)
+          .experimentScope(experiment)
+          .build();
         executionRequest.setScopes(ImmutableMap.of("default", canaryScopePair));
         request.setExecutionRequest(executionRequest);
 

--- a/kayenta-standalone-canary-analysis/src/main/java/com/netflix/kayenta/canaryanalysis/orca/stage/SetupAndExecuteCanariesStage.java
+++ b/kayenta-standalone-canary-analysis/src/main/java/com/netflix/kayenta/canaryanalysis/orca/stage/SetupAndExecuteCanariesStage.java
@@ -209,9 +209,10 @@ public class SetupAndExecuteCanariesStage implements StageDefinitionBuilder {
           scope.getExtendedScopeParams()
       );
 
-      CanaryScopePair canaryScopePair = new CanaryScopePair()
-          .setControlScope(controlScope)
-          .setExperimentScope(experimentScope);
+      CanaryScopePair canaryScopePair = CanaryScopePair.builder()
+          .controlScope(controlScope)
+          .experimentScope(experimentScope)
+          .build();
 
       scopes.put(scope.getScopeName(), canaryScopePair);
     });

--- a/kayenta-standalone-canary-analysis/src/main/java/com/netflix/kayenta/canaryanalysis/orca/task/RunCanaryTask.java
+++ b/kayenta-standalone-canary-analysis/src/main/java/com/netflix/kayenta/canaryanalysis/orca/task/RunCanaryTask.java
@@ -75,10 +75,11 @@ public class RunCanaryTask implements Task {
     CanaryAdhocExecutionRequest request = new CanaryAdhocExecutionRequest();
     request.setCanaryConfig(context.getCanaryConfig());
 
-    CanaryExecutionRequest executionRequest = new CanaryExecutionRequest()
-        .setScopes(context.getScopes())
-        .setThresholds(context.getScoreThresholds())
-        .setSiteLocal(context.getSiteLocal());
+    CanaryExecutionRequest executionRequest = CanaryExecutionRequest.builder()
+        .scopes(context.getScopes())
+        .thresholds(context.getScoreThresholds())
+        .siteLocal(context.getSiteLocal())
+        .build();
 
     request.setExecutionRequest(executionRequest);
 


### PR DESCRIPTION
Potentially breaking change:  I'm not sure all metric services will behave properly here.

Real world bug this fixes:  One of control/experiment has data with tags, the other has no data and Atlas fakes up a placeholder metric.  When these are paired, the metric mixer then generates empty arrays for the tags AND for the empty tag list "metric" we faked up to pair.  The judge currently expects arrays of NaNs, not empty arrays, as its contract.

This restructures how the mixer service works, which currently uses a placeholder that the metric service must insert when no data was returned.  This feels like we could instead use the metric's runtime scope to derive the number of points expected, but that means we would lose the query attributes for the UI to provide.  Additionally, while the scope has a requested step size, the metric service can return what was actually used, and that could differ.

The main purpose of the placeholder is to provide the UI hints to point to the data explorer, so the user can dig in if they wish to metrics.  In an ideal world, the metric service would provide some sort of templated query that could then have the tag keys and values inserted prior to the UI rendering the links...  but that's another PR.