### PR TITLE
refactor(core): make ObjectType an interface instead of enum

### DIFF
--- a/kayenta-core/src/main/java/com/netflix/kayenta/storage/ObjectType.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/storage/ObjectType.java
@@ -23,27 +23,36 @@ import com.netflix.kayenta.domain.standalonecanaryanalysis.CanaryAnalysisExecuti
 import com.netflix.kayenta.metrics.MetricSet;
 import com.netflix.kayenta.metrics.MetricSetPair;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
-@AllArgsConstructor
-public enum ObjectType {
-  CANARY_CONFIG(new TypeReference<CanaryConfig>() {}, "canary_config", "canary_config.json"),
-  CANARY_RESULT_ARCHIVE(
-      new TypeReference<CanaryExecutionStatusResponse>() {},
-      "canary_archive",
-      "canary_archive.json"),
-  METRIC_SET_LIST(new TypeReference<List<MetricSet>>() {}, "metrics", "metric_sets.json"),
-  METRIC_SET_PAIR_LIST(
-      new TypeReference<List<MetricSetPair>>() {}, "metric_pairs", "metric_set_pairs.json"),
-  STANDALONE_CANARY_RESULT_ARCHIVE(
-      new TypeReference<CanaryAnalysisExecutionStatusResponse>() {},
-      "standalone_canary_archive",
-      "standalone_canary_archive.json");
+public interface ObjectType {
 
-  @Getter final TypeReference<?> typeReference;
+  ObjectType CANARY_CONFIG =
+      new StandardObjectType(
+          new TypeReference<CanaryConfig>() {}, "canary_config", "canary_config.json");
 
-  @Getter final String group;
+  ObjectType CANARY_RESULT_ARCHIVE =
+      new StandardObjectType(
+          new TypeReference<CanaryExecutionStatusResponse>() {},
+          "canary_archive",
+          "canary_archive.json");
 
-  @Getter final String defaultFilename;
+  ObjectType METRIC_SET_LIST =
+      new StandardObjectType(
+          new TypeReference<List<MetricSet>>() {}, "metrics", "metric_sets.json");
+
+  ObjectType METRIC_SET_PAIR_LIST =
+      new StandardObjectType(
+          new TypeReference<List<MetricSetPair>>() {}, "metric_pairs", "metric_set_pairs.json");
+
+  ObjectType STANDALONE_CANARY_RESULT_ARCHIVE =
+      new StandardObjectType(
+          new TypeReference<CanaryAnalysisExecutionStatusResponse>() {},
+          "standalone_canary_archive",
+          "standalone_canary_archive.json");
+
+  TypeReference<?> getTypeReference();
+
+  String getGroup();
+
+  String getDefaultFilename();
 }

--- a/kayenta-core/src/main/java/com/netflix/kayenta/storage/StandardObjectType.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/storage/StandardObjectType.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Playtika
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.storage;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import lombok.Value;
+
+@Value
+public class StandardObjectType implements ObjectType {
+
+  TypeReference<?> typeReference;
+  String group;
+  String defaultFilename;
+}


### PR DESCRIPTION
make ObjectType an interface instead of enum to be able to use StorageService for some custom object types