### PR TITLE
fix(kayenta): remove spring-boot-properties-migrator from depedencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,6 @@ subprojects { project ->
       api "org.slf4j:slf4j-api"
       api "org.springframework.boot:spring-boot-starter-web"
       api "com.netflix.spinnaker.kork:kork-swagger"
-      api "org.springframework.boot:spring-boot-properties-migrator"
       api "com.netflix.spinnaker.orca:orca-core"
 
       api "com.squareup.retrofit:retrofit"


### PR DESCRIPTION
fix(kayenta): remove spring-boot-properties-migrator from depedencies as not needed after migration to Spring Boot 2
