### PR TITLE
fix(datadog): check for null values in datadog time series

### DIFF
--- a/kayenta-datadog/src/main/java/com/netflix/kayenta/datadog/service/DatadogTimeSeries.java
+++ b/kayenta-datadog/src/main/java/com/netflix/kayenta/datadog/service/DatadogTimeSeries.java
@@ -58,7 +58,7 @@ public class DatadogTimeSeries {
 
         // If the point at this index matches the timestamp at this position,
         // add the value to the array and advance the index.
-        if (point.get(0).longValue() == time) {
+        if (point.get(0).longValue() == time && point.get(1) != null) {
           this.adjustedPointList.add(point.get(1).doubleValue());
           idx++;
         } else {


### PR DESCRIPTION
hi there! I noticed that a time series I was getting back from datadog had `null` values in it, leading to NPEs when the code here was trying to populate from the datadog API response. 

I'm not sure if I chose a strange query to use in DD, or maybe my app isn't reporting metrics in to DD properly? But, I figured I'd pose the PR here anyway in case other people run into the same null pointer exception.

Here's an example API response I was getting from Datadog that had `null` values in it:

```
{
  "status": "ok",
  "res_type": "time_series",
  "from_date": 1612350973000,
  "series": [
    {
      "end": 1612351110000,
      "attributes": {},
      "metric": "(api.request_5xx / api.request_all)",
      "interval": 1,
      "tag_set": [],
      "start": 1612350980000,
      "length": 14,
      "query_index": 0,
      "aggr": "sum",
      "scope": "canary:true,env:lt",
      "pointlist": [
        [
          1612350980000,
          null
        ],
        [
          1612350990000,
          0
        ],
        [
          1612351000000,
          10
        ],
        [
          1612351010000,
          10
        ],
        [
          1612351020000,
          0
        ],
        [
          1612351030000,
          null
        ],
        [
          1612351040000,
          null
        ],
        [
          1612351050000,
          0
        ],
        [
          1612351060000,
          0
        ],
        [
          1612351070000,
          10
        ],
        [
          1612351080000,
          6.666666666666666
        ],
        [
          1612351090000,
          null
        ],
        [
          1612351100000,
          10
        ],
        [
          1612351110000,
          0
        ]
      ],
      "expression": "(sum:api.request_5xx{canary:true,env:lt}.as_count() / sum:api.request_all{canary:true,env:lt})",
      "unit": null,
      "display_name": "(api.request_5xx / api.request_all)"
    }
  ],
  "to_date": 1612351111000,
  "resp_version": 1,
  "query": "sum:api.request_5xx{env:lt,canary:true}.as_count()/sum:api.request_all{env:lt,canary:true}",
  "message": "",
  "group_by": []
}
```