### PR TITLE
refactor(config): move Halyard defaults into code and deprecate Halyard-specific config

### DIFF
--- a/halconfig/README.md
+++ b/halconfig/README.md
@@ -1,0 +1,7 @@
+This directory contains skeleton Kayenta configs to which Halyard concatenates
+its generated deployment-specific config.
+
+These configs are **deprecated** and in general should not be further updated.
+To set a default config value, either set the value in
+`kayenta-web/config/kayenta.yml` or set a default in the code reading the
+config property.

--- a/halconfig/kayenta.yml
+++ b/halconfig/kayenta.yml
@@ -1,4 +1,1 @@
 # halconfig
-
-redis:
-  connection: ${services.redis.baseUrl:redis://localhost:6379}

--- a/kayenta-datadog/src/main/java/com/netflix/kayenta/datadog/config/DatadogManagedAccount.java
+++ b/kayenta-datadog/src/main/java/com/netflix/kayenta/datadog/config/DatadogManagedAccount.java
@@ -18,6 +18,7 @@ package com.netflix.kayenta.datadog.config;
 
 import com.netflix.kayenta.retrofit.config.RemoteService;
 import com.netflix.kayenta.security.AccountCredentials;
+import java.util.Collections;
 import java.util.List;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
@@ -30,5 +31,6 @@ public class DatadogManagedAccount {
 
   @NotNull private RemoteService endpoint;
 
-  private List<AccountCredentials.Type> supportedTypes;
+  private List<AccountCredentials.Type> supportedTypes =
+      Collections.singletonList(AccountCredentials.Type.METRICS_STORE);
 }

--- a/kayenta-newrelic-insights/src/main/java/com/netflix/kayenta/newrelic/config/NewRelicManagedAccount.java
+++ b/kayenta-newrelic-insights/src/main/java/com/netflix/kayenta/newrelic/config/NewRelicManagedAccount.java
@@ -18,6 +18,7 @@ package com.netflix.kayenta.newrelic.config;
 
 import com.netflix.kayenta.retrofit.config.RemoteService;
 import com.netflix.kayenta.security.AccountCredentials;
+import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
@@ -36,5 +37,6 @@ public class NewRelicManagedAccount {
 
   @Nullable private String defaultLocationKey;
 
-  private List<AccountCredentials.Type> supportedTypes;
+  private List<AccountCredentials.Type> supportedTypes =
+      Collections.singletonList(AccountCredentials.Type.METRICS_STORE);
 }

--- a/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/config/PrometheusManagedAccount.java
+++ b/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/config/PrometheusManagedAccount.java
@@ -18,6 +18,7 @@ package com.netflix.kayenta.prometheus.config;
 
 import com.netflix.kayenta.retrofit.config.RemoteService;
 import com.netflix.kayenta.security.AccountCredentials;
+import java.util.Collections;
 import java.util.List;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
@@ -41,5 +42,6 @@ public class PrometheusManagedAccount {
   // Optional parameter for use when protecting prometheus with basic auth.
   private String usernamePasswordFile;
 
-  private List<AccountCredentials.Type> supportedTypes;
+  private List<AccountCredentials.Type> supportedTypes =
+      Collections.singletonList(AccountCredentials.Type.METRICS_STORE);
 }

--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/config/SignalFxManagedAccount.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/config/SignalFxManagedAccount.java
@@ -19,6 +19,7 @@ package com.netflix.kayenta.signalfx.config;
 
 import com.netflix.kayenta.retrofit.config.RemoteService;
 import com.netflix.kayenta.security.AccountCredentials;
+import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
@@ -31,7 +32,8 @@ public class SignalFxManagedAccount {
 
   private String accessToken;
 
-  private List<AccountCredentials.Type> supportedTypes;
+  private List<AccountCredentials.Type> supportedTypes =
+      Collections.singletonList(AccountCredentials.Type.METRICS_STORE);
 
   @Nullable private RemoteService endpoint;
 

--- a/kayenta-web/config/kayenta.yml
+++ b/kayenta-web/config/kayenta.yml
@@ -2,7 +2,7 @@ server:
   port: 8090
 
 redis:
-  connection: redis://localhost:6379
+  connection: ${services.redis.baseUrl:redis://localhost:6379}
 
 kayenta:
   atlas:


### PR DESCRIPTION
* refactor(config): move Halyard defaults into code 

  Halyard currently defaults the `supportedTypes` list of Datadog, Prometheus, SignalFx, and New Relic accounts to a singleton list including type METRICS_STORE, which is the only reasonable choice for these account types. Let's lift that defaulting into the classes themselves, so that Kleat does not need to set them. While I think this would also be a reasonable default to set for the other metrics-only accounts, this change is limited to those accounts currently configurable using Halyard.

* refactor(config): deprecate Halyard-specific config file 

  Lifts the redis endpoint from the Halyard-specific config to the base config. This should not impact existing Halyard or non-Halyard users.
