### PR TITLE
fix(retry): Retry logic wasn't properly checking the response for nulls

### DIFF
--- a/kayenta-core/src/main/java/com/netflix/kayenta/metrics/SynchronousQueryProcessor.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/metrics/SynchronousQueryProcessor.java
@@ -151,6 +151,10 @@ public class SynchronousQueryProcessor {
       // retry in case of network errors
       return true;
     }
+    if (e.getResponse() == null) {
+      // We don't have a network error, but the response is null. It's better to not retry these.
+      return false;
+    }
     HttpStatus responseStatus = HttpStatus.resolve(e.getResponse().getStatus());
     if (responseStatus == null) {
       return false;
@@ -160,7 +164,8 @@ public class SynchronousQueryProcessor {
   }
 
   private boolean isNetworkError(RetrofitError e) {
-    return e.getResponse() == null && e.getCause() instanceof IOException;
+    return e.getKind() == RetrofitError.Kind.NETWORK
+        || (e.getResponse() == null && e.getCause() instanceof IOException);
   }
 
   public Map<String, ?> processQueryAndReturnMap(


### PR DESCRIPTION
We were hitting a strange end case (usually associated with a timeout) where the cause was not an IOException but the response was null. This was often associated with a read timeout, which is probably not safe to retry.
First time touching this code. Happy for any and all feedback.