### PR TITLE
fix(standalone-canary-analysis): custom parent pipeline execution id is not used

### DIFF
--- a/kayenta-standalone-canary-analysis/src/main/java/com/netflix/kayenta/standalonecanaryanalysis/orca/task/RunCanaryTask.java
+++ b/kayenta-standalone-canary-analysis/src/main/java/com/netflix/kayenta/standalonecanaryanalysis/orca/task/RunCanaryTask.java
@@ -100,7 +100,7 @@ public class RunCanaryTask implements Task {
       canaryExecutionResponse =
           executionMapper.buildExecution(
               Optional.ofNullable(context.getApplication()).orElse(AD_HOC),
-              stage.getExecution().getId(),
+              context.getParentPipelineExecutionId(),
               Optional.ofNullable(context.getCanaryConfigId()).orElse(AD_HOC),
               request.getCanaryConfig(),
               null,


### PR DESCRIPTION
When I retrieve results for the standalone canary analysis via archive endpoint I see that `parentPipelineExecutionId` is already set, but I haven't provided it. This PR fixes `parentPipelineExecutionId` to be equal to the one that was set by the user.

@fieldju could you please review?