### PR TITLE
fix(kayenta): Fix management endpoints configuration after migration to Spring Boot 2

### DIFF
--- a/kayenta-web/config/kayenta.yml
+++ b/kayenta-web/config/kayenta.yml
@@ -115,7 +115,9 @@ kayenta:
 #    endpoint:
 #      baseUrl: http://remotejudge.example.com/path/to/service
 
-management.security.enabled: false
+
+management.endpoints.web.exposure.include: '*'
+management.endpoint.health.show-details: always
 
 keiko:
   queue:


### PR DESCRIPTION
`management.security.enabled` is removed from Spring Boot 2.