### PR TITLE
feat(signalfx): Add configurable remote baseurls to support realms.

### DIFF
--- a/kayenta-signalfx/README.md
+++ b/kayenta-signalfx/README.md
@@ -9,7 +9,10 @@ This module adds support to Kayenta to use SignalFx as a metric source.
     enabled: true
     accounts:
     - name: sfx-integration-test-account
-      accessToken: ${kayenta.signalfx.apiKey}
+      accessToken: ${kayenta.signalfx.apiKey} # The sfx api token
+      endpoint.baseUrl: https://stream.signalfx.com # Optional defaults to https://stream.signalfx.com
+      defaultScopeKey: server_scope # Optional, if omitted every request must supply the _scope_key param in extended scope params
+      defaultLocationKey: server_region # Optional, if omitted requests must supply the _location_key if it is needed.
       supportedTypes:
       - METRICS_STORE
 ```

--- a/kayenta-signalfx/src/integration-test/resources/config/kayenta.yml
+++ b/kayenta-signalfx/src/integration-test/resources/config/kayenta.yml
@@ -1,33 +1,7 @@
 redis:
   connection: redis://localhost:${redis.port}
 
-#retrofit:
-#  logLevel: FULL
-
 kayenta:
-  atlas:
-    enabled: false
-
-  google:
-    enabled: false
-
-  aws:
-    enabled: false
-
-  datadog:
-    enabled: false
-
-  prometheus:
-    enabled: false
-
-  influxdb:
-    enabled: false
-
-  gcs:
-    enabled: false
-
-  s3:
-    enabled: false
 
   signalfx:
     enabled: true
@@ -38,9 +12,6 @@ kayenta:
       - METRICS_STORE
       defaultScopeKey: canary-scope
       defaultLocationKey: location
-
-  stackdriver:
-    enabled: false
 
   memory:
     enabled: true
@@ -54,8 +25,6 @@ kayenta:
 
   standaloneCanaryAnalysis.enabled: true
 
-management.security.enabled: false
-
 keiko:
   queue:
     redis:
@@ -66,23 +35,3 @@ spectator:
   applicationName: ${spring.application.name}
   webEndpoint:
     enabled: true
-
-swagger:
-  enabled: true
-  title: Kayenta API
-  description:
-  contact:
-  patterns:
-  - /admin.*
-  - /canary.*
-  - /canaryConfig.*
-  - /canaryJudgeResult.*
-  - /credentials.*
-  - /fetch.*
-  - /health
-  - /judges.*
-  - /metadata.*
-  - /metricSetList.*
-  - /metricSetPairList.*
-  - /pipeline.*
-  - /standalone.*

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/config/SignalFxConfiguration.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/config/SignalFxConfiguration.java
@@ -39,6 +39,7 @@ import org.springframework.util.CollectionUtils;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Configuration
@@ -79,8 +80,8 @@ public class SignalFxConfiguration {
       List<AccountCredentials.Type> supportedTypes = signalFxManagedAccount.getSupportedTypes();
       SignalFxCredentials signalFxCredentials = new SignalFxCredentials(signalFxManagedAccount.getAccessToken());
 
-      final RemoteService signalFxSignalFlowEndpoint = new RemoteService()
-          .setBaseUrl(SIGNAL_FX_SIGNAL_FLOW_ENDPOINT_URI);
+      final RemoteService signalFxSignalFlowEndpoint = Optional.ofNullable(signalFxManagedAccount.getEndpoint())
+          .orElse(new RemoteService().setBaseUrl(SIGNAL_FX_SIGNAL_FLOW_ENDPOINT_URI));
 
       SignalFxNamedAccountCredentials.SignalFxNamedAccountCredentialsBuilder accountCredentialsBuilder =
           SignalFxNamedAccountCredentials

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/config/SignalFxManagedAccount.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/config/SignalFxManagedAccount.java
@@ -17,6 +17,7 @@
 
 package com.netflix.kayenta.signalfx.config;
 
+import com.netflix.kayenta.retrofit.config.RemoteService;
 import com.netflix.kayenta.security.AccountCredentials;
 import lombok.Data;
 
@@ -33,6 +34,9 @@ public class SignalFxManagedAccount {
   private String accessToken;
 
   private List<AccountCredentials.Type> supportedTypes;
+
+  @Nullable
+  private RemoteService endpoint;
 
   @Nullable
   private String defaultScopeKey;

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/service/SignalFxRequestError.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/service/SignalFxRequestError.java
@@ -17,6 +17,8 @@
 
 package com.netflix.kayenta.signalfx.service;
 
+import java.util.Optional;
+
 public class SignalFxRequestError extends RuntimeException {
 
   private static final String MSG_TEMPLATE =
@@ -26,6 +28,7 @@ public class SignalFxRequestError extends RuntimeException {
   public SignalFxRequestError(ErrorResponse errorResponse, String program, long start, long end,
                               long resolution, String accountName) {
 
-    super(String.format(MSG_TEMPLATE, program, start, end, resolution, accountName, errorResponse.toString()));
+    super(String.format(MSG_TEMPLATE, program, start, end, resolution, accountName,
+        errorResponse != null ? errorResponse.toString() : "no response received from Signal Fx"));
   }
 }


### PR DESCRIPTION
Fixes #549 

Context: This metric source originally had support for this like the other metrics sources, but I couldn't find evidence at the time (not sure if realms are new or not) that the endpoint ever changed. So I had removed the configurable option and hard coded the endpoint url. [See this conversation for more details.](https://github.com/spinnaker/kayenta/pull/385#discussion_r225203024) This PR brings it back since someone has asked for it.