### PR TITLE
fix(build): renable and reverse logic to prevent the accidental disabling of integration tests

### DIFF
--- a/kayenta-integration-tests/kayenta-integration-tests.gradle
+++ b/kayenta-integration-tests/kayenta-integration-tests.gradle
@@ -16,8 +16,8 @@ test.testLogging {
 
 gradle.taskGraph.whenReady {
     tasks.test.enabled = (
-      properties.getOrDefault('ENABLE_INTEGRATION_TESTS', 'false') == 'true'
-        || System.getProperty('ENABLE_INTEGRATION_TESTS', 'false') == 'true'
-        || System.getenv().getOrDefault('ENABLE_INTEGRATION_TESTS', 'false') == 'true'
+      properties.getOrDefault('DISABLE_INTEGRATION_TESTS', 'false') != 'true'
+        || System.getProperty('DISABLE_INTEGRATION_TESTS', 'false') != 'true'
+        || System.getenv().getOrDefault('DISABLE_INTEGRATION_TESTS', 'false') != 'true'
     )
 }

--- a/kayenta-integration-tests/src/test/java/com/netflix/kayenta/configuration/MetricsReportingConfiguration.java
+++ b/kayenta-integration-tests/src/test/java/com/netflix/kayenta/configuration/MetricsReportingConfiguration.java
@@ -20,6 +20,8 @@ import com.netflix.kayenta.metrics.MetricsGenerator;
 import com.netflix.kayenta.metrics.PercentilePrecisionMeterConfigurationFilter;
 import com.netflix.kayenta.metrics.RandomProvider;
 import com.netflix.kayenta.steps.StandaloneCanaryAnalysisSteps;
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Registry;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,6 +32,14 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(CanaryAnalysisCasesConfigurationProperties.class)
 @Configuration
 public class MetricsReportingConfiguration {
+
+  /**
+   * Override the spectator registry so that the spring composite micrometer registry gets created.
+   */
+  @Bean
+  Registry registry() {
+    return new DefaultRegistry();
+  }
 
   @Bean
   public RandomProvider randomProvider() {


### PR DESCRIPTION
This PR: https://github.com/spinnaker/kayenta/pull/708/files disabled integration tests and they have not been running since April, when I thought they had been.

This PR reverses the logic to make them opt-out rather than opt-in so they do not get accidentally disabled.