### PR TITLE
feat(config): default AWS and Google rootFolder to `kayenta`

### DIFF
--- a/kayenta-aws/src/main/java/com/netflix/kayenta/aws/config/AwsManagedAccount.java
+++ b/kayenta-aws/src/main/java/com/netflix/kayenta/aws/config/AwsManagedAccount.java
@@ -28,7 +28,7 @@ public class AwsManagedAccount {
 
   private String bucket;
   private String region;
-  private String rootFolder;
+  private String rootFolder = "kayenta";
   private String profileName;
   private String endpoint;
   private String proxyHost;

--- a/kayenta-google/src/main/java/com/netflix/kayenta/google/config/GoogleManagedAccount.java
+++ b/kayenta-google/src/main/java/com/netflix/kayenta/google/config/GoogleManagedAccount.java
@@ -35,7 +35,7 @@ public class GoogleManagedAccount {
 
   private String bucket;
   private String bucketLocation;
-  private String rootFolder;
+  private String rootFolder = "kayenta";
 
   private List<AccountCredentials.Type> supportedTypes;
 


### PR DESCRIPTION
Halyard is defaulting the AWS and Google accounts' rootFolder to "kayenta." Since kleat will not provide such defaults, let's move the default from config into code. This will not change behavior for Halyard users relying on the default, or any users setting their own rootFolder in config.