### PR TITLE
feat: added hooks before archiving executions so that spring security…

### DIFF
--- a/kayenta-core/src/main/java/com/netflix/kayenta/config/KayentaConfiguration.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/config/KayentaConfiguration.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.common.collect.ImmutableList;
 import com.netflix.kayenta.atlas.config.KayentaSerializationConfigurationProperties;
 import com.netflix.kayenta.canary.CanaryMetricSetQueryConfig;
+import com.netflix.kayenta.events.CanaryExecutionCompletedEvent;
 import com.netflix.kayenta.metrics.MapBackedMetricsServiceRepository;
 import com.netflix.kayenta.metrics.MetricSetMixerService;
 import com.netflix.kayenta.metrics.MetricsRetryConfigurationProperties;
@@ -39,8 +40,10 @@ import com.netflix.spinnaker.kork.jackson.ObjectMapperSubtypeConfigurer;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -68,6 +71,12 @@ public class KayentaConfiguration {
   @ConditionalOnMissingBean(AccountCredentialsRepository.class)
   AccountCredentialsRepository accountCredentialsRepository() {
     return new MapBackedAccountCredentialsRepository();
+  }
+
+  @Bean
+  @Qualifier("pre-canary-execution-archive-hook")
+  Consumer<CanaryExecutionCompletedEvent> preCanaryArchiveHook() {
+    return (event) -> log.debug("no-op pre-canary execution archive hook");
   }
 
   @Bean

--- a/kayenta-core/src/main/java/com/netflix/kayenta/events/listeners/ExecutionArchivalListener.kt
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/events/listeners/ExecutionArchivalListener.kt
@@ -21,15 +21,19 @@ import com.netflix.kayenta.security.AccountCredentials
 import com.netflix.kayenta.security.AccountCredentialsRepository
 import com.netflix.kayenta.storage.ObjectType
 import com.netflix.kayenta.storage.StorageServiceRepository
+import java.util.function.Consumer
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory.getLogger
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 
 @Component
 class ExecutionArchivalListener(
   private val accountCredentialsRepository: AccountCredentialsRepository,
-  private val storageServiceRepository: StorageServiceRepository
+  private val storageServiceRepository: StorageServiceRepository,
+  @Qualifier("pre-canary-execution-archive-hook")
+  private val preCanaryArchiveHook: Consumer<CanaryExecutionCompletedEvent>
 ) {
 
   init {
@@ -38,6 +42,7 @@ class ExecutionArchivalListener(
 
   @EventListener
   fun onApplicationEvent(event: CanaryExecutionCompletedEvent) {
+    preCanaryArchiveHook.accept(event)
     val response = event.canaryExecutionStatusResponse
     val storageAccountName = response.storageAccountName
     if (storageAccountName != null) {

--- a/kayenta-standalone-canary-analysis/src/main/java/com/netflix/kayenta/standalonecanaryanalysis/config/StandaloneCanaryAnalysisModuleConfiguration.java
+++ b/kayenta-standalone-canary-analysis/src/main/java/com/netflix/kayenta/standalonecanaryanalysis/config/StandaloneCanaryAnalysisModuleConfiguration.java
@@ -16,8 +16,12 @@
 
 package com.netflix.kayenta.standalonecanaryanalysis.config;
 
+import com.netflix.kayenta.standalonecanaryanalysis.event.StandaloneCanaryAnalysisExecutionCompletedEvent;
+import java.util.function.Consumer;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
@@ -25,4 +29,10 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty("kayenta.standalone-canary-analysis.enabled")
 @ComponentScan({"com.netflix.kayenta.standalonecanaryanalysis"})
 @Slf4j
-public class StandaloneCanaryAnalysisModuleConfiguration {}
+public class StandaloneCanaryAnalysisModuleConfiguration {
+  @Bean
+  @Qualifier("pre-scape-archive-hook")
+  Consumer<StandaloneCanaryAnalysisExecutionCompletedEvent> preScapeArchiveHook() {
+    return (event) -> log.debug("no-op pre-SCAPE archive hook");
+  }
+}

--- a/kayenta-standalone-canary-analysis/src/main/java/com/netflix/kayenta/standalonecanaryanalysis/event/listener/StandaloneCanaryAnalysisExecutionArchivalListener.java
+++ b/kayenta-standalone-canary-analysis/src/main/java/com/netflix/kayenta/standalonecanaryanalysis/event/listener/StandaloneCanaryAnalysisExecutionArchivalListener.java
@@ -6,9 +6,10 @@ import com.netflix.kayenta.standalonecanaryanalysis.event.StandaloneCanaryAnalys
 import com.netflix.kayenta.standalonecanaryanalysis.storage.StandaloneCanaryAnalysisObjectType;
 import com.netflix.kayenta.storage.StorageServiceRepository;
 import java.util.Optional;
+import java.util.function.Consumer;
 import lombok.extern.slf4j.Slf4j;
-import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -18,28 +19,33 @@ public class StandaloneCanaryAnalysisExecutionArchivalListener {
 
   private final AccountCredentialsRepository accountCredentialsRepository;
   private final StorageServiceRepository storageServiceRepository;
+  private final Consumer<StandaloneCanaryAnalysisExecutionCompletedEvent> preScapeArchiveHook;
 
   @Autowired
   public StandaloneCanaryAnalysisExecutionArchivalListener(
       AccountCredentialsRepository accountCredentialsRepository,
-      StorageServiceRepository storageServiceRepository) {
+      StorageServiceRepository storageServiceRepository,
+      @Qualifier("pre-scape-archive-hook")
+          Consumer<StandaloneCanaryAnalysisExecutionCompletedEvent> preScapeArchiveHook) {
     this.accountCredentialsRepository = accountCredentialsRepository;
     this.storageServiceRepository = storageServiceRepository;
+    this.preScapeArchiveHook = preScapeArchiveHook;
   }
 
   @EventListener
   public void onApplicationEvent(StandaloneCanaryAnalysisExecutionCompletedEvent event) {
-    val response = event.getCanaryAnalysisExecutionStatusResponse();
+    preScapeArchiveHook.accept(event);
+    var response = event.getCanaryAnalysisExecutionStatusResponse();
 
     Optional.ofNullable(response.getStorageAccountName())
         .ifPresent(
             storageAccountName -> {
-              val resolvedStorageAccountName =
+              var resolvedStorageAccountName =
                   accountCredentialsRepository
                       .getRequiredOneBy(storageAccountName, AccountCredentials.Type.OBJECT_STORE)
                       .getName();
 
-              val storageService =
+              var storageService =
                   storageServiceRepository.getRequiredOne(resolvedStorageAccountName);
 
               storageService.storeObject(


### PR DESCRIPTION
… authentication details can be read from the pipeline context and injected into the security context in extension projects

See :point_down:  for example usage
![image](https://user-images.githubusercontent.com/711726/111712158-4f837d80-880a-11eb-91fb-25bf9fb3d377.png)
![image](https://user-images.githubusercontent.com/711726/111712137-472b4280-880a-11eb-88f2-b4eabcc525d9.png)
