### PR TITLE
fix(docker): docker compose fixes

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,10 +2,15 @@ version: "3.7"
 services:
   redis:
     image: redis:latest
+    ports:
+      - 6379:6379
   kayenta:
     build: .
     ports:
       - 8090:8090
+    environment:
+      - services.redis.baseUrl=redis://redis:6379
+      - redis.connection=redis://redis:6379
     volumes:
       - "~/.spinnaker/kayenta.yml:/opt/kayenta/config/kayenta.yml"
     depends_on:


### PR DESCRIPTION
Running in standalone mode, `kayenta` was not able to connect to the running `redis` instance.

Prior to the PR, the following error was seen

`kayenta_1  | Caused by: redis.clients.jedis.exceptions.JedisConnectionException: Failed connecting to host localhost:6379`