### PR TITLE
fix(prometheus): prevent NPE when metricName isn't set

### DIFF
--- a/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/metrics/PrometheusMetricsService.java
+++ b/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/metrics/PrometheusMetricsService.java
@@ -208,6 +208,9 @@ public class PrometheusMetricsService implements MetricsService {
 
       return promQlExpr;
     } else {
+      if (StringUtils.isEmpty(queryConfig.getMetricName())) {
+        throw new IllegalArgumentException("Metric Name is required when query type is Default.");
+      }
       StringBuilder queryBuilder = new StringBuilder(queryConfig.getMetricName());
 
       queryBuilder =


### PR DESCRIPTION
Currently there is no validation before use the MetricName property, which can produce a NPE if there is no value set
Frontend validation https://github.com/spinnaker/deck-kayenta/pull/548

`java.lang.NullPointerException: null
	at java.base/java.lang.StringBuilder.<init>(StringBuilder.java:124) ~[na:na]
	at com.netflix.kayenta.prometheus.metrics.PrometheusMetricsService.buildQuery(PrometheusMetricsService.java:211) ~[kayenta-prometheus.jar:na]
	at com.netflix.kayenta.prometheus.metrics.PrometheusMetricsService.queryMetrics(PrometheusMetricsService.java:253) ~[kayenta-prometheus.jar:na]`


