### PR TITLE
Replace freemarker with stringsubstitutor from commons-text for template expanding

### DIFF
--- a/kayenta-core/kayenta-core.gradle
+++ b/kayenta-core/kayenta-core.gradle
@@ -17,9 +17,8 @@ dependencies {
   api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
   api "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
 
-
+  api "org.apache.commons:commons-text:1.8"
   api "org.springframework.boot:spring-boot-starter-actuator"
-  api "org.springframework.boot:spring-boot-starter-freemarker"
   api "org.springframework.boot:spring-boot-starter-json"
   api "net.logstash.logback:logstash-logback-encoder"
 

--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryConfig.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryConfig.java
@@ -51,7 +51,7 @@ public class CanaryConfig {
 
   @NotNull @Singular @Getter private List<CanaryMetricConfig> metrics;
 
-  @NotNull @Getter private Map<String, String> templates;
+  @NotNull @Singular @Getter private Map<String, String> templates;
 
   @NotNull @Getter private CanaryClassifierConfig classifier;
 }

--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryMetricSetQueryConfig.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryMetricSetQueryConfig.java
@@ -30,18 +30,21 @@ public interface CanaryMetricSetQueryConfig {
     return null;
   }
 
-  // Optionally defines a metric-specific query template. Takes precedence over
-  // customFilterTemplate.
-  // It is expanded by using the key/value pairs in extendedScopeParams as the variable bindings.
+  /**
+   * Optionally defines a metric-specific query template. Takes precedence over {@link
+   * #getCustomFilterTemplate}. It is expanded by using the key/value pairs in {@link
+   * CanaryScope#extendedScopeParams} as the variable bindings.
+   */
   default String getCustomInlineTemplate() {
     return null;
   }
 
-  // Optionally refers by name to a FreeMarker template defined in the canary config top-level
-  // 'templates' map. It is
-  // expanded by using the key/value pairs in extendedScopeParams as the variable bindings. Once
-  // expanded, the
-  // resulting filter is used when composing the query.
+  /**
+   * Optionally refers by name to a template defined in the canary config top-level {@link
+   * CanaryConfig#templates} map. It is expanded by using the key/value pairs in {@link
+   * CanaryScope#extendedScopeParams} as the variable bindings. Once expanded, the resulting filter
+   * is used when composing the query.
+   */
   default String getCustomFilterTemplate() {
     return null;
   }

--- a/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryScope.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/canary/CanaryScope.java
@@ -23,6 +23,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.Singular;
 
 @Data
 @Builder
@@ -40,9 +41,8 @@ public class CanaryScope {
 
   @NotNull protected Long step;
 
-  // Metric source specific parameters which may be used to further
-  // alter the canary scope.
-  Map<String, String> extendedScopeParams;
+  /** Metric source specific parameters which may be used to further alter the canary scope. */
+  @Singular Map<String, String> extendedScopeParams;
 
   public Duration calculateDuration() {
     return Duration.between(start, end);

--- a/kayenta-core/src/main/java/com/netflix/kayenta/metrics/MetricsService.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/metrics/MetricsService.java
@@ -33,8 +33,7 @@ public interface MetricsService {
       String metricsAccountName,
       CanaryConfig canaryConfig,
       CanaryMetricConfig canaryMetricConfig,
-      CanaryScope canaryScope)
-      throws IOException {
+      CanaryScope canaryScope) {
     return "buildQuery() is not implemented for " + this.getClass().getSimpleName() + ".";
   }
 

--- a/kayenta-core/src/test/groovy/com/netflix/kayenta/canary/providers/metrics/QueryConfigUtilsSpec.groovy
+++ b/kayenta-core/src/test/groovy/com/netflix/kayenta/canary/providers/metrics/QueryConfigUtilsSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright 2018 Google, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License")
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-package com.netflix.kayenta.canary.providers
+package com.netflix.kayenta.canary.providers.metrics
 
 import com.netflix.kayenta.canary.CanaryConfig
 import com.netflix.kayenta.canary.CanaryMetricConfig
-import com.netflix.kayenta.canary.CanaryMetricSetQueryConfig
-import com.netflix.kayenta.canary.providers.metrics.QueryConfigUtils
-import org.springframework.util.StringUtils
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -44,7 +41,7 @@ class QueryConfigUtilsSpec extends Specification {
   }
 
   @Unroll
-  void "Template #template is unescaped so it can be expanded by freemarker"() {
+  void "Template #template is unescaped so it can be expanded by string substitutor"() {
     expect:
     QueryConfigUtils.unescapeTemplate(template) == expectedUnescapedTemplate
 
@@ -73,24 +70,5 @@ class QueryConfigUtilsSpec extends Specification {
     'A test: key1=val1.'                 || 'A test: key1=val1.'
     null                                 || null
     ""                                   || ""
-  }
-}
-
-class TestCanaryMetricSetQueryConfig implements CanaryMetricSetQueryConfig {
-
-  String customInlineTemplate
-
-  @Override
-  CanaryMetricSetQueryConfig cloneWithEscapedInlineTemplate() {
-    if (StringUtils.isEmpty(customInlineTemplate)) {
-      return this
-    } else {
-      return new TestCanaryMetricSetQueryConfig(customInlineTemplate: customInlineTemplate.replace('${', '$\\{'))
-    }
-  }
-
-  @Override
-  String getServiceType() {
-    "test-service"
   }
 }

--- a/kayenta-core/src/test/groovy/com/netflix/kayenta/canary/providers/metrics/QueryConfigUtilsTest.java
+++ b/kayenta-core/src/test/groovy/com/netflix/kayenta/canary/providers/metrics/QueryConfigUtilsTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020 Playtika
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.canary.providers.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.netflix.kayenta.canary.CanaryConfig;
+import com.netflix.kayenta.canary.CanaryMetricSetQueryConfig;
+import com.netflix.kayenta.canary.CanaryScope;
+import org.junit.Test;
+
+public class QueryConfigUtilsTest {
+
+  @Test
+  public void expandCustomFilter_returnsNullIfTemplatesNotSet() {
+    CanaryConfig canaryConfig = CanaryConfig.builder().build();
+    TestCanaryMetricSetQueryConfig metricSetQuery = new TestCanaryMetricSetQueryConfig();
+    CanaryScope canaryScope = CanaryScope.builder().build();
+    String[] baseScopeAttribute = {};
+
+    String actual =
+        QueryConfigUtils.expandCustomFilter(
+            canaryConfig, metricSetQuery, canaryScope, baseScopeAttribute);
+
+    assertThat(actual).isNull();
+  }
+
+  @Test
+  public void
+      expandCustomFilter_returnsExpandedTemplateWithExtractedBaseScopeAttributesFromFilterTemplate() {
+    CanaryConfig canaryConfig = CanaryConfig.builder().build();
+    TestCanaryMetricSetQueryConfig metricSetQuery = new TestCanaryMetricSetQueryConfig();
+    metricSetQuery.setCustomInlineTemplate(
+        "test template ${p1} ${p2} ${scope} ${location} ${serviceType} $\\{p1} $\\{p2}");
+    metricSetQuery.setServiceType("my-service-type");
+    CanaryScope canaryScope =
+        CanaryScope.builder()
+            .scope("my-test-scope")
+            .location("my-test-location")
+            .extendedScopeParam("p1", "v1")
+            .extendedScopeParam("p2", "v2")
+            .build();
+    String[] baseScopeAttribute = {"scope", "location", "serviceType"};
+
+    assertThatThrownBy(
+            () ->
+                QueryConfigUtils.expandCustomFilter(
+                    canaryConfig, metricSetQuery, canaryScope, baseScopeAttribute))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Unable to find property 'serviceType'."); // see:
+    // https://github.com/spinnaker/kayenta/pull/659#issuecomment-579819419
+
+    // instead should be:
+    //    assertThat(actual)
+    //        .isEqualTo("test template v1 v2 my-test-scope my-test-location my-service-type v1
+    // v2");
+  }
+
+  @Test
+  public void
+      expandCustomFilter_returnsExpandedTemplateIfAllParametersAvailableFromFilterTemplate() {
+    CanaryConfig canaryConfig =
+        CanaryConfig.builder()
+            .template("test-template", "test template ${p1} ${p2} $\\{p1} $\\{p2}")
+            .build();
+    CanaryMetricSetQueryConfig metricSetQuery = mock(CanaryMetricSetQueryConfig.class);
+    CanaryScope canaryScope =
+        CanaryScope.builder().extendedScopeParam("p1", "v1").extendedScopeParam("p2", "v2").build();
+    String[] baseScopeAttribute = {};
+    when(metricSetQuery.getCustomFilterTemplate()).thenReturn("test-template");
+
+    String actual =
+        QueryConfigUtils.expandCustomFilter(
+            canaryConfig, metricSetQuery, canaryScope, baseScopeAttribute);
+
+    assertThat(actual).isEqualTo("test template v1 v2 v1 v2");
+  }
+
+  @Test
+  public void
+      expandCustomFilter_returnsExpandedTemplateIfAllParametersAvailableFromInlineTemplate() {
+    CanaryConfig canaryConfig = CanaryConfig.builder().build();
+    CanaryMetricSetQueryConfig metricSetQuery = mock(CanaryMetricSetQueryConfig.class);
+    CanaryScope canaryScope =
+        CanaryScope.builder().extendedScopeParam("p1", "v1").extendedScopeParam("p2", "v2").build();
+    String[] baseScopeAttribute = {};
+    when(metricSetQuery.getCustomInlineTemplate())
+        .thenReturn("test template ${p1} ${p2} $\\{p1} $\\{p2}");
+
+    String actual =
+        QueryConfigUtils.expandCustomFilter(
+            canaryConfig, metricSetQuery, canaryScope, baseScopeAttribute);
+
+    assertThat(actual).isEqualTo("test template v1 v2 v1 v2");
+  }
+
+  @Test
+  public void expandCustomFilter_failsWithExceptionIfParameterMissing() {
+    CanaryConfig canaryConfig = CanaryConfig.builder().build();
+    CanaryMetricSetQueryConfig metricSetQuery = mock(CanaryMetricSetQueryConfig.class);
+    CanaryScope canaryScope =
+        CanaryScope.builder().extendedScopeParam("p1", "v1").extendedScopeParam("p2", "v2").build();
+    String[] baseScopeAttribute = {};
+    when(metricSetQuery.getCustomInlineTemplate())
+        .thenReturn("test template ${unknown-param} ${p2}");
+
+    assertThatThrownBy(
+            () ->
+                QueryConfigUtils.expandCustomFilter(
+                    canaryConfig, metricSetQuery, canaryScope, baseScopeAttribute))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Problem evaluating custom filter template: test template ${unknown-param} ${p2}");
+  }
+}

--- a/kayenta-core/src/test/groovy/com/netflix/kayenta/canary/providers/metrics/TestCanaryMetricSetQueryConfig.groovy
+++ b/kayenta-core/src/test/groovy/com/netflix/kayenta/canary/providers/metrics/TestCanaryMetricSetQueryConfig.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Playtika
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.canary.providers.metrics
+
+import com.netflix.kayenta.canary.CanaryMetricSetQueryConfig
+import org.springframework.util.StringUtils
+
+class TestCanaryMetricSetQueryConfig implements CanaryMetricSetQueryConfig {
+
+    String customInlineTemplate
+    String serviceType = "test-service"
+
+    @Override
+    CanaryMetricSetQueryConfig cloneWithEscapedInlineTemplate() {
+        if (StringUtils.isEmpty(customInlineTemplate)) {
+            return this
+        } else {
+            return new TestCanaryMetricSetQueryConfig(customInlineTemplate: customInlineTemplate.replace('${', '$\\{'))
+        }
+    }
+
+    @Override
+    String getServiceType() {
+        serviceType
+    }
+}

--- a/kayenta-datadog/src/main/java/com/netflix/kayenta/datadog/metrics/DatadogMetricsService.java
+++ b/kayenta-datadog/src/main/java/com/netflix/kayenta/datadog/metrics/DatadogMetricsService.java
@@ -78,8 +78,7 @@ public class DatadogMetricsService implements MetricsService {
       String metricsAccountName,
       CanaryConfig canaryConfig,
       CanaryMetricConfig canaryMetricConfig,
-      CanaryScope canaryScope)
-      throws IOException {
+      CanaryScope canaryScope) {
 
     DatadogCanaryMetricSetQueryConfig queryConfig =
         (DatadogCanaryMetricSetQueryConfig) canaryMetricConfig.getQuery();

--- a/kayenta-graphite/src/main/java/com/netflix/kayenta/graphite/metrics/GraphiteMetricsService.java
+++ b/kayenta-graphite/src/main/java/com/netflix/kayenta/graphite/metrics/GraphiteMetricsService.java
@@ -82,8 +82,7 @@ public class GraphiteMetricsService implements MetricsService {
       String metricsAccountName,
       CanaryConfig canaryConfig,
       CanaryMetricConfig canaryMetricConfig,
-      CanaryScope canaryScope)
-      throws IOException {
+      CanaryScope canaryScope) {
     GraphiteCanaryMetricSetQueryConfig queryConfig =
         (GraphiteCanaryMetricSetQueryConfig) canaryMetricConfig.getQuery();
 

--- a/kayenta-newrelic-insights/src/main/java/com/netflix/kayenta/newrelic/metrics/NewRelicMetricsService.java
+++ b/kayenta-newrelic-insights/src/main/java/com/netflix/kayenta/newrelic/metrics/NewRelicMetricsService.java
@@ -73,8 +73,7 @@ public class NewRelicMetricsService implements MetricsService {
       String metricsAccountName,
       CanaryConfig canaryConfig,
       CanaryMetricConfig canaryMetricConfig,
-      CanaryScope canaryScope)
-      throws IOException {
+      CanaryScope canaryScope) {
 
     NewRelicScopeConfiguration scopeConfiguration =
         newrelicScopeConfigurationMap.get(metricsAccountName);

--- a/kayenta-newrelic-insights/src/main/java/com/netflix/kayenta/newrelic/metrics/NewRelicQueryBuilderService.java
+++ b/kayenta-newrelic-insights/src/main/java/com/netflix/kayenta/newrelic/metrics/NewRelicQueryBuilderService.java
@@ -5,7 +5,6 @@ import com.netflix.kayenta.canary.providers.metrics.NewRelicCanaryMetricSetQuery
 import com.netflix.kayenta.canary.providers.metrics.QueryConfigUtils;
 import com.netflix.kayenta.newrelic.canary.NewRelicCanaryScope;
 import com.netflix.kayenta.newrelic.config.NewRelicScopeConfiguration;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -37,8 +36,7 @@ public class NewRelicQueryBuilderService {
       CanaryConfig canaryConfig,
       NewRelicCanaryScope canaryScope,
       NewRelicCanaryMetricSetQueryConfig queryConfig,
-      NewRelicScopeConfiguration scopeConfiguration)
-      throws IOException {
+      NewRelicScopeConfiguration scopeConfiguration) {
 
     String[] baseScopeAttributes = new String[] {"scope", "location", "step"};
 

--- a/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/metrics/PrometheusMetricsService.java
+++ b/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/metrics/PrometheusMetricsService.java
@@ -195,8 +195,7 @@ public class PrometheusMetricsService implements MetricsService {
       String metricsAccountName,
       CanaryConfig canaryConfig,
       CanaryMetricConfig canaryMetricConfig,
-      CanaryScope canaryScope)
-      throws IOException {
+      CanaryScope canaryScope) {
     PrometheusCanaryMetricSetQueryConfig queryConfig =
         (PrometheusCanaryMetricSetQueryConfig) canaryMetricConfig.getQuery();
     PrometheusCanaryScope prometheusCanaryScope = (PrometheusCanaryScope) canaryScope;

--- a/kayenta-stackdriver/src/main/java/com/netflix/kayenta/stackdriver/metrics/StackdriverMetricsService.java
+++ b/kayenta-stackdriver/src/main/java/com/netflix/kayenta/stackdriver/metrics/StackdriverMetricsService.java
@@ -89,8 +89,7 @@ public class StackdriverMetricsService implements MetricsService {
       String metricsAccountName,
       CanaryConfig canaryConfig,
       CanaryMetricConfig canaryMetricConfig,
-      CanaryScope canaryScope)
-      throws IOException {
+      CanaryScope canaryScope) {
     StackdriverCanaryMetricSetQueryConfig queryConfig =
         (StackdriverCanaryMetricSetQueryConfig) canaryMetricConfig.getQuery();
     StackdriverCanaryScope stackdriverCanaryScope = (StackdriverCanaryScope) canaryScope;

--- a/kayenta-stackdriver/src/test/groovy/com/netflix/kayenta/providers/metrics/StackdriverCanaryMetricSetQueryConfigSpec.groovy
+++ b/kayenta-stackdriver/src/test/groovy/com/netflix/kayenta/providers/metrics/StackdriverCanaryMetricSetQueryConfigSpec.groovy
@@ -92,7 +92,6 @@ class StackdriverCanaryMetricSetQueryConfigSpec extends Specification {
     ["my-template-1": 'A test: key1=${key1}.',
      "my-template-2": 'A test: key2=${key2}.']                | "my-template-x"        | null
     [:]                                                       | "my-template-x"        | null
-    null                                                      | "my-template-x"        | null
     ["my-template": 'A test: key1=${key1} key2=${key2}.']     | "my-template"          | [key3: "value-3",
                                                                                           key4: "value-4"]
     ["my-template": 'A test: key1=$\\{key1} key2=$\\{key2}.'] | "my-template"          | [key3: "value-3",


### PR DESCRIPTION
Freemarker is very powerful template engine, but in Kayenta only 1 percent of it's capabilities are actually used. For template expanding with map of variables simple string substitutor does the trick.
Also this change allowed to remove `throws IOException` from the signature of `MetricsService.buildQuery`.

Added tests for all basic scenarios of `QueryConfigUtils`. 