### PR TITLE
chore(core): replace runtime with runtimeOnly in kayenta-web.gradle

### DIFF
--- a/kayenta-web/kayenta-web.gradle
+++ b/kayenta-web/kayenta-web.gradle
@@ -37,5 +37,5 @@ dependencies {
 
   implementation "org.springframework.boot:spring-boot-starter-actuator"
   implementation "com.netflix.spinnaker.kork:kork-web"
-  runtime "com.netflix.spinnaker.kork:kork-secrets-aws"
+  runtimeOnly "com.netflix.spinnaker.kork:kork-secrets-aws"
 }


### PR DESCRIPTION
according to [gradle docs](https://docs.gradle.org/5.3.1/userguide/java_plugin.html#sec:java_plugin_and_dependency_management)

`runtime` is a deprecated scope and we should be using `runtimeOnly`