### PR TITLE
feat(standalone-canary-analysis): add executions ids to stage metadata

### DIFF
--- a/kayenta-core/src/main/java/com/netflix/kayenta/domain/standalonecanaryanalysis/StageMetadata.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/domain/standalonecanaryanalysis/StageMetadata.java
@@ -44,4 +44,7 @@ public class StageMetadata {
   @NotNull
   @ApiModelProperty(value = "The Orca execution status of the stage")
   ExecutionStatus status;
+
+  @ApiModelProperty(value = "The execution id if the stage is a runCanary stage")
+  String executionId;
 }

--- a/kayenta-standalone-canary-analysis/src/main/java/com/netflix/kayenta/standalonecanaryanalysis/service/CanaryAnalysisService.java
+++ b/kayenta-standalone-canary-analysis/src/main/java/com/netflix/kayenta/standalonecanaryanalysis/service/CanaryAnalysisService.java
@@ -28,6 +28,7 @@ import com.netflix.kayenta.domain.standalonecanaryanalysis.StageMetadata;
 import com.netflix.kayenta.security.AccountCredentials;
 import com.netflix.kayenta.security.AccountCredentialsRepository;
 import com.netflix.kayenta.standalonecanaryanalysis.CanaryAnalysisConfig;
+import com.netflix.kayenta.standalonecanaryanalysis.orca.MonitorKayentaCanaryContext;
 import com.netflix.kayenta.standalonecanaryanalysis.orca.stage.GenerateCanaryAnalysisResultStage;
 import com.netflix.kayenta.standalonecanaryanalysis.orca.stage.SetupAndExecuteCanariesStage;
 import com.netflix.kayenta.storage.ObjectType;
@@ -170,7 +171,12 @@ public class CanaryAnalysisService {
                         .map(
                             stage ->
                                 new StageMetadata(
-                                    stage.getType(), stage.getName(), stage.getStatus()))
+                                    stage.getType(),
+                                    stage.getName(),
+                                    stage.getStatus(),
+                                    stage
+                                        .mapTo(MonitorKayentaCanaryContext.class)
+                                        .getCanaryPipelineExecutionId()))
                         .collect(Collectors.toList()))
                 .complete(isComplete)
                 .executionStatus(pipelineStatus);


### PR DESCRIPTION
- Implementation of #671 
- Updates `StageMetadata` to have the execution ids available for canary intervals for standalone canary analysis