### PR TITLE
fix(judge): Disable first pass outlier removal by default.

### DIFF
--- a/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/classifiers/metric/BaseMetricClassifier.scala
+++ b/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/classifiers/metric/BaseMetricClassifier.scala
@@ -56,6 +56,20 @@ object NaNStrategy {
   }
 }
 
+sealed trait OutlierStrategy
+object OutlierStrategy {
+  case object Remove extends OutlierStrategy
+  case object Keep extends OutlierStrategy
+
+  def parse(outlierStrategy: String): OutlierStrategy = {
+    outlierStrategy match {
+      case "remove" => OutlierStrategy.Remove
+      case "keep" => OutlierStrategy.Keep
+      case _ => OutlierStrategy.Keep
+    }
+  }
+}
+
 case class MetricClassification(classification: MetricClassificationLabel,
                                 reason: Option[String],
                                 deviation: Double,


### PR DESCRIPTION
Adds the ability to re-enable outlier removal on a per-metric basis:
```
    {
      "name": "5xx rate",
      "query": {
        "type": "prometheus",
        "customInlineTemplate": "PromQL:avg(rate(gateway_http_responses{code=\"5xx\", pod=~\"$\\{scope}\"}[2m]))",
        "serviceType": "prometheus"
      },
      "groups": [
        "Group 1"
      ],
      "analysisConfigurations": {
        "canary": {
          "outlierStrategy":"remove"
        }
      },
      "scopeName": "default"
    },
```