### PR TITLE
feat(atlas): Find atlas back-end by accountId

### DIFF
--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/backends/AtlasStorageDatabase.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/backends/AtlasStorageDatabase.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.atlas.backends;
+
+import com.netflix.kayenta.atlas.model.AtlasStorage;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class AtlasStorageDatabase {
+
+  private Map<String, AtlasStorage> atlasStorages = new HashMap<>();
+
+  public synchronized Optional<String> getGlobalUri(String scheme, String accountId) {
+    Optional<String> uri = atlasStorages.entrySet().stream()
+      .filter(map -> map.getKey().equals(accountId))
+      .findFirst()
+      .map(Map.Entry::getValue)
+      .map(AtlasStorage::getGlobal)
+      .map(s -> scheme + "://" + s);
+    return uri;
+  }
+
+  public synchronized Optional<String> getRegionalUri(String scheme, String accountId, String region) {
+    Optional<String> uri = atlasStorages.entrySet().stream()
+      .filter(map -> map.getKey().equals(accountId))
+      .findFirst()
+      .map(Map.Entry::getValue)
+      .flatMap(s -> s.getRegionalCnameForRegion(region))
+      .map(s -> scheme + "://" + s);
+    return uri;
+  }
+
+  public synchronized void update(Map<String, Map<String, AtlasStorage>> newAtlasStorages) {
+    if (!newAtlasStorages.containsKey("atlas_storage")) {
+      throw new IllegalArgumentException("Expected fetched AtlasStorage URI to contain a top level key 'atlas_storage'");
+    }
+    atlasStorages = newAtlasStorages.get("atlas_storage");
+  }
+}

--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/backends/AtlasStorageUpdater.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/backends/AtlasStorageUpdater.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.kayenta.atlas.backends;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.kayenta.atlas.model.AtlasStorage;
+import com.netflix.kayenta.atlas.service.AtlasStorageRemoteService;
+import com.netflix.kayenta.retrofit.config.RemoteService;
+import com.netflix.kayenta.retrofit.config.RetrofitClientFactory;
+import com.squareup.okhttp.OkHttpClient;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import retrofit.RetrofitError;
+import retrofit.converter.JacksonConverter;
+
+import javax.validation.constraints.NotNull;
+import java.util.Map;
+
+@Slf4j
+@Builder
+public class AtlasStorageUpdater {
+  @Getter
+  private final AtlasStorageDatabase atlasStorageDatabase = new AtlasStorageDatabase();
+
+  @NotNull
+  private String uri;
+
+  // If we have retrieved backends.json at least once, we will keep using it forever
+  // even if we fail later.  It doesn't really change much over time, so this
+  // is likely safe enough.
+  @Builder.Default
+  private boolean succeededAtLeastOnce = false;
+
+  boolean run(RetrofitClientFactory retrofitClientFactory, ObjectMapper objectMapper, OkHttpClient okHttpClient) {
+    RemoteService remoteService = new RemoteService();
+    remoteService.setBaseUrl(uri);
+    AtlasStorageRemoteService atlasStorageRemoteService = retrofitClientFactory.createClient(AtlasStorageRemoteService.class,
+                                                                                             new JacksonConverter(objectMapper),
+                                                                                             remoteService,
+                                                                                             okHttpClient);
+    try {
+      Map<String, Map<String, AtlasStorage>> atlasStorageMap = atlasStorageRemoteService.fetch();
+      atlasStorageDatabase.update(atlasStorageMap);
+    } catch (RetrofitError e) {
+      log.warn("While fetching atlas backends from " + uri, e);
+      return succeededAtLeastOnce;
+    }
+    succeededAtLeastOnce = true;
+    return true;
+  }
+}

--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/backends/AtlasStorageUpdaterService.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/backends/AtlasStorageUpdaterService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2019 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -34,15 +34,15 @@ import java.util.List;
 @Slf4j
 @EnableConfigurationProperties
 @ConditionalOnProperty("kayenta.atlas.enabled")
-public class BackendUpdaterService extends AbstractHealthIndicator {
+public class AtlasStorageUpdaterService extends AbstractHealthIndicator {
   private final RetrofitClientFactory retrofitClientFactory;
   private final ObjectMapper objectMapper;
   private final OkHttpClient okHttpClient;
-  private final List<BackendUpdater> backendUpdaters = new ArrayList<>();
+  private final List<AtlasStorageUpdater> atlasStorageUpdaters = new ArrayList<>();
   private int checksCompleted = 0;
 
   @Autowired
-  public BackendUpdaterService(RetrofitClientFactory retrofitClientFactory, ObjectMapper objectMapper, OkHttpClient okHttpClient) {
+  public AtlasStorageUpdaterService(RetrofitClientFactory retrofitClientFactory, ObjectMapper objectMapper, OkHttpClient okHttpClient) {
     this.retrofitClientFactory = retrofitClientFactory;
     this.objectMapper = objectMapper;
     this.okHttpClient = okHttpClient;
@@ -55,7 +55,7 @@ public class BackendUpdaterService extends AbstractHealthIndicator {
     // TODO: Locking may not matter as we should rarely, if ever, modify this list.
     // TODO: Although, for healthcheck, it may...
     int checks = 0;
-    for (BackendUpdater updater: backendUpdaters) {
+    for (AtlasStorageUpdater updater: atlasStorageUpdaters) {
       synchronized(this) {
         boolean result = updater.run(retrofitClientFactory, objectMapper, okHttpClient);
         if (result)
@@ -65,18 +65,18 @@ public class BackendUpdaterService extends AbstractHealthIndicator {
     checksCompleted = checks;
   }
 
-  public synchronized void add(BackendUpdater updater) {
-    backendUpdaters.add(updater);
+  public synchronized void add(AtlasStorageUpdater updater) {
+    atlasStorageUpdaters.add(updater);
   }
 
   @Override
   protected synchronized void doHealthCheck(Health.Builder builder) throws Exception {
-    if (checksCompleted == backendUpdaters.size()) {
+    if (checksCompleted == atlasStorageUpdaters.size()) {
       builder.up();
     } else {
       builder.down();
     }
     builder.withDetail("checksCompleted", checksCompleted);
-    builder.withDetail("checksExpected", backendUpdaters.size());
+    builder.withDetail("checksExpected", atlasStorageUpdaters.size());
   }
 }

--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/canary/AtlasCanaryScope.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/canary/AtlasCanaryScope.java
@@ -40,6 +40,8 @@ public class AtlasCanaryScope extends CanaryScope {
   @NotNull
   private String environment;
 
+  private String accountId; // AWS or other account ID we will use to look up the atlas back-end for.
+
   public String cq() {
     if (type == null) {
       throw new IllegalArgumentException("Atlas canary scope requires 'type' to be asg, cluster, or query.");

--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/canary/AtlasCanaryScopeFactory.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/canary/AtlasCanaryScopeFactory.java
@@ -50,6 +50,7 @@ public class AtlasCanaryScopeFactory implements CanaryScopeFactory {
     atlasCanaryScope.setDeployment(extendedScopeParams.getOrDefault("deployment", "main"));
     atlasCanaryScope.setDataset(extendedScopeParams.getOrDefault("dataset", "regional"));
     atlasCanaryScope.setEnvironment(extendedScopeParams.getOrDefault("environment", "test"));
+    atlasCanaryScope.setAccountId(extendedScopeParams.get("accountId"));
 
     return atlasCanaryScope;
   }

--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/config/AtlasConfiguration.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/config/AtlasConfiguration.java
@@ -16,6 +16,8 @@
 
 package com.netflix.kayenta.atlas.config;
 
+import com.netflix.kayenta.atlas.backends.AtlasStorageUpdater;
+import com.netflix.kayenta.atlas.backends.AtlasStorageUpdaterService;
 import com.netflix.kayenta.atlas.backends.BackendUpdater;
 import com.netflix.kayenta.atlas.backends.BackendUpdaterService;
 import com.netflix.kayenta.atlas.metrics.AtlasMetricsService;
@@ -44,10 +46,12 @@ import java.util.List;
 @Slf4j
 public class AtlasConfiguration {
 
+  private final AtlasStorageUpdaterService atlasStorageUpdaterService;
   private final BackendUpdaterService backendUpdaterService;
 
   @Autowired
-  public AtlasConfiguration(BackendUpdaterService backendUpdaterService) {
+  public AtlasConfiguration(AtlasStorageUpdaterService atlasStorageUpdaterService, BackendUpdaterService backendUpdaterService) {
+    this.atlasStorageUpdaterService = atlasStorageUpdaterService;
     this.backendUpdaterService = backendUpdaterService;
   }
 
@@ -74,7 +78,8 @@ public class AtlasConfiguration {
           .builder()
           .build();
 
-      BackendUpdater updater = BackendUpdater.builder().uri(backendsJsonUriPrefix).build();
+      BackendUpdater backendUpdater = BackendUpdater.builder().uri(backendsJsonUriPrefix).build();
+      AtlasStorageUpdater atlasStorageUpdater = AtlasStorageUpdater.builder().uri(backendsJsonUriPrefix).build();
       AtlasNamedAccountCredentials.AtlasNamedAccountCredentialsBuilder atlasNamedAccountCredentialsBuilder =
         AtlasNamedAccountCredentials
           .builder()
@@ -82,7 +87,8 @@ public class AtlasConfiguration {
           .credentials(atlasCredentials)
           .fetchId(atlasManagedAccount.getFetchId())
           .recommendedLocations(atlasManagedAccount.getRecommendedLocations())
-          .backendUpdater(updater);
+          .atlasStorageUpdater(atlasStorageUpdater)
+          .backendUpdater(backendUpdater);
 
       if (!CollectionUtils.isEmpty(supportedTypes)) {
         atlasNamedAccountCredentialsBuilder.supportedTypes(supportedTypes);
@@ -93,6 +99,7 @@ public class AtlasConfiguration {
       atlasMetricsServiceBuilder.accountName(name);
 
       backendUpdaterService.add(atlasNamedAccountCredentials.getBackendUpdater());
+      atlasStorageUpdaterService.add(atlasNamedAccountCredentials.getAtlasStorageUpdater());
     }
 
     AtlasMetricsService atlasMetricsService = atlasMetricsServiceBuilder.build();

--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/model/AtlasStorage.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/model/AtlasStorage.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.kayenta.atlas.model;
+
+import lombok.*;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Optional;
+
+@Builder
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+public class AtlasStorage {
+
+  @NotNull
+  @Getter
+  private String global;
+
+  @NotNull
+  @Getter
+  private String regional;
+
+  @NotNull
+  @Getter
+  private List<String> regions;
+
+  public Optional<String> getRegionalCnameForRegion(String region) {
+    if (regions.contains(region)) {
+      return Optional.of(regional.replace("$(region)", region));
+    } else {
+      return Optional.empty();
+    }
+  }
+}

--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/model/Backend.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/model/Backend.java
@@ -35,7 +35,6 @@ import lombok.*;
 
 import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/security/AtlasNamedAccountCredentials.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/security/AtlasNamedAccountCredentials.java
@@ -17,6 +17,7 @@
 package com.netflix.kayenta.atlas.security;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.netflix.kayenta.atlas.backends.AtlasStorageUpdater;
 import com.netflix.kayenta.atlas.backends.BackendUpdater;
 import com.netflix.kayenta.security.AccountCredentials;
 import lombok.Builder;
@@ -52,6 +53,9 @@ public class AtlasNamedAccountCredentials implements AccountCredentials<AtlasCre
 
   @JsonIgnore
   private BackendUpdater backendUpdater;
+
+  @JsonIgnore
+  private AtlasStorageUpdater atlasStorageUpdater;
 
   @Override
   public List<String> getLocations() {

--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/service/AtlasStorageRemoteService.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/service/AtlasStorageRemoteService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.kayenta.atlas.service;
+
+import com.netflix.kayenta.atlas.model.AtlasStorage;
+import retrofit.http.GET;
+
+import java.util.Map;
+
+public interface AtlasStorageRemoteService {
+
+  @GET("/api/v1/atlas/storage.json")
+  Map<String, Map<String, AtlasStorage>> fetch();
+}


### PR DESCRIPTION
Add support for going from an accountId (usually an AWS account ID string) to an atlas backend which stores data for that account.

This change adds another magic URL (which I should document) to the Atlas back-end.  This database consists of a set of account IDs to Atlas back-ends.  This makes kayenta-atlas more Netflix specific, but I can address this later should anyone show interest in using Atlas outside of Netflix.
