### PR TITLE
config(kayenta-core): Add KayentaSerializationConfigurationProperties

### DIFF
--- a/kayenta-core/src/main/java/com/netflix/kayenta/config/KayentaSerializationConfigurationProperties.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/config/KayentaSerializationConfigurationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 
 package com.netflix.kayenta.atlas.config;
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.Data;
 
+@Data
 public class KayentaSerializationConfigurationProperties {
 
-  @Getter @Setter private boolean writeDatesAsTimestamps = false;
+  private boolean writeDatesAsTimestamps = false;
 
-  @Getter @Setter private boolean writeDurationsAsTimestamps = false;
+  private boolean writeDurationsAsTimestamps = false;
 }

--- a/kayenta-core/src/main/java/com/netflix/kayenta/config/KayentaSerializationConfigurationProperties.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/config/KayentaSerializationConfigurationProperties.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.atlas.config;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class KayentaSerializationConfigurationProperties {
+
+  @Getter @Setter private boolean writeDatesAsTimestamps = false;
+
+  @Getter @Setter private boolean writeDurationsAsTimestamps = false;
+}

--- a/kayenta-core/src/main/java/com/netflix/kayenta/retrofit/config/RetrofitClientConfiguration.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/retrofit/config/RetrofitClientConfiguration.java
@@ -17,6 +17,7 @@
 package com.netflix.kayenta.retrofit.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.kayenta.atlas.config.KayentaSerializationConfigurationProperties;
 import com.netflix.kayenta.config.KayentaConfiguration;
 import com.netflix.spinnaker.config.OkHttpClientConfiguration;
 import com.netflix.spinnaker.orca.retrofit.exceptions.RetrofitExceptionHandler;
@@ -60,7 +61,10 @@ public class RetrofitClientConfiguration {
   @ConditionalOnMissingBean(ObjectMapper.class)
   ObjectMapper retrofitObjectMapper() {
     ObjectMapper objectMapper = new ObjectMapper();
-    KayentaConfiguration.configureObjectMapperFeatures(objectMapper);
+    KayentaSerializationConfigurationProperties kayentaSerializationConfigurationProperties =
+        new KayentaSerializationConfigurationProperties();
+    KayentaConfiguration.configureObjectMapperFeatures(
+        objectMapper, kayentaSerializationConfigurationProperties);
     return objectMapper;
   }
 }

--- a/kayenta-core/src/test/groovy/com/netflix/kayenta/metrics/CanaryScopeSpec.groovy
+++ b/kayenta-core/src/test/groovy/com/netflix/kayenta/metrics/CanaryScopeSpec.groovy
@@ -17,10 +17,9 @@
 package com.netflix.kayenta.metrics
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.kayenta.atlas.config.KayentaSerializationConfigurationProperties
 import com.netflix.kayenta.canary.CanaryScope
 import com.netflix.kayenta.config.KayentaConfiguration
-import com.netflix.kayenta.retrofit.config.RetrofitClientConfiguration
-import org.springframework.beans.factory.annotation.Autowired
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -58,7 +57,9 @@ class CanaryScopeSpec extends Specification {
 
   private ObjectMapper myObjectMapper() {
     ObjectMapper objectMapper = new ObjectMapper();
-    KayentaConfiguration.configureObjectMapperFeatures(objectMapper);
+    KayentaSerializationConfigurationProperties kayentaSerializationConfigurationProperties = new KayentaSerializationConfigurationProperties();
+    kayentaSerializationConfigurationProperties.setWriteDatesAsTimestamps(false);
+    KayentaConfiguration.configureObjectMapperFeatures(objectMapper, kayentaSerializationConfigurationProperties);
     return objectMapper;
   }
 

--- a/kayenta-core/src/test/groovy/com/netflix/kayenta/metrics/CanaryScopeSpec.groovy
+++ b/kayenta-core/src/test/groovy/com/netflix/kayenta/metrics/CanaryScopeSpec.groovy
@@ -57,9 +57,7 @@ class CanaryScopeSpec extends Specification {
 
   private ObjectMapper myObjectMapper() {
     ObjectMapper objectMapper = new ObjectMapper();
-    KayentaSerializationConfigurationProperties kayentaSerializationConfigurationProperties = new KayentaSerializationConfigurationProperties();
-    kayentaSerializationConfigurationProperties.setWriteDatesAsTimestamps(false);
-    KayentaConfiguration.configureObjectMapperFeatures(objectMapper, kayentaSerializationConfigurationProperties);
+    KayentaConfiguration.configureObjectMapperFeatures(objectMapper, new KayentaSerializationConfigurationProperties());
     return objectMapper;
   }
 

--- a/kayenta-core/src/test/groovy/com/netflix/kayenta/util/KayentaSerializationConfigurationPropertiesTest.groovy
+++ b/kayenta-core/src/test/groovy/com/netflix/kayenta/util/KayentaSerializationConfigurationPropertiesTest.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.kayenta.util
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.kayenta.atlas.config.KayentaSerializationConfigurationProperties
+import com.netflix.kayenta.config.KayentaConfiguration
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.time.Duration
+import java.time.Instant
+
+class KayentaSerializationConfigurationPropertiesTest extends Specification {
+    private final String testInstantString = "1970-01-01T01:01:01Z"
+    private final Instant instant = Instant.parse(testInstantString)
+    private final Duration duration = Duration.between(Instant.EPOCH, instant)
+
+    @Unroll
+    void "Test Data and Duration serialization - #description"() {
+        setup:
+        ObjectMapper objectMapper = new ObjectMapper()
+        KayentaSerializationConfigurationProperties properties = new KayentaSerializationConfigurationProperties()
+        properties.setWriteDatesAsTimestamps(datesAsTimestamps)
+        properties.setWriteDurationsAsTimestamps(durationsAsTimestamps)
+        KayentaConfiguration.configureObjectMapperFeatures(objectMapper, properties)
+
+        when:
+        StringWriter jsonStream = new StringWriter()
+        objectMapper.writeValue(jsonStream, instant)
+        String instantJson = jsonStream.toString()
+
+        and:
+        jsonStream = new StringWriter()
+        objectMapper.writeValue(jsonStream, duration)
+        String durationJson = jsonStream.toString()
+
+        then:
+        instantJson.replace('"', '') == instantString
+        durationJson.replace('"', '')  == durationString
+
+        where:
+        description                                  | datesAsTimestamps | durationsAsTimestamps || instantString          | durationString
+        "Dates as String, Durations as String"       | false             | false                 || "1970-01-01T01:01:01Z" | "PT1H1M1S"
+        "Dates as Timestamp, Durations as String"    | true              | false                 || "3661.000000000"       | "PT1H1M1S"
+        "Dates as String, Durations as Timestamp"    | false             | true                  || "1970-01-01T01:01:01Z" | "3661.000000000"
+        "Dates as Timestamp, Durations as Timestamp" | true              | true                  || "3661.000000000"       | "3661.000000000"
+    }
+}

--- a/kayenta-web/config/kayenta.yml
+++ b/kayenta-web/config/kayenta.yml
@@ -157,6 +157,11 @@ kayenta:
       attempts: 10
       backoffPeriodMultiplierMs: 1000
 
+  # Set the serialization options for springboot.jackson
+  serialization:
+    writeDatesAsTimestamps: false
+    writeDurationsAsTimestamps: false
+
 management.endpoints.web.exposure.include: '*'
 management.endpoint.health.show-details: always
 


### PR DESCRIPTION
A recent change to the `springboot.jackson.ObjectMapper`'s serialization behaviour changed the way `canaryDuration` is serialized in canary reports. This PR adds a configuration section to control that behaviour, and sets to default to match the behaviour before the change.

Jackson 2.10+ changes the default behaviour for serializing Duration from String to Timestamp.
The behaviour is already being set explicitly for Date objects, but wasn't addressed for Duration objects.
Rather than setting this property explicitly, I added a configuration stanza to `kayenta.yml` to allow users to set their preferred behaviour, and defaulting to the old behaviour of encoding both Date and Duration as Strings.

Before (with the updated serialization behaviour):
```
"canaryDuration": 1800000
```

After (with `writeDurationsAsTimestamps: false` in `kayenta.yml`):
```
"canaryDuration": "PT30M"
```

You can set either `Date`, `Duration`, or both to be serialized as Integer milliseconds by setting
```
kayenta:
  serialization:
    writeDatesAsTimestamp: true
    writeDurationsAsTimestamp: true
```
in `kayenta.yml`