### PR TITLE
fix(web): Enhance exception handling to return detailed message for the standard exceptions

### DIFF
--- a/kayenta-standalone-canary-analysis/src/main/java/com/netflix/kayenta/standalonecanaryanalysis/controller/StandaloneCanaryAnalysisController.java
+++ b/kayenta-standalone-canary-analysis/src/main/java/com/netflix/kayenta/standalonecanaryanalysis/controller/StandaloneCanaryAnalysisController.java
@@ -16,8 +16,7 @@
 
 package com.netflix.kayenta.standalonecanaryanalysis.controller;
 
-import static org.springframework.web.bind.annotation.RequestMethod.GET;
-import static org.springframework.web.bind.annotation.RequestMethod.POST;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import com.netflix.kayenta.canary.CanaryConfig;
 import com.netflix.kayenta.canary.providers.metrics.QueryConfigUtils;
@@ -38,7 +37,9 @@ import io.swagger.annotations.ApiParam;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -90,7 +91,7 @@ public class StandaloneCanaryAnalysisController {
   @ApiOperation(
       value =
           "Initiate a canary analysis execution with multiple canary judgements using a stored canary config")
-  @RequestMapping(value = "/{canaryConfigId:.+}", consumes = "application/json", method = POST)
+  @PostMapping(value = "/{canaryConfigId:.+}", consumes = APPLICATION_JSON_VALUE)
   public CanaryAnalysisExecutionResponse initiateCanaryAnalysis(
       @ApiParam(
               value = "The initiating user",
@@ -181,7 +182,7 @@ public class StandaloneCanaryAnalysisController {
   @ApiOperation(
       value =
           "Initiate an canary analysis execution with multiple canary judgements with the CanaryConfig provided in the request body")
-  @RequestMapping(consumes = "application/json", method = POST)
+  @PostMapping(consumes = APPLICATION_JSON_VALUE)
   public CanaryAnalysisExecutionResponse initiateCanaryAnalysisExecutionWithConfig(
       @ApiParam(
               value = "The initiating user",
@@ -248,7 +249,7 @@ public class StandaloneCanaryAnalysisController {
    * @return The canary analysis execution object that will have the results and status.
    */
   @ApiOperation(value = "Retrieve status and results for a canary analysis execution")
-  @RequestMapping(value = "/{canaryAnalysisExecutionId:.+}", method = GET)
+  @GetMapping(value = "/{canaryAnalysisExecutionId:.+}")
   public CanaryAnalysisExecutionStatusResponse getCanaryAnalysisExecution(
       @ApiParam(value = "The id for the Canary Analysis Execution") @PathVariable
           final String canaryAnalysisExecutionId,

--- a/kayenta-web/src/main/java/com/netflix/kayenta/controllers/CanaryConfigController.java
+++ b/kayenta-web/src/main/java/com/netflix/kayenta/controllers/CanaryConfigController.java
@@ -16,6 +16,8 @@
 
 package com.netflix.kayenta.controllers;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import com.netflix.kayenta.canary.CanaryConfig;
 import com.netflix.kayenta.canary.CanaryConfigUpdateResponse;
 import com.netflix.kayenta.security.AccountCredentials;
@@ -26,13 +28,11 @@ import com.netflix.kayenta.storage.StorageService;
 import com.netflix.kayenta.storage.StorageServiceRepository;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import io.swagger.annotations.ApiOperation;
-import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Pattern;
-import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -58,7 +58,7 @@ public class CanaryConfigController {
   }
 
   @ApiOperation(value = "Retrieve a canary config from object storage")
-  @RequestMapping(value = "/{canaryConfigId:.+}", method = RequestMethod.GET)
+  @GetMapping(value = "/{canaryConfigId:.+}")
   public CanaryConfig loadCanaryConfig(
       @RequestParam(required = false) final String configurationAccountName,
       @PathVariable String canaryConfigId) {
@@ -80,11 +80,10 @@ public class CanaryConfigController {
   }
 
   @ApiOperation(value = "Write a canary config to object storage")
-  @RequestMapping(consumes = "application/json", method = RequestMethod.POST)
+  @PostMapping(consumes = APPLICATION_JSON_VALUE)
   public CanaryConfigUpdateResponse storeCanaryConfig(
       @RequestParam(required = false) final String configurationAccountName,
-      @RequestBody CanaryConfig canaryConfig)
-      throws IOException {
+      @RequestBody CanaryConfig canaryConfig) {
     String resolvedConfigurationAccountName =
         CredentialsHelper.resolveAccountByNameOrType(
             configurationAccountName,
@@ -139,15 +138,11 @@ public class CanaryConfigController {
   }
 
   @ApiOperation(value = "Update a canary config")
-  @RequestMapping(
-      value = "/{canaryConfigId:.+}",
-      consumes = "application/json",
-      method = RequestMethod.PUT)
+  @PutMapping(value = "/{canaryConfigId:.+}", consumes = APPLICATION_JSON_VALUE)
   public CanaryConfigUpdateResponse updateCanaryConfig(
       @RequestParam(required = false) final String configurationAccountName,
       @PathVariable String canaryConfigId,
-      @RequestBody CanaryConfig canaryConfig)
-      throws IOException {
+      @RequestBody CanaryConfig canaryConfig) {
     String resolvedConfigurationAccountName =
         CredentialsHelper.resolveAccountByNameOrType(
             configurationAccountName,
@@ -209,11 +204,11 @@ public class CanaryConfigController {
   }
 
   @ApiOperation(value = "Delete a canary config")
-  @RequestMapping(value = "/{canaryConfigId:.+}", method = RequestMethod.DELETE)
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @DeleteMapping(value = "/{canaryConfigId:.+}")
   public void deleteCanaryConfig(
       @RequestParam(required = false) final String configurationAccountName,
-      @PathVariable String canaryConfigId,
-      HttpServletResponse response) {
+      @PathVariable String canaryConfigId) {
     String resolvedConfigurationAccountName =
         CredentialsHelper.resolveAccountByNameOrType(
             configurationAccountName,
@@ -229,12 +224,10 @@ public class CanaryConfigController {
 
     configurationService.deleteObject(
         resolvedConfigurationAccountName, ObjectType.CANARY_CONFIG, canaryConfigId);
-
-    response.setStatus(HttpStatus.NO_CONTENT.value());
   }
 
   @ApiOperation(value = "Retrieve a list of canary config ids and timestamps")
-  @RequestMapping(method = RequestMethod.GET)
+  @GetMapping
   public List<Map<String, Object>> listAllCanaryConfigs(
       @RequestParam(required = false) final String configurationAccountName,
       @RequestParam(required = false, value = "application") final List<String> applications) {

--- a/kayenta-web/src/main/java/com/netflix/kayenta/controllers/CanaryController.java
+++ b/kayenta-web/src/main/java/com/netflix/kayenta/controllers/CanaryController.java
@@ -16,6 +16,8 @@
 
 package com.netflix.kayenta.controllers;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.netflix.kayenta.canary.*;
 import com.netflix.kayenta.security.AccountCredentials;
@@ -67,10 +69,7 @@ public class CanaryController {
   //
   // TODO(duftler): Allow for user to be passed in.
   @ApiOperation(value = "Initiate a canary pipeline")
-  @RequestMapping(
-      value = "/{canaryConfigId:.+}",
-      consumes = "application/json",
-      method = RequestMethod.POST)
+  @PostMapping(value = "/{canaryConfigId:.+}", consumes = APPLICATION_JSON_VALUE)
   public CanaryExecutionResponse initiateCanary(
       @RequestParam(required = false) final String application,
       @RequestParam(required = false) final String parentPipelineExecutionId,
@@ -119,7 +118,7 @@ public class CanaryController {
   //
   // TODO(duftler): Allow for user to be passed in.
   @ApiOperation(value = "Initiate a canary pipeline with CanaryConfig provided")
-  @RequestMapping(consumes = "application/json", method = RequestMethod.POST)
+  @PostMapping(consumes = APPLICATION_JSON_VALUE)
   public CanaryExecutionResponse initiateCanaryWithConfig(
       @RequestParam(required = false) final String application,
       @RequestParam(required = false) final String parentPipelineExecutionId,
@@ -159,7 +158,7 @@ public class CanaryController {
   // Get the results of a canary run by ID
   //
   @ApiOperation(value = "Retrieve status and results for a canary run")
-  @RequestMapping(value = "/{canaryExecutionId:.+}", method = RequestMethod.GET)
+  @GetMapping(value = "/{canaryExecutionId:.+}")
   public CanaryExecutionStatusResponse getCanaryResults(
       @RequestParam(required = false) final String storageAccountName,
       @PathVariable String canaryExecutionId) {
@@ -187,7 +186,7 @@ public class CanaryController {
   }
 
   @ApiOperation(value = "Retrieve a list of an application's canary results")
-  @RequestMapping(value = "/executions", method = RequestMethod.GET)
+  @GetMapping(value = "/executions")
   List<CanaryExecutionStatusResponse> getCanaryResultsByApplication(
       @RequestParam(required = false) String application,
       @RequestParam(value = "limit", defaultValue = "20") int limit,

--- a/kayenta-web/src/main/java/com/netflix/kayenta/controllers/CanaryResultArchiveController.java
+++ b/kayenta-web/src/main/java/com/netflix/kayenta/controllers/CanaryResultArchiveController.java
@@ -16,6 +16,8 @@
 
 package com.netflix.kayenta.controllers;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import com.netflix.kayenta.canary.CanaryArchiveResultUpdateResponse;
 import com.netflix.kayenta.canary.CanaryExecutionStatusResponse;
 import com.netflix.kayenta.security.AccountCredentials;
@@ -58,7 +60,7 @@ public class CanaryResultArchiveController {
   }
 
   @ApiOperation(value = "Retrieve an archived canary result from object storage")
-  @RequestMapping(value = "/{pipelineId:.+}", method = RequestMethod.GET)
+  @GetMapping(value = "/{pipelineId:.+}")
   public CanaryExecutionStatusResponse loadArchivedCanaryResult(
       @RequestParam(required = false) final String storageAccountName,
       @PathVariable String pipelineId) {
@@ -71,7 +73,7 @@ public class CanaryResultArchiveController {
   }
 
   @ApiOperation(value = "Create an archived canary result to object storage")
-  @RequestMapping(consumes = "application/json", method = RequestMethod.POST)
+  @PostMapping(consumes = APPLICATION_JSON_VALUE)
   public CanaryArchiveResultUpdateResponse storeArchivedCanaryResult(
       @RequestParam(required = false) final String storageAccountName,
       @RequestParam(required = false) String pipelineId,
@@ -105,10 +107,7 @@ public class CanaryResultArchiveController {
   }
 
   @ApiOperation(value = "Update an archived canary result in object storage")
-  @RequestMapping(
-      value = "/{pipelineId:.+}",
-      consumes = "application/json",
-      method = RequestMethod.PUT)
+  @PutMapping(value = "/{pipelineId:.+}", consumes = APPLICATION_JSON_VALUE)
   public CanaryArchiveResultUpdateResponse updateArchivedCanaryResult(
       @RequestParam(required = false) final String storageAccountName,
       @PathVariable String pipelineId,
@@ -138,7 +137,7 @@ public class CanaryResultArchiveController {
   }
 
   @ApiOperation(value = "Delete an archived canary result from object storage")
-  @RequestMapping(value = "/{pipelineId:.+}", method = RequestMethod.DELETE)
+  @DeleteMapping(value = "/{pipelineId:.+}")
   public void deleteArchivedCanaryResult(
       @RequestParam(required = false) final String storageAccountName,
       @PathVariable String pipelineId,
@@ -154,7 +153,7 @@ public class CanaryResultArchiveController {
   }
 
   @ApiOperation(value = "Retrieve a list of archived canary result ids in object storage")
-  @RequestMapping(method = RequestMethod.GET)
+  @GetMapping
   public List<Map<String, Object>> listAllCanaryArchivedResults(
       @RequestParam(required = false) final String storageAccountName) {
     String resolvedConfigurationAccountName = resolveStorageAccountName(storageAccountName);

--- a/kayenta-web/src/main/java/com/netflix/kayenta/controllers/ControllerExceptionHandler.java
+++ b/kayenta-web/src/main/java/com/netflix/kayenta/controllers/ControllerExceptionHandler.java
@@ -19,13 +19,17 @@ package com.netflix.kayenta.controllers;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import java.util.Collections;
 import java.util.Map;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @RestControllerAdvice
-public class ControllerExceptionHandler {
+public class ControllerExceptionHandler extends ResponseEntityExceptionHandler {
 
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   @ExceptionHandler(IllegalArgumentException.class)
@@ -37,6 +41,12 @@ public class ControllerExceptionHandler {
   @ExceptionHandler(NotFoundException.class)
   public Map handleException(NotFoundException e) {
     return toErrorResponse(e);
+  }
+
+  @Override
+  protected ResponseEntity<Object> handleExceptionInternal(
+      Exception ex, Object body, HttpHeaders headers, HttpStatus status, WebRequest request) {
+    return super.handleExceptionInternal(ex, toErrorResponse(ex), headers, status, request);
   }
 
   private Map toErrorResponse(Exception e) {

--- a/kayenta-web/src/main/java/com/netflix/kayenta/controllers/CredentialsController.java
+++ b/kayenta-web/src/main/java/com/netflix/kayenta/controllers/CredentialsController.java
@@ -21,8 +21,8 @@ import com.netflix.kayenta.security.AccountCredentialsRepository;
 import io.swagger.annotations.ApiOperation;
 import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -37,7 +37,7 @@ public class CredentialsController {
   }
 
   @ApiOperation(value = "Retrieve a list of all configured credentials")
-  @RequestMapping(method = RequestMethod.GET)
+  @GetMapping
   Set<? extends AccountCredentials> list() {
     return accountCredentialsRepository.getAll();
   }

--- a/kayenta-web/src/main/java/com/netflix/kayenta/controllers/MetricSetListController.java
+++ b/kayenta-web/src/main/java/com/netflix/kayenta/controllers/MetricSetListController.java
@@ -16,6 +16,8 @@
 
 package com.netflix.kayenta.controllers;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import com.netflix.kayenta.metrics.MetricSet;
 import com.netflix.kayenta.security.AccountCredentials;
 import com.netflix.kayenta.security.AccountCredentialsRepository;
@@ -52,7 +54,7 @@ public class MetricSetListController {
   }
 
   @ApiOperation(value = "Retrieve a metric set list from object storage")
-  @RequestMapping(value = "/{metricSetListId:.+}", method = RequestMethod.GET)
+  @GetMapping(value = "/{metricSetListId:.+}")
   public List<MetricSet> loadMetricSetList(
       @RequestParam(required = false) final String accountName,
       @PathVariable String metricSetListId) {
@@ -72,7 +74,7 @@ public class MetricSetListController {
   }
 
   @ApiOperation(value = "Write a metric set list to object storage")
-  @RequestMapping(consumes = "application/json", method = RequestMethod.POST)
+  @PostMapping(consumes = APPLICATION_JSON_VALUE)
   public Map storeMetricSetList(
       @RequestParam(required = false) final String accountName,
       @RequestBody List<MetricSet> metricSetList)
@@ -96,7 +98,7 @@ public class MetricSetListController {
   }
 
   @ApiOperation(value = "Delete a metric set list")
-  @RequestMapping(value = "/{metricSetListId:.+}", method = RequestMethod.DELETE)
+  @DeleteMapping(value = "/{metricSetListId:.+}")
   public void deleteMetricSetList(
       @RequestParam(required = false) final String accountName,
       @PathVariable String metricSetListId,
@@ -118,7 +120,7 @@ public class MetricSetListController {
   }
 
   @ApiOperation(value = "Retrieve a list of metric set list ids and timestamps")
-  @RequestMapping(method = RequestMethod.GET)
+  @GetMapping
   public List<Map<String, Object>> listAllMetricSetLists(
       @RequestParam(required = false) final String accountName) {
     String resolvedAccountName =

--- a/kayenta-web/src/main/java/com/netflix/kayenta/controllers/MetricSetPairListController.java
+++ b/kayenta-web/src/main/java/com/netflix/kayenta/controllers/MetricSetPairListController.java
@@ -16,6 +16,8 @@
 
 package com.netflix.kayenta.controllers;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import com.netflix.kayenta.metrics.MetricSetPair;
 import com.netflix.kayenta.security.AccountCredentials;
 import com.netflix.kayenta.security.AccountCredentialsRepository;
@@ -50,7 +52,7 @@ public class MetricSetPairListController {
   }
 
   @ApiOperation(value = "Retrieve a metric set pair list from object storage")
-  @RequestMapping(value = "/{metricSetPairListId:.+}", method = RequestMethod.GET)
+  @GetMapping(value = "/{metricSetPairListId:.+}")
   public List<MetricSetPair> loadMetricSetPairList(
       @RequestParam(required = false) final String accountName,
       @PathVariable final String metricSetPairListId) {
@@ -71,9 +73,7 @@ public class MetricSetPairListController {
 
   @ApiOperation(
       value = "Retrieve a single metric set pair from a metricSetPairList from object storage")
-  @RequestMapping(
-      value = "/{metricSetPairListId:.+}/{metricSetPairId:.+}",
-      method = RequestMethod.GET)
+  @GetMapping(value = "/{metricSetPairListId:.+}/{metricSetPairId:.+}")
   public ResponseEntity<MetricSetPair> loadMetricSetPair(
       @RequestParam(required = false) final String accountName,
       @PathVariable final String metricSetPairListId,
@@ -102,7 +102,7 @@ public class MetricSetPairListController {
   }
 
   @ApiOperation(value = "Write a metric set pair list to object storage")
-  @RequestMapping(consumes = "application/json", method = RequestMethod.POST)
+  @PostMapping(consumes = APPLICATION_JSON_VALUE)
   public Map storeMetricSetPairList(
       @RequestParam(required = false) final String accountName,
       @RequestBody final List<MetricSetPair> metricSetPairList)
@@ -129,7 +129,7 @@ public class MetricSetPairListController {
   }
 
   @ApiOperation(value = "Delete a metric set pair list")
-  @RequestMapping(value = "/{metricSetPairListId:.+}", method = RequestMethod.DELETE)
+  @DeleteMapping(value = "/{metricSetPairListId:.+}")
   public void deleteMetricSetPairList(
       @RequestParam(required = false) final String accountName,
       @PathVariable final String metricSetPairListId,
@@ -152,7 +152,7 @@ public class MetricSetPairListController {
   }
 
   @ApiOperation(value = "Retrieve a list of metric set pair list ids and timestamps")
-  @RequestMapping(method = RequestMethod.GET)
+  @GetMapping
   public List<Map<String, Object>> listAllMetricSetPairLists(
       @RequestParam(required = false) final String accountName) {
     String resolvedAccountName =

--- a/kayenta-web/src/main/java/com/netflix/kayenta/controllers/MetricsServiceMetadataController.java
+++ b/kayenta-web/src/main/java/com/netflix/kayenta/controllers/MetricsServiceMetadataController.java
@@ -28,8 +28,8 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -50,7 +50,7 @@ public class MetricsServiceMetadataController {
   }
 
   @ApiOperation(value = "Retrieve a list of descriptors for use in populating the canary config ui")
-  @RequestMapping(method = RequestMethod.GET)
+  @GetMapping
   public List<Map> listMetadata(
       @RequestParam(required = false) final String metricsAccountName,
       @RequestParam(required = false) final String filter)

--- a/kayenta-web/src/main/java/com/netflix/kayenta/controllers/MetricsServicesController.java
+++ b/kayenta-web/src/main/java/com/netflix/kayenta/controllers/MetricsServicesController.java
@@ -26,8 +26,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -42,7 +42,7 @@ public class MetricsServicesController {
   }
 
   @ApiOperation(value = "Retrieve a list of all configured metrics services")
-  @RequestMapping(method = RequestMethod.GET)
+  @GetMapping
   List<MetricsServiceDetail> list() {
     Set<AccountCredentials> metricAccountCredentials =
         CredentialsHelper.getAllAccountsOfType(METRICS_STORE, accountCredentialsRepository);

--- a/kayenta-web/src/test/java/com/netflix/kayenta/controllers/BaseControllerTest.java
+++ b/kayenta-web/src/test/java/com/netflix/kayenta/controllers/BaseControllerTest.java
@@ -1,32 +1,30 @@
 package com.netflix.kayenta.controllers;
 
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-
 import com.netflix.kayenta.canary.CanaryJudge;
 import com.netflix.kayenta.canary.ExecutionMapper;
 import com.netflix.kayenta.config.WebConfiguration;
+import com.netflix.kayenta.config.WebSecurityConfig;
 import com.netflix.kayenta.metrics.MetricsServiceRepository;
 import com.netflix.kayenta.security.AccountCredentialsRepository;
 import com.netflix.kayenta.storage.StorageServiceRepository;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
-import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.mockito.Answers;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 @SpringBootTest(
     classes = BaseControllerTest.TestControllersConfiguration.class,
     webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc(printOnlyOnFailure = false)
 @RunWith(SpringRunner.class)
 public abstract class BaseControllerTest {
 
@@ -43,18 +41,10 @@ public abstract class BaseControllerTest {
 
   @MockBean CanaryJudge canaryJudge;
 
-  @Autowired private WebApplicationContext webApplicationContext;
-
-  protected MockMvc mockMvc;
-
-  @Before
-  public void setUp() {
-    this.mockMvc =
-        MockMvcBuilders.webAppContextSetup(this.webApplicationContext).alwaysDo(print()).build();
-  }
+  @Autowired protected MockMvc mockMvc;
 
   @EnableWebMvc
-  @Import(WebConfiguration.class)
+  @Import({WebConfiguration.class, WebSecurityConfig.class})
   @Configuration
   public static class TestControllersConfiguration {}
 }


### PR DESCRIPTION
- Enhance exception handling to return detailed message for the standard exceptions (like invalid requests) handled by Spring (see: ResponseEntityExceptionHandler). 
- Enhance controller method definitions.

Motivation behind this change: when user sends invalid request or any other internal error occurs, he/she gets only http status in response and no reason for what is the issue; this pull request addresses this issue and adds simple json response body with `message` field.

