### PR TITLE
chore(signalfx): bump sfx version and fix integration tests

### DIFF
--- a/kayenta-signalfx/kayenta-signalfx.gradle
+++ b/kayenta-signalfx/kayenta-signalfx.gradle
@@ -109,7 +109,7 @@ integrationTest {
 dependencies {
   implementation project(":kayenta-core")
 
-  api 'com.signalfx.public:signalfx-java:0.0.48'
+  api 'com.signalfx.public:signalfx-java:1.0.5'
 
   testImplementation 'com.tngtech.java:junit-dataprovider:1.13.1'
   testImplementation project(":kayenta-standalone-canary-analysis")

--- a/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/EndToEndCanaryIntegrationTests.java
+++ b/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/EndToEndCanaryIntegrationTests.java
@@ -41,7 +41,7 @@ import org.junit.Test;
 @Slf4j
 public class EndToEndCanaryIntegrationTests extends BaseSignalFxIntegrationTest {
 
-  public static final int CANARY_WINDOW_IN_MINUTES = 1;
+  public static final int CANARY_WINDOW_IN_MINUTES = 5;
 
   @BeforeClass
   public static void beforeClass() {

--- a/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/EndToEndStandaloneCanaryAnalysisIntegrationTests.java
+++ b/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/EndToEndStandaloneCanaryAnalysisIntegrationTests.java
@@ -64,8 +64,8 @@ public class EndToEndStandaloneCanaryAnalysisIntegrationTests extends BaseSignal
                         .step(1L)
                         .build()))
             .thresholds(CanaryClassifierThresholdsConfig.builder().marginal(50D).pass(75D).build())
-            .lifetimeDurationMins(3L)
-            .analysisIntervalMins(1L)
+            .lifetimeDurationMins(5L)
+            .analysisIntervalMins(2L)
             .build();
 
     request.setExecutionRequest(executionRequest);

--- a/kayenta-signalfx/src/integration-test/resources/integration-test-canary-config.json
+++ b/kayenta-signalfx/src/integration-test/resources/integration-test-canary-config.json
@@ -26,18 +26,7 @@
     {
       "name": "Bad Request Rate for /v1/some-endpoint",
       "query": {
-        "metricName": "kayenta.integration-test.request.count",
-        "queryPairs": [
-          {
-            "key": "uri",
-            "value": "/v1/some-endpoint"
-          },
-          {
-            "key": "status_code",
-            "value": "4*"
-          }
-        ],
-        "aggregationMethod": "sum",
+        "customInlineTemplate": "data('kayenta.integration-test.request.count', filter=filter('uri', '/v1/some-endpoint') and filter('status_code', '4*') and filter('canary-scope', '${scope}') and filter('location', '${location}')).mean(by=['location', 'canary-scope']).publish()",
         "serviceType": "signalfx",
         "type": "signalfx"
       },


### PR DESCRIPTION
- Fixed integration tests that were failing due to timing and query issues
- Upgraded signalfx version to 1.0.5
