### PR TITLE
refactor(newrelic): get nr endpoint from config

### DIFF
--- a/kayenta-newrelic-insights/src/main/java/com/netflix/kayenta/newrelic/config/NewRelicConfiguration.java
+++ b/kayenta-newrelic-insights/src/main/java/com/netflix/kayenta/newrelic/config/NewRelicConfiguration.java
@@ -45,8 +45,6 @@ import retrofit.converter.JacksonConverter;
 @Slf4j
 public class NewRelicConfiguration {
 
-  private static final String NEWRELIC_INSIGHTS_ENDPOINT = "https://insights-api.newrelic.com";
-
   @Bean
   @ConfigurationProperties("kayenta.newrelic")
   NewRelicConfigurationProperties newrelicConfigurationProperties() {
@@ -105,13 +103,17 @@ public class NewRelicConfiguration {
               .applicationKey(account.getApplicationKey())
               .build();
 
-      RemoteService remoteService = new RemoteService().setBaseUrl(NEWRELIC_INSIGHTS_ENDPOINT);
+      RemoteService endpoint = account.getEndpoint();
+
+      if (endpoint == null) {
+        endpoint = new RemoteService().setBaseUrl("https://insights-api.newrelic.com");
+      }
 
       NewRelicNamedAccountCredentials.NewRelicNamedAccountCredentialsBuilder
           accountCredentialsBuilder =
               NewRelicNamedAccountCredentials.builder()
                   .name(name)
-                  .endpoint(remoteService)
+                  .endpoint(endpoint)
                   .credentials(credentials);
 
       if (!CollectionUtils.isEmpty(supportedTypes)) {
@@ -120,7 +122,7 @@ public class NewRelicConfiguration {
               retrofitClientFactory.createClient(
                   NewRelicRemoteService.class,
                   new JacksonConverter(objectMapper),
-                  remoteService,
+                  endpoint,
                   okHttpClient));
         }
         accountCredentialsBuilder.supportedTypes(supportedTypes);

--- a/kayenta-web/config/kayenta.yml
+++ b/kayenta-web/config/kayenta.yml
@@ -87,6 +87,7 @@ kayenta:
 #      defaultLocationKey: server_region # Optional, if omitted requests must supply the _location_key if it is needed.
 #      supportedTypes:
 #        - METRICS_STORE
+#      endpoint.baseUrl: https://insights-api.newrelic.com
 
   prometheus:
     enabled: false


### PR DESCRIPTION
There's a couple of reasons for this: 1) we need to be able to configure this endpoint for staging, 2) this is the convention that the other providers follow; there's no reason to have this be hardcoded as a constant and not configurable.