### PR TITLE
Support Negated Filters and Multiple QueryPair values when building SignalFlow

### DIFF
--- a/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/metrics/SimpleSignalFlowProgramBuilderTest.java
+++ b/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/metrics/SimpleSignalFlowProgramBuilderTest.java
@@ -269,4 +269,97 @@ public class SimpleSignalFlowProgramBuilderTest {
 
     assertEquals(expected, builder.build());
   }
+
+  @Test
+  public void
+      test_that_the_program_builder_builds_the_expected_program_when_query_pair_is_negated() {
+    String metricName = "request.count";
+    String aggregationMethod = "mean";
+
+    SignalFxCanaryScope scope = new SignalFxCanaryScope();
+    SignalFxScopeConfiguration scopeConfiguration = new SignalFxScopeConfiguration();
+    scope.setScope("1.0.0");
+    scope.setScopeKey("version");
+    scope.setExtendedScopeParams(
+        ImmutableMap.of(
+            "env", "production",
+            "_scope_key", "version"));
+
+    SimpleSignalFlowProgramBuilder builder =
+        SimpleSignalFlowProgramBuilder.create(metricName, aggregationMethod, scopeConfiguration);
+
+    builder.withQueryPair(new QueryPair("!app", "cms"));
+    builder.withScope(scope);
+
+    String expected =
+        "data('request.count', filter="
+            + "(not filter('app', 'cms')) "
+            + "and filter('version', '1.0.0') "
+            + "and filter('env', 'production'))"
+            + ".mean(by=['env', 'version']).publish()";
+
+    assertEquals(expected, builder.build());
+  }
+
+  @Test
+  public void
+      test_that_the_program_builder_builds_the_expected_program_when_query_pair_has_comma_in_value() {
+    String metricName = "request.count";
+    String aggregationMethod = "mean";
+
+    SignalFxCanaryScope scope = new SignalFxCanaryScope();
+    SignalFxScopeConfiguration scopeConfiguration = new SignalFxScopeConfiguration();
+    scope.setScope("1.0.0");
+    scope.setScopeKey("version");
+    scope.setExtendedScopeParams(
+        ImmutableMap.of(
+            "env", "production",
+            "_scope_key", "version"));
+
+    SimpleSignalFlowProgramBuilder builder =
+        SimpleSignalFlowProgramBuilder.create(metricName, aggregationMethod, scopeConfiguration);
+
+    builder.withQueryPair(new QueryPair("app", "cms,api"));
+    builder.withScope(scope);
+
+    String expected =
+        "data('request.count', filter="
+            + "filter('app', 'cms','api') "
+            + "and filter('version', '1.0.0') "
+            + "and filter('env', 'production'))"
+            + ".mean(by=['env', 'version']).publish()";
+
+    assertEquals(expected, builder.build());
+  }
+
+  @Test
+  public void
+      test_that_the_program_builder_builds_the_expected_program_when_query_pair_has_comma_in_value_and_is_negated() {
+    String metricName = "request.count";
+    String aggregationMethod = "mean";
+
+    SignalFxCanaryScope scope = new SignalFxCanaryScope();
+    SignalFxScopeConfiguration scopeConfiguration = new SignalFxScopeConfiguration();
+    scope.setScope("1.0.0");
+    scope.setScopeKey("version");
+    scope.setExtendedScopeParams(
+        ImmutableMap.of(
+            "env", "production",
+            "_scope_key", "version"));
+
+    SimpleSignalFlowProgramBuilder builder =
+        SimpleSignalFlowProgramBuilder.create(metricName, aggregationMethod, scopeConfiguration);
+
+    builder.withQueryPair(new QueryPair("!app", "cms,api"));
+    builder.withScope(scope);
+
+    String expected =
+        "data('request.count', filter="
+            + "(not filter('app', 'cms','api')) "
+            + "and filter('version', '1.0.0') "
+            + "and filter('env', 'production'))"
+            + ".mean(by=['env', 'version']).publish()";
+
+    assertEquals(expected, builder.build());
+  }
 }


### PR DESCRIPTION
## Summary of Changes

This MR addresses the following two use cases for generating SignalFX SignalFlow which are currently not properly supported.

1. **Negated Filters**

For example, in SignalFX, when building SignalFlow, the following is valid:

```
!app:cms
```

which would translate to the following SignalFlow

```
filter=(not filter('app', 'cms'))
```

However, if you tried to use `!code` when defining the `key` for Query Pairs in Kayenta SignalFX, it would generate the following SignalFlow.

```
filter('!app', 'cms')
```
2. **Multiple QueryPair Values**

In SignalFX, when building SignalFlow, the following is valid:

```
app:cms,api
```

which would translate to the following SignalFlow

```
filter('app', 'cms', 'api')
```

However, if you attempted to do this currently using `cms, api` as the `value` in a QueryPair, it would incorrectly generate the following SignalFlow

```
filter('app', 'cms, api')
```

This MR also ensures that the combination of a negated and multiple value query pair is properly handled.

For example, if the following Query Pair is provided:

```
!app:cms,api
```

It would properly generate the following SignalFlow

```
filter=(not filter('app', 'cms', 'api'))
```