### PR TITLE
fix(azure): HTTPS support for Azure Storage (spinnaker#6205)

### DIFF
--- a/kayenta-azure/src/main/java/com/netflix/kayenta/azure/security/AzureCredentials.java
+++ b/kayenta-azure/src/main/java/com/netflix/kayenta/azure/security/AzureCredentials.java
@@ -41,7 +41,7 @@ public class AzureCredentials {
 
   public CloudBlobContainer getAzureContainer(String containerName) throws Exception {
     final String storageConnectionString =
-        "DefaultEndpointsProtocol=http;"
+        "DefaultEndpointsProtocol=https;"
             + "AccountName="
             + this.storageAccountName
             + ";"


### PR DESCRIPTION
**Why:**
- Kayenta has support for storing objects and metrics in Azure Storage but it's hardcoded to HTTP.
- HTTP is insecure.
- Azure Storage by default supports HTTPS.

**What:**
- Changed `DefaultEndpointsProtocol` to HTTPS

**Issue:**
- https://github.com/spinnaker/spinnaker/issues/6205
