### PR TITLE
chore(GHA PR build): turn on the cross compiler here too

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,4 +25,4 @@ jobs:
       env:
         GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
         ENABLE_INTEGRATION_TESTS: true
-      run: ./gradlew build javadoc
+      run: ./gradlew -PenableCrossCompilerPlugin=true build javadoc


### PR DESCRIPTION
Not sure why I missed this before. I suppose just because it wasn't needed. In any event, I updated my script to add this going forward.
