### PR TITLE
chore(dependencies): Upgrade Spring Boot to 2.2.1, part 2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 #Mon Jun 17 22:31:26 UTC 2019
-orcaVersion=7.56.1
+orcaVersion=7.71.0
 kotlinVersion=1.3.20
 enablePublishing=false
 spinnakerGradleVersion=7.0.1
 mathCommonsVersion=3.6.1
-keikoVersion=2.10.1
+keikoVersion=3.0.0
 org.gradle.parallel=true

--- a/kayenta-core/src/main/java/com/netflix/kayenta/index/CanaryConfigIndexingAgent.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/index/CanaryConfigIndexingAgent.java
@@ -38,6 +38,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.exceptions.JedisException;
+import redis.clients.jedis.params.SetParams;
 
 @Slf4j
 public class CanaryConfigIndexingAgent extends AbstractHealthIndicator {
@@ -97,7 +98,10 @@ public class CanaryConfigIndexingAgent extends AbstractHealthIndicator {
     try (Jedis jedis = jedisPool.getResource()) {
       long startTime = System.currentTimeMillis();
       String acquiredIndexingLock =
-          jedis.set(INDEXING_INSTANCE_KEY, currentInstanceId, "NX", "EX", indexingLockTTLSec);
+          jedis.set(
+              INDEXING_INSTANCE_KEY,
+              currentInstanceId,
+              SetParams.setParams().nx().ex(indexingLockTTLSec));
 
       if (!"OK".equals(acquiredIndexingLock)) {
         String lockHolderInstanceId = jedis.get(INDEXING_INSTANCE_KEY);

--- a/kayenta-core/src/main/java/com/netflix/kayenta/persistence/config/RedisConnectionInfo.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/persistence/config/RedisConnectionInfo.java
@@ -20,7 +20,7 @@ import java.net.URI;
 import lombok.Builder;
 import lombok.Data;
 import redis.clients.jedis.Protocol;
-import redis.clients.util.JedisURIHelper;
+import redis.clients.jedis.util.JedisURIHelper;
 
 @Builder
 @Data

--- a/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/ManagementTest.java
+++ b/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/ManagementTest.java
@@ -55,7 +55,7 @@ public class ManagementTest extends BaseIntegrationTest {
                 .assertThat()
                 .statusCode(HttpStatus.OK.value())
                 .body("status", is("UP"))
-                .body("details.canaryConfigIndexingAgent.status", is("UP"))
-                .body("details.redisHealth.status", is("UP")));
+                .body("components.canaryConfigIndexingAgent.status", is("UP"))
+                .body("components.redisHealth.status", is("UP")));
   }
 }

--- a/kayenta-web/src/test/java/com/netflix/kayenta/controllers/CanaryConfigControllerTest.java
+++ b/kayenta-web/src/test/java/com/netflix/kayenta/controllers/CanaryConfigControllerTest.java
@@ -46,7 +46,7 @@ public class CanaryConfigControllerTest extends BaseControllerTest {
                 CONFIGS_ACCOUNT))
         .andDo(print())
         .andExpect(status().isOk())
-        .andExpect(content().contentType("application/json;charset=UTF-8"))
+        .andExpect(content().contentType("application/json"))
         .andExpect(jsonPath("$.applications.length()").value(is(1)))
         .andExpect(jsonPath("$.applications[0]").value(is("test-app")));
   }
@@ -65,7 +65,7 @@ public class CanaryConfigControllerTest extends BaseControllerTest {
                 CONFIGS_ACCOUNT))
         .andDo(print())
         .andExpect(status().isNotFound())
-        .andExpect(content().contentType("application/json;charset=UTF-8"))
+        .andExpect(content().contentType("application/json"))
         .andExpect(jsonPath("$.message").value(is("dummy message")));
   }
 
@@ -81,7 +81,7 @@ public class CanaryConfigControllerTest extends BaseControllerTest {
                 CONFIGS_ACCOUNT))
         .andDo(print())
         .andExpect(status().isBadRequest())
-        .andExpect(content().contentType("application/json;charset=UTF-8"))
+        .andExpect(content().contentType("application/json"))
         .andExpect(
             jsonPath("$.message")
                 .value(containsString("Unable to resolve account " + CONFIGS_ACCOUNT)));


### PR DESCRIPTION
Bumping orca and keiko versions to inherit the new version of boot2 and all associated transitive dependencies.

* utf-8 removal from the test: the default changed in Spring MVC, see deprecation notice: `org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE`
* Fixed jedis2->jedis3 client code.
* Fixed `ManagementTest`: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.2-Release-Notes#health-endpoint-json