### PR TITLE
fix: document metadataCachingIntervalMS in kayenta.yaml

### DIFF
--- a/kayenta-datadog/src/main/java/com/netflix/kayenta/datadog/config/DatadogConfigurationProperties.java
+++ b/kayenta-datadog/src/main/java/com/netflix/kayenta/datadog/config/DatadogConfigurationProperties.java
@@ -24,7 +24,8 @@ import lombok.Setter;
 
 public class DatadogConfigurationProperties {
 
-  @Getter @Setter private long metadataCachingIntervalMS = Duration.ofSeconds(60).toMillis();
+  // Datadog has an api limit of 100 metric retrievals per hour, default to 15 minutes here
+  @Getter @Setter private long metadataCachingIntervalMS = Duration.ofMinutes(15).toMillis();
 
   @Getter private List<DatadogManagedAccount> accounts = new ArrayList<>();
 }

--- a/kayenta-web/config/kayenta.yml
+++ b/kayenta-web/config/kayenta.yml
@@ -60,6 +60,7 @@ kayenta:
 
   datadog:
     enabled: false
+#    metadataCachingIntervalMS: 900000
 #    accounts:
 #      - name: my-datadog-account
 #        apiKey: xxxx
@@ -91,6 +92,7 @@ kayenta:
 
   prometheus:
     enabled: false
+#   metadataCachingIntervalMS: 60000
 #    accounts:
 #      - name: my-prometheus-account
 #        endpoint:
@@ -130,6 +132,7 @@ kayenta:
 
   stackdriver:
     enabled: false
+#    metadataCachingIntervalMS: 60000
 
   memory:
     enabled: false


### PR DESCRIPTION
Document the metadataCachingIntervalMS setting which can be set in the service-local.yaml - update datadog poller default to 15 minutes due to api limits