### PR TITLE
chore(release): Use the alpine containers instead of openjdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,11 @@ RUN tar -xf /tmp/workdir/kayenta-web/build/distributions/kayenta.tar -C /opt
 #
 # Release Image
 #
-FROM openjdk:8-alpine
+FROM alpine:3.10
 
 MAINTAINER delivery-engineering@netflix.com
+
+RUN apk --no-cache add --update openjdk8-jre
 
 # Set where to look for config from
 ENV KAYENTA_OPTS=-Dspring.config.location=file:/opt/kayenta/config/kayenta.yml

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,7 +1,7 @@
-FROM openjdk:8-jre-alpine
+FROM alpine:3.10
 MAINTAINER delivery-engineering@netflix.com
 COPY --from=compile /compiled_sources/kayenta-web/build/install/kayenta /opt/kayenta
-RUN apk --no-cache add --update bash
+RUN apk --no-cache add --update bash openjdk8-jre
 RUN adduser -D -S spinnaker
 USER spinnaker
 CMD ["/opt/kayenta/bin/kayenta"]


### PR DESCRIPTION
The container we had been using hasn't been updated in months. See
spinnaker/spinnaker#5204.