### PR TITLE
feat(core): move CanaryJudgesController to kayenta-web module

### DIFF
--- a/kayenta-web/src/main/java/com/netflix/kayenta/controllers/CanaryJudgesController.java
+++ b/kayenta-web/src/main/java/com/netflix/kayenta/controllers/CanaryJudgesController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2017 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kayenta-web/src/main/java/com/netflix/kayenta/controllers/CanaryJudgesController.java
+++ b/kayenta-web/src/main/java/com/netflix/kayenta/controllers/CanaryJudgesController.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2017 Google, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License")
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -43,9 +43,10 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.CollectionUtils;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -74,7 +75,7 @@ public class CanaryJudgesController {
   }
 
   @ApiOperation(value = "Retrieve a list of all configured canary judges")
-  @RequestMapping(method = RequestMethod.GET)
+  @GetMapping
   List<CanaryJudge> list() {
     return canaryJudges;
   }
@@ -82,7 +83,7 @@ public class CanaryJudgesController {
   @ApiOperation(
       value =
           "Exercise a judge directly, without any orchestration or querying of metrics services")
-  @RequestMapping(value = "/judge", method = RequestMethod.POST)
+  @PostMapping(value = "/judge")
   public CanaryJudgeResult judge(
       @RequestParam(required = false) final String configurationAccountName,
       @RequestParam(required = false) final String storageAccountName,
@@ -151,7 +152,7 @@ public class CanaryJudgesController {
   }
 
   @ApiOperation(value = "Apply a pair of judges to a canned set of data")
-  @RequestMapping(value = "/comparison", method = RequestMethod.POST)
+  @PostMapping(value = "/comparison")
   public CanaryExecutionResponse initiateJudgeComparison(
       @RequestParam(required = false) final String configurationAccountName,
       @RequestParam(required = false) final String storageAccountName,
@@ -201,7 +202,7 @@ public class CanaryJudgesController {
   }
 
   @ApiOperation(value = "Retrieve the results of a judge comparison")
-  @RequestMapping(value = "/comparison/{executionId:.+}", method = RequestMethod.GET)
+  @GetMapping(value = "/comparison/{executionId:.+}")
   public Map getJudgeComparisonResults(@PathVariable String executionId) {
     Execution pipeline =
         executionRepository.retrieve(Execution.ExecutionType.PIPELINE, executionId);


### PR DESCRIPTION
CanaryJudgesController is the only controller that is located in kayenta-core module. All other Kayenta web endpoints are located in kayenta-web.