### PR TITLE
feat(Kayenta/Atlas): Add context to atlas query error message

### DIFF
--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/config/AtlasSSEConverter.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/config/AtlasSSEConverter.java
@@ -47,10 +47,21 @@ public class AtlasSSEConverter implements Converter {
       Arrays.asList("timeseries", "close");
 
   private final ObjectMapper kayentaObjectMapper;
+  private String queryName;
+  private String queryString;
+  private String configName;
 
   @Autowired
   public AtlasSSEConverter(ObjectMapper kayentaObjectMapper) {
+    this(kayentaObjectMapper, null, null, null);
+  }
+
+  public AtlasSSEConverter(
+      ObjectMapper kayentaObjectMapper, String configName, String queryName, String queryString) {
     this.kayentaObjectMapper = kayentaObjectMapper;
+    this.queryName = queryName;
+    this.queryString = queryString;
+    this.configName = configName;
   }
 
   @Override
@@ -105,7 +116,13 @@ public class AtlasSSEConverter implements Converter {
           || !EXPECTED_RESULTS_TYPE_LIST.contains(atlasResultsType)) {
         if (atlasResultsType.equals("error")) {
           if (atlasResults.getMessage().contains("IllegalStateException")) {
-            throw new FatalQueryException("Atlas query failed: " + atlasResults.getMessage());
+            throw new FatalQueryException(
+                "Atlas query"
+                    + ((configName != null) ? " in canary config [" + configName + "]" : "")
+                    + ((queryName != null) ? " for query [" + queryName + "]" : "")
+                    + ((queryString != null) ? " with query string [" + queryString + "]" : "")
+                    + " failed: "
+                    + atlasResults.getMessage());
           } else {
             throw new RetryableQueryException("Atlas query failed: " + atlasResults.getMessage());
           }

--- a/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/metrics/AtlasMetricsService.java
+++ b/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/metrics/AtlasMetricsService.java
@@ -18,6 +18,7 @@ package com.netflix.kayenta.atlas.metrics;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.kayenta.atlas.backends.AtlasStorageDatabase;
 import com.netflix.kayenta.atlas.backends.BackendDatabase;
 import com.netflix.kayenta.atlas.canary.AtlasCanaryScope;
@@ -66,7 +67,7 @@ public class AtlasMetricsService implements MetricsService {
 
   @Autowired private final RetrofitClientFactory retrofitClientFactory;
 
-  @Autowired private final AtlasSSEConverter atlasSSEConverter;
+  @Autowired private final ObjectMapper kayentaObjectMapper;
 
   @Autowired private final Registry registry;
 
@@ -183,6 +184,13 @@ public class AtlasMetricsService implements MetricsService {
     RemoteService remoteService = new RemoteService();
     log.info("Using Atlas backend {}", uri);
     remoteService.setBaseUrl(uri);
+    AtlasSSEConverter atlasSSEConverter =
+        new AtlasSSEConverter(
+            kayentaObjectMapper,
+            canaryConfig.getName(),
+            canaryMetricConfig.getName(),
+            canaryMetricConfig.getQuery().toString());
+
     AtlasRemoteService atlasRemoteService =
         retrofitClientFactory.createClient(
             AtlasRemoteService.class, atlasSSEConverter, remoteService, okHttpClient);


### PR DESCRIPTION
When an Atlas a metric's query string for Atlas results in a query error, the current error message lacks context about which metric, and which config are at fault. This change adds those details to the error message.

- Create a new instance of the Atlas converter for each query, and provide it with the unique query context information required for enriching the error log, should an error arise.
- Add config name, query name, and query string to the Atlas converter instance
- Include them in the error message when atlas responds with an `IllegalStateError` (bad Atlas query), so it's easier to trace it back to the specific query for troubleshooting.

**Before**:
```
retrofit.RetrofitError: Atlas query failed: IllegalStateException: no matches for word ':and' with stack [Equal], candidates: [Query Query -- Query], [TimeSeriesExpr TimeSeriesExpr -- TimeSeriesExpr]
```
**After**:
```
com.netflix.kayenta.metrics.FatalQueryException: Atlas query in canary config [serverlabnharamati-canary] for query [CPU] with query string [AtlasCanaryMetricSetQueryConfig(q=name,Cpu,:eq,:and)] failed: IllegalStateException: no matches for word ':and' with stack [Equal], candidates: [Query Query -- Query], [TimeSeriesExpr TimeSeriesExpr -- TimeSeriesExpr]
```

