### PR TITLE
refactor(signalfx): add additional test metrics to integration canary config

### DIFF
--- a/kayenta-signalfx/src/integration-test/resources/integration-test-canary-config.json
+++ b/kayenta-signalfx/src/integration-test/resources/integration-test-canary-config.json
@@ -51,6 +51,44 @@
         "Integration Test Group"
       ],
       "scopeName": "default"
+    },
+    {
+      "name": "an error count metric, that doesn't exist",
+      "query": {
+        "metricName": "kayenta.integration-test.errors.count",
+        "aggregationMethod": "sum",
+        "serviceType": "signalfx",
+        "type": "signalfx"
+      },
+      "analysisConfigurations": {
+        "canary": {
+          "direction": "increase",
+          "nanStrategy": "replace",
+          "critical" : true
+        }
+      },
+      "groups": [
+        "Integration Test Group"
+      ],
+      "scopeName": "default"
+    },
+    {
+      "name": "another error count metric, that doesn't exist",
+      "query": {
+        "metricName": "kayenta.integration-test.errors2.count",
+        "aggregationMethod": "sum",
+        "serviceType": "signalfx",
+        "type": "signalfx"
+      },
+      "analysisConfigurations": {
+        "canary": {
+          "direction": "increase"
+        }
+      },
+      "groups": [
+        "Integration Test Group"
+      ],
+      "scopeName": "default"
     }
   ],
   "classifier": {


### PR DESCRIPTION
This adds a couple metrics to the integration test canary config that massages logic around when metrics do not report data. 

I made this to test https://github.com/spinnaker/kayenta/pull/499, the integration tests still pass as expected.