### PR TITLE
feat(datadog): Support metric types and tags

### DIFF
--- a/kayenta-datadog/src/main/java/com/netflix/kayenta/canary/providers/metrics/DatadogCanaryMetricSetQueryConfig.java
+++ b/kayenta-datadog/src/main/java/com/netflix/kayenta/canary/providers/metrics/DatadogCanaryMetricSetQueryConfig.java
@@ -16,8 +16,12 @@
 
 package com.netflix.kayenta.canary.providers.metrics;
 
+import static java.util.Collections.emptyList;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.netflix.kayenta.canary.CanaryMetricSetQueryConfig;
+import java.util.List;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -32,9 +36,22 @@ import lombok.ToString;
 @JsonTypeName("datadog")
 public class DatadogCanaryMetricSetQueryConfig implements CanaryMetricSetQueryConfig {
 
+  public enum MetricType {
+    @JsonProperty("count")
+    COUNT,
+    @JsonProperty("gauge")
+    GAUGE,
+    @JsonProperty("rate")
+    RATE,
+  }
+
   public static final String SERVICE_TYPE = "datadog";
 
   @NotNull @Getter private String metricName;
+
+  @Builder.Default @NotNull @Getter private MetricType metricType = MetricType.GAUGE;
+
+  @Builder.Default @NotNull @Getter private List<String> tags = emptyList();
 
   @Override
   public String getServiceType() {

--- a/kayenta-datadog/src/main/java/com/netflix/kayenta/datadog/metrics/DatadogMetricsService.java
+++ b/kayenta-datadog/src/main/java/com/netflix/kayenta/datadog/metrics/DatadogMetricsService.java
@@ -87,15 +87,15 @@ public class DatadogMetricsService implements MetricsService {
       return composeCountQuery(metricName, scope, tags);
     }
     // Currently, treat Rate and Gauge the same.
-    return composeGuageQuery(metricName, scope, tags);
+    return composeGaugeQuery(metricName, scope, tags);
   }
 
   private String composeCountQuery(String metricName, String scope, List<String> tags) {
-    String guageQuery = composeGuageQuery(metricName, scope, tags);
-    return "sum:" + guageQuery + ".as_count()";
+    String gaugeQuery = composeGaugeQuery(metricName, scope, tags);
+    return "sum:" + gaugeQuery + ".as_count()";
   }
 
-  private String composeGuageQuery(String metricName, String scope, List<String> tags) {
+  private String composeGaugeQuery(String metricName, String scope, List<String> tags) {
     String tagString = scope;
     if (!tags.isEmpty()) {
       tagString += "," + tags.stream().collect(Collectors.joining(","));

--- a/kayenta-datadog/src/main/test/java/com/netflix/kayenta/datadog/metrics/DatadogMetricsServiceTest.java
+++ b/kayenta-datadog/src/main/test/java/com/netflix/kayenta/datadog/metrics/DatadogMetricsServiceTest.java
@@ -62,7 +62,7 @@ public class DatadogMetricsServiceTest {
   }
 
   @Test
-  public void buildGuageQuery() {
+  public void buildGaugeQuery() {
     when(mockDatadogCanaryMetricSetQueryConfig.getMetricType()).thenReturn(MetricType.GAUGE);
     String query = buildQuery();
     assertEquals(

--- a/kayenta-datadog/src/main/test/java/com/netflix/kayenta/datadog/metrics/DatadogMetricsServiceTest.java
+++ b/kayenta-datadog/src/main/test/java/com/netflix/kayenta/datadog/metrics/DatadogMetricsServiceTest.java
@@ -1,0 +1,89 @@
+package com.netflix.kayenta.datadog.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import com.netflix.kayenta.canary.CanaryConfig;
+import com.netflix.kayenta.canary.CanaryMetricConfig;
+import com.netflix.kayenta.canary.CanaryScope;
+import com.netflix.kayenta.canary.providers.metrics.DatadogCanaryMetricSetQueryConfig;
+import com.netflix.kayenta.canary.providers.metrics.DatadogCanaryMetricSetQueryConfig.MetricType;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DatadogMetricsServiceTest {
+
+  @Mock private List<String> mockAccountNames;
+
+  @Mock private CanaryConfig mockCanaryConfig;
+
+  @Mock private DatadogCanaryMetricSetQueryConfig mockDatadogCanaryMetricSetQueryConfig;
+
+  @Mock private CanaryMetricConfig mockCanaryMetricConfig;
+
+  @Mock private CanaryScope mockCanaryScope;
+
+  private final String metricsAccountName = "accountName";
+
+  private DatadogMetricsService datadogMetricsService;
+
+  private List<String> tags;
+
+  @BeforeEach
+  public void setUp() {
+    tags = Arrays.asList(new String[] {"status:200", "endpoint:getListings"});
+    datadogMetricsService = new datadogMetricsService(mockAccountNames);
+    when(mockCanaryScope.getScope()).thenReturn("kube_namespace:dora-canary");
+    when(mockDatadogCanaryMetricSetQueryConfig.getMetricName())
+        .thenReturn("services_platform.service.response.p95");
+    when(mockCanaryMetricConfig.getQuery()).thenReturn(mockDatadogCanaryMetricSetQueryConfig);
+    when(mockDatadogCanaryMetricSetQueryConfig.getTags()).thenReturn(tags);
+  }
+
+  private String buildQuery() {
+    return datadogMetricsService.buildQuery(
+        metricsAccountName, mockCanaryConfig, mockCanaryMetricConfig, mockCanaryScope);
+  }
+
+  @Test
+  public void buildCountQuery() {
+    when(mockDatadogCanaryMetricSetQueryConfig.getMetricType()).thenReturn(MetricType.COUNT);
+    String query = buildQuery();
+    assertEquals(
+        query,
+        "sum:services_platform.service.response.p95{kube_namespace:dora-canary,status:200,endpoint:getListings}.as_count()");
+  }
+
+  @Test
+  public void buildGuageQuery() {
+    when(mockDatadogCanaryMetricSetQueryConfig.getMetricType()).thenReturn(MetricType.GAUGE);
+    String query = buildQuery();
+    assertEquals(
+        query,
+        "services_platform.service.response.p95{kube_namespace:dora-canary,status:200,endpoint:getListings}");
+  }
+
+  @Test
+  public void buildRateQuery() {
+    when(mockDatadogCanaryMetricSetQueryConfig.getMetricType()).thenReturn(MetricType.RATE);
+    String query = buildQuery();
+    assertEquals(
+        query,
+        "services_platform.service.response.p95{kube_namespace:dora-canary,status:200,endpoint:getListings}");
+  }
+
+  @Test
+  public void buildQueryWithoutTags() {
+    when(mockDatadogCanaryMetricSetQueryConfig.getMetricType()).thenReturn(MetricType.GAUGE);
+    when(mockDatadogCanaryMetricSetQueryConfig.getTags()).thenReturn(Collections.emptyList());
+    String query = buildQuery();
+    assertEquals(query, "services_platform.service.response.p95{kube_namespace:dora-canary}");
+  }
+}


### PR DESCRIPTION
feat(datadog): Support metric types and tags

**Problem**
Kayenta does not currently support querying Datadog count metrics. <s>Current string formatting has no aggregation prefixes and rollup postfixes.</s> Current string formatting allows for prefix aggregations, but no postfix aggregations.


(Diagram from Datadog docs: https://docs.datadoghq.com/graphing/functions/)
![image](https://user-images.githubusercontent.com/4308672/63813149-94228d80-c8e1-11e9-8f48-2679ffc69c01.png)

The lack of postfix time-aggregations creates applied unwanted transformations to `count` time-series, resulting in false positives.

**Solution**
To reduce false positives around count metrics, Airbnb extended Kayenta to support [Datadog's three metric types](https://docs.datadoghq.com/developers/metrics/#metric-types). We also added support for optional tag arrays in the Canary Configs. Before this extension, the only way to add static tags to Datadog metric queries was to hackishly append tags to scope strings and associated metrics with unique scopes.

**Related**
This PR is assisted by a proposed change to deck-kayenta which would whitelist `metricType` and `tags` in `ICanaryConfig`: https://github.com/spinnaker/deck-kayenta/pull/468

---
We have deployed this change for a week at Airbnb and have verified that it is compatible with existing Canary Configs.