### PR TITLE
chore(build): Add cloudbuild.yaml file

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,13 @@
+steps:
+- name: gcr.io/spinnaker-marketplace/gradle_cache
+  env: ["GRADLE_USER_HOME=/gradle_cache/.gradle"]
+  entrypoint: "bash"
+  args: ["-c", "./gradlew kayenta-web:installDist -x test"]
+- name: gcr.io/cloud-builders/docker
+  args: ["build", "-t", "gcr.io/$PROJECT_ID/$REPO_NAME:$TAG_NAME", "-f", "Dockerfile.slim", "."]
+  env: ["GRADLE_USER_HOME=/gradle_cache/.gradle"]
+images:
+- gcr.io/$PROJECT_ID/$REPO_NAME:$TAG_NAME
+timeout: 3600s
+options:
+  machineType: N1_HIGHCPU_8


### PR DESCRIPTION
Add a cloudbuild.yaml file that reproduces the one generated on-the-fly during the official build process.