### PR TITLE
Workaround prom templating issues

### DIFF
--- a/kayenta-prometheus/src/main/java/com/netflix/kayenta/canary/providers/metrics/PrometheusCanaryMetricSetQueryConfig.java
+++ b/kayenta-prometheus/src/main/java/com/netflix/kayenta/canary/providers/metrics/PrometheusCanaryMetricSetQueryConfig.java
@@ -45,6 +45,15 @@ public class PrometheusCanaryMetricSetQueryConfig implements CanaryMetricSetQuer
   @Getter
   private List<String> groupByFields;
 
+  @Getter
+  private List<String> functions;
+
+  @Getter
+  private String scopeLabel;
+
+  @Getter
+  private String locationLabel;
+
   /**
    * @deprecated Use customInlineTemplate instead.
    */

--- a/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/controllers/PrometheusFetchController.java
+++ b/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/controllers/PrometheusFetchController.java
@@ -63,6 +63,7 @@ public class PrometheusFetchController {
                           @RequestParam(required = false) final String storageAccountName,
                           @ApiParam(defaultValue = "cpu") @RequestParam String metricSetName,
                           @ApiParam(defaultValue = "node_cpu") @RequestParam String metricName,
+                          @RequestParam(required = false) List<String> functions,
                           @RequestParam(required = false) List<String> groupByFields,
                           @RequestParam(required = false) String project,
                           @ApiParam(value = "Used to identify the type of the resource being queried, " +
@@ -74,6 +75,10 @@ public class PrometheusFetchController {
                           @ApiParam(value = "The name of the resource to use when scoping the query. " +
                                             "The most common use-case is to provide a server group name.")
                             @RequestParam(required = false) String scope,
+                          @ApiParam(value = "The prom key to set to the location.")
+                            @RequestParam(required = false) String locationLabel,
+                          @ApiParam(value = "The prom key to set to the scope.")
+                            @RequestParam(required = false) String scopeLabel,
                           @ApiParam(defaultValue = "mode=~\"user|system\"")
                             @RequestParam(required = false) List<String> labelBindings,
                           @ApiParam(value = "An ISO format timestamp, e.g.: 2018-03-08T01:02:53Z")
@@ -104,7 +109,10 @@ public class PrometheusFetchController {
         .builder()
         .metricName(metricName)
         .labelBindings(labelBindings)
-        .groupByFields(groupByFields);
+        .groupByFields(groupByFields)
+        .functions(functions)
+        .scopeLabel(scopeLabel)
+        .locationLabel(locationLabel);
 
     if (!StringUtils.isEmpty(resourceType)) {
       prometheusCanaryMetricSetQueryConfigBuilder.resourceType(resourceType);


### PR DESCRIPTION
This PR is a workaround issues we've had using templating with prometheus.  For more context see https://github.com/spinnaker/spinnaker/issues/4235

Sorry ahead of time for my use of terminology.  I'm a spinnaker n00bie and may misuse terms.

It seems that the prometheus service is properly able to parse the template and fetch the appropriate metrics when watching the logs.  However, orca? `c.n.s.o.p.u.ContextParameterProcessor` is also trying to process the templating and fails which fails the whole pipeline.

This PR works around that by not passing any `${}` anywhere so orca doesn't try to process it and fail.  We added some query config parameters to still allow building "complex" prom queries without using `${}` templating.

Basically, with a metric query config like:

```
        "query": {
          "type": "prometheus",
          "metricName": "num_of_404s",
          "customInlineTemplate": "PromQL:sum(irate(statuses{code=\"404\",kubernetes_name=\"${scope}\"}[5m]))",
          "serviceType": "prometheus"
        },
...
    "scopes": [
      {
        "scopeName": "default",
        "controlScope": "my-control",
        "experimentScope": "my-experiment",
        "step": 10
      }
    ],
```

We would expect queries of:
* control: `PromQL:sum(irate(statuses{code="404",kubernetes_name="my-control"}[5m]))`
* experiment: `PromQL:sum(irate(statuses{code="404",kubernetes_name="my-experiment"}[5m]))`

With this workaround you would achieve this instead with the following metrics query config:

```
        "query": {
          "type": "prometheus",
          "metricName": "statuses",
          "scopeLabel": "kubernetes_name=",
          "functions": ["irate::[5m]", "sum::"],
          "customInlineTemplate": "code=\"404\"",
          "serviceType": "prometheus"
        },
```

We are using `scopeLabel` and `locationLabel` (not in example) to define the filters set from `scope` and `location` respectively.

We also added `functions` to allow building a PromQL query using functions.  It is parsed as `<functionName>:<beginning args>:<ending args>`.

I'm not necessarily advocating  having this merged.  But I'm trying to bring visibility to issues when trying to use Prom metrics in kayenta's current state.

IMO the real fix is having orca `c.n.s.o.p.u.ContextParameterProcessor` properly evaluate the expression.  It seems to me it doesn't even need to parse it, just pass it through to be consumed/processed by the prometheus service directly.
