### PR TITLE
fix(config): include updatedTimestamp when indexing configs

### DIFF
--- a/kayenta-objectstore-configbin/src/main/java/com/netflix/kayenta/configbin/storage/ConfigBinStorageService.java
+++ b/kayenta-objectstore-configbin/src/main/java/com/netflix/kayenta/configbin/storage/ConfigBinStorageService.java
@@ -351,6 +351,8 @@ public class ConfigBinStorageService implements StorageService {
     return new ImmutableMap.Builder<String, Object>()
         .put("id", id)
         .put("name", config.getName())
+        .put("updatedTimestamp", config.getUpdatedTimestamp())
+        .put("updatedTimestampIso", config.getUpdatedTimestampIso())
         .build();
   }
 }


### PR DESCRIPTION
When using ConfigBin (i.e. working at Netflix), all the canary configs appear to have been updated very recently (but not all at the same time). It's because of [this block of code in the CanaryConfigIndexingAgent](https://github.com/spinnaker/kayenta/blob/master/kayenta-core/src/main/java/com/netflix/kayenta/index/CanaryConfigIndexingAgent.java#L156-L163):
```java
                Long updatedTimestamp = (Long) canaryConfigSummary.get("updatedTimestamp");
                String updatedTimestampIso =
                    (String) canaryConfigSummary.get("updatedTimestampIso");

                if (updatedTimestamp == null) {
                  updatedTimestamp = canaryConfigIndex.getRedisTime();
                  updatedTimestampIso = Instant.ofEpochMilli(updatedTimestamp).toString();
                }
```
This will work a lot better when we supply the `updatedTimestamp` to the agent.