### PR TITLE
fix(dockerfile): gradle build exceptions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Builder Image
 #
-FROM gradle:5.4-jdk8 AS builder
+FROM gradle:5.6.4-jdk8 AS builder
 
 # Prep build environment
 ENV GRADLE_USER_HOME=cache


### PR DESCRIPTION
Error Line (on Dockerfile):
`RUN gradle build`

Error Message
```
* Where:
Build file '/tmp/workdir/build.gradle' line: 19
* What went wrong:
Could not compile build file '/tmp/workdir/build.gradle'.
> startup failed:
  build file '/tmp/workdir/build.gradle': 19: argument list must be exactly 1 literal non empty string
  See https://docs.gradle.org/5.4.1/userguide/plugins.html#sec:plugins_block for information on the plugins {} block
   @ line 19, column 37.
       id "io.spinnaker.project" version "$spinnakerGradleVersion" apply false
                                         ^
  build file '/tmp/workdir/build.gradle': 20: argument list must be exactly 1 literal non empty string
  See https://docs.gradle.org/5.4.1/userguide/plugins.html#sec:plugins_block for information on the plugins {} block
   @ line 20, column 30.
       id "nebula.kotlin" version "$kotlinVersion" apply false
                                  ^
  2 errors
```

[Github Link to Gradle issue](https://github.com/gradle/gradle/issues/1697)

Fix:
Change
`FROM gradle:5.4-jdk8 AS builder` 
to 
`FROM gradle:5.6.4-jdk8 AS builder`

BREAKING CHANGE: None

