### PR TITLE
fix(kubernetes): Adding STS Jar to classpath

### DIFF
--- a/kayenta-aws/kayenta-aws.gradle
+++ b/kayenta-aws/kayenta-aws.gradle
@@ -2,4 +2,5 @@ dependencies {
   implementation project(":kayenta-core")
 
   api "com.amazonaws:aws-java-sdk-s3"
+  api "com.amazonaws:aws-java-sdk-sts"
 }


### PR DESCRIPTION
With this, anyone that uses a task role inside EKS will be able to access
S3 buckets granted to them by their task-role.

Fixes #790 
