### PR TITLE
fix(judge): Incorrect Effect Size with Zero Means (#510)

### DIFF
--- a/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/stats/EffectSizes.scala
+++ b/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/stats/EffectSizes.scala
@@ -14,8 +14,9 @@ object EffectSizes {
     * Note: This is included for backwards compatibility
     */
   def meanRatio(control: Array[Double], experiment: Array[Double]): Double = {
-    require(StatUtils.mean(control) != 0.0, "the mean of the control must be non-zero")
-    StatUtils.mean(experiment)/StatUtils.mean(control)
+    val controlMean = StatUtils.mean(control)
+    val experimentMean = StatUtils.mean(experiment)
+    if(controlMean == 0.0 || experimentMean == 0.0) Double.NaN else experimentMean/controlMean
   }
 
   /**
@@ -24,8 +25,7 @@ object EffectSizes {
     * Note: This is included for backwards compatibility
     */
   def meanRatio(control: Metric, experiment: Metric): Double = {
-    require(mean(control) != 0.0, "the mean of the control must be non-zero")
-    mean(experiment)/mean(control)
+    meanRatio(control.values, experiment.values)
   }
 
   /**
@@ -34,8 +34,7 @@ object EffectSizes {
     * Note: This is included for backwards compatibility
     */
   def meanRatio(control: MetricStatistics, experiment: MetricStatistics): Double = {
-    require(control.mean != 0.0, "the mean of the control must be non-zero")
-    experiment.mean/control.mean
+    if(control.mean == 0.0 || experiment.mean == 0.0) Double.NaN else experiment.mean/control.mean
   }
 
   /**

--- a/kayenta-judge/src/test/scala/com/netflix/kayenta/judge/ClassifierSuite.scala
+++ b/kayenta-judge/src/test/scala/com/netflix/kayenta/judge/ClassifierSuite.scala
@@ -638,6 +638,67 @@ class ClassifierSuite extends FunSuite{
     assert(result.classification == High)
   }
 
+  test("Mann-Whitney Zero Mean: High Metric with Effect Size"){
+    val experimentData =  Array(54.9, 54.5, 55.1, 55.6, 57.4)
+    val controlData = Array(0.0, 0.0, 0.0, 0.0, 0.0)
+
+    val experimentMetric = Metric("high-metric", experimentData, "canary")
+    val controlMetric = Metric("high-metric", controlData, "baseline")
+
+    val classifier = new MannWhitneyClassifier(tolerance = 0.10, confLevel = 0.95, effectSizeThresholds = (0.8, 1.2))
+    val result = classifier.classify(controlMetric, experimentMetric, MetricDirection.Either)
+
+    assert(result.classification == High)
+    assert(result.deviation.isNaN)
+  }
+
+  test("Mann-Whitney Zero Mean: Low Metric with Effect Size"){
+    val experimentData =  Array(0.0, 0.0, 0.0, 0.0, 0.0)
+    val controlData = Array(54.9, 54.5, 55.1, 55.6, 57.4)
+
+    val experimentMetric = Metric("low-metric", experimentData, "canary")
+    val controlMetric = Metric("low-metric", controlData, "baseline")
+
+    val classifier = new MannWhitneyClassifier(tolerance = 0.10, confLevel = 0.95, effectSizeThresholds = (0.8, 1.2))
+    val result = classifier.classify(controlMetric, experimentMetric, MetricDirection.Either)
+
+    assert(result.classification == Low)
+    assert(result.deviation.isNaN)
+  }
+
+  test("Mann-Whitney Zero Mean: Critical Metric"){
+    val experimentData = Array(
+      0.05000000074505806, 0.05000000074505806, 0.01666666753590107,
+      0.01666666753590107, 0.01666666753590107, 0.05000000074505806,
+      0.03333333507180214, 0.05000000260770321, 0.05000000260770321,
+      0.13333333656191826,
+    )
+    val controlData = Array(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+    val experimentMetric = Metric("high-metric", experimentData, "canary")
+    val controlMetric = Metric("high-metric", controlData, "baseline")
+
+    val classifier = new MannWhitneyClassifier(tolerance = 0.10, confLevel = 0.95, criticalThresholds=(0.8, 1.2))
+    val result = classifier.classify(controlMetric, experimentMetric, MetricDirection.Either, NaNStrategy.Replace, isCriticalMetric = true)
+
+    assert(result.classification == High)
+    assert(result.critical)
+  }
+
+  test("Mann-Whitney Zero Mean: Pass Metric"){
+    val experimentData =  Array(0.0, 0.0, 0.0, 0.0, 0.0)
+    val controlData = Array(0.0, 0.0, 0.0, 0.0, 0.0)
+
+    val experimentMetric = Metric("pass-metric", experimentData, "canary")
+    val controlMetric = Metric("pass-metric", controlData, "baseline")
+
+    val classifier = new MannWhitneyClassifier(tolerance = 0.10, confLevel = 0.95, effectSizeThresholds = (0.8, 1.2))
+    val result = classifier.classify(controlMetric, experimentMetric, MetricDirection.Either)
+
+    assert(result.classification == Pass)
+    assert(result.deviation == 1.0)
+  }
+
   test("Mean Inequality Classifier Test: High Metric"){
     val experimentData = Array(10.0, 20.0, 30.0, 40.0, 50.0)
     val controlData = Array(1.0, 2.0, 3.0, 4.0, 5.0)

--- a/kayenta-judge/src/test/scala/com/netflix/kayenta/judge/StatisticSuite.scala
+++ b/kayenta-judge/src/test/scala/com/netflix/kayenta/judge/StatisticSuite.scala
@@ -113,7 +113,7 @@ class StatisticSuite extends FunSuite{
     val experimentStats = DescriptiveStatistics.summary(experimentMetric)
     val controlStats = DescriptiveStatistics.summary(controlMetric)
 
-    val result = EffectSizes.meanRatio(controlMetric, experimentMetric)
+    val result = EffectSizes.meanRatio(controlStats, experimentStats)
     assert(result === 1.0)
   }
 
@@ -146,9 +146,8 @@ class StatisticSuite extends FunSuite{
     val experimentMetric = Metric("high-metric", experimentData, "canary")
     val controlMetric = Metric("high-metric", controlData, "baseline")
 
-    assertThrows[IllegalArgumentException]{
-      EffectSizes.meanRatio(controlMetric, experimentMetric)
-    }
+    val result = EffectSizes.meanRatio(controlMetric, experimentMetric)
+    assert(result.isNaN)
   }
 
   test("Effect Size: Cohen's D"){


### PR DESCRIPTION
In the scenario where the experiment or control metric has a mean of zero, the effect size (mean ratio) should not be computed and should be reported as NaN. In addition, the effect size comparison should be ignored when the statistic cannot be computed.