### PR TITLE
fix(kayenta): Fixes generated pom.xml to omit invalid declaration of lombok

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,9 @@ buildscript {
     classpath "com.netflix.spinnaker.gradle:spinnaker-dev-plugin:$spinnakerGradleVersion"
     if (Boolean.valueOf(enablePublishing)) {
       classpath "com.netflix.spinnaker.gradle:spinnaker-gradle-project:$spinnakerGradleVersion"
+// TODO: nebula-publishing-plugin version override should be removed as soon as spinnaker-gradle-project is updated
+// this override is needed to omit compileOnly dependencies from generated pom.xml
+      classpath "com.netflix.nebula:nebula-publishing-plugin:12.0.1"
     }
 
     classpath "com.netflix.nebula:nebula-kotlin-plugin:$kotlinVersion"

--- a/kayenta-bom/kayenta-bom.gradle
+++ b/kayenta-bom/kayenta-bom.gradle
@@ -17,15 +17,9 @@
 apply plugin: "java-platform"
 apply plugin: "maven-publish"
 
-// without this building the pom fails when using the Nebula publishing plugin
-configurations {
-  create("compileOnly")
-}
-
 javaPlatform {
   allowDependencies()
 }
-
 
 if (Boolean.valueOf(enablePublishing)) {
   publishing {


### PR DESCRIPTION
Fixes generated pom.xml to omit invalid declaration of lombok dependency.

compileOnly dependency should not be added to generated pom.xml,
see discussion: https://discuss.gradle.org/t/publishing-plugin-should-respect-compileonly-configuration/22903/2

Current `pom.xml` of any kayenta-* dependency is broken and leads to the following output when is used in Maven project:
```
[WARNING] The POM for com.netflix.kayenta:kayenta-web:jar:2.2.1 is invalid, transitive dependencies (if any) will not be available, enable debug logging for more details
```
`kayenta-web` pom.xml contains the following invalid declaration:
<img width="562" alt="Screen Shot 2019-07-01 at 8 43 06 PM" src="https://user-images.githubusercontent.com/1207414/60456205-50910780-9c41-11e9-9dee-79b4acbc9452.png">
The issue with publishing compileOnly dependencies was fixed in latest `nebula-publishing-plugin` (https://github.com/nebula-plugins/nebula-publishing-plugin/commit/a5432aadc4b2886f1d9965361054d9614737c7df).
This PR contains override for the plugin version (it should be omitted as soon as `gradle-netflixoss-project-plugin` gets updated with latest nebula plugins).