### PR TITLE
chore(dockerfile): change deprecated maintainer instructor to label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN tar -xf /tmp/workdir/kayenta-web/build/distributions/kayenta.tar -C /opt
 #
 FROM alpine:3.11
 
-MAINTAINER delivery-engineering@netflix.com
+LABEL maintainer="delivery-engineering@netflix.com"
 
 RUN apk --no-cache add --update openjdk8-jre
 


### PR DESCRIPTION
## What

As title. The `MAINTAINER` label is deprecated and now we should use `LABEL` instead.

## Ref

https://docs.docker.com/engine/reference/builder/#maintainer-deprecated