### PR TITLE
fix(datadog): Create MetricSet placeholder

### DIFF
--- a/kayenta-datadog/src/main/java/com/netflix/kayenta/datadog/metrics/DatadogMetricsService.java
+++ b/kayenta-datadog/src/main/java/com/netflix/kayenta/datadog/metrics/DatadogMetricsService.java
@@ -133,6 +133,22 @@ public class DatadogMetricsService implements MetricsService {
       );
     }
 
+    if (ret.isEmpty()) {
+      // Add placeholder metric set.
+      ret.add(
+        MetricSet.builder()
+          .name(canaryMetricConfig.getName())
+          .startTimeMillis(canaryScope.getStart().toEpochMilli())
+          .startTimeIso(canaryScope.getStart().toString())
+          .endTimeMillis(canaryScope.getEnd().toEpochMilli())
+          .endTimeIso(canaryScope.getEnd().toString())
+          .stepMillis(1000)
+          .values(new ArrayList<>())
+          .attribute("query", query)
+          .build()
+      );
+    }
+
     return ret;
   }
 


### PR DESCRIPTION
**fix(datadog): Support placeholder metrics in `DatadogMetricsService`**

DatadogMetricsService currently returns an empty `List<MetricSet>` if no metrics can be found for some `canaryConfig` and `scope`.  This can result in complete CanaryAnalysis stage failure if one metric cannot be found for a CanaryConfig.

This can be frustrating in several cases:
- An application chooses to stop publishing a metric, but does not update the CanaryConfig.
- An application publishes some, but not all, metrics needed for a shared CanaryConfig that it references.

Kayenta already gracefully supports a lack of MetricSet values. This change will leverage that support by creating an empty placeholder metric when Datadog fails to return any metric.

References:
[Stackdriver placeholder example](https://github.com/spinnaker/kayenta/blob/master/kayenta-stackdriver/src/main/java/com/netflix/kayenta/stackdriver/metrics/StackdriverMetricsService.java#L316-L319)
[Error raised without Datadog placeholder](https://github.com/spinnaker/kayenta/blob/084a1a7d771ba1d42a54510bf730c796dbb891a5/kayenta-core/src/main/java/com/netflix/kayenta/metrics/MetricSetMixerService.java#L184)

![UI failure when an existing metric cannot be found for a control scope tag](https://user-images.githubusercontent.com/4308672/57959549-37aedb80-78b9-11e9-8904-4a5e4b841623.png)