### PR TITLE
fix(datadog): fix null handling in DatadogTimeSeries

### DIFF
--- a/kayenta-datadog/src/main/java/com/netflix/kayenta/datadog/service/DatadogTimeSeries.java
+++ b/kayenta-datadog/src/main/java/com/netflix/kayenta/datadog/service/DatadogTimeSeries.java
@@ -58,8 +58,13 @@ public class DatadogTimeSeries {
 
         // If the point at this index matches the timestamp at this position,
         // add the value to the array and advance the index.
-        if (point.get(0).longValue() == time && point.get(1) != null) {
-          this.adjustedPointList.add(point.get(1).doubleValue());
+        if (point.get(0).longValue() == time) {
+          if (point.get(1) == null) {
+            this.adjustedPointList.add(Double.NaN);
+          } else {
+            this.adjustedPointList.add(point.get(1).doubleValue());
+          }
+
           idx++;
         } else {
           // Otherwise, put in a NaN to represent the "gap" in the Datadog

--- a/kayenta-datadog/src/test/java/com/netflix/kayenta/datadog/service/DatadogTimeSeriesTest.java
+++ b/kayenta-datadog/src/test/java/com/netflix/kayenta/datadog/service/DatadogTimeSeriesTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.datadog.service;
+
+import static com.netflix.kayenta.datadog.service.DatadogTimeSeries.*;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Test;
+
+public class DatadogTimeSeriesTest {
+
+  private static final long START = 1620785040000L;
+  private static final long INTERVAL_MILLIS = 5000L;
+
+  @Test
+  public void fillsInSparseValuesWithNaN() {
+    DatadogSeriesEntry series =
+        new DatadogSeriesEntry()
+            .setInterval(INTERVAL_MILLIS / 1000)
+            .setStart(START)
+            .setEnd(START + 10 * INTERVAL_MILLIS)
+            .setPointlist(
+                List.of(
+                    Arrays.asList(START + 0 * INTERVAL_MILLIS, 1),
+                    Arrays.asList(START + 2 * INTERVAL_MILLIS, 1),
+                    Arrays.asList(START + 3 * INTERVAL_MILLIS, 1),
+                    Arrays.asList(START + 4 * INTERVAL_MILLIS, 1),
+                    Arrays.asList(START + 10 * INTERVAL_MILLIS, 1)));
+
+    List<Double> expected =
+        List.of(
+            1.0,
+            Double.NaN,
+            1.0,
+            1.0,
+            1.0,
+            Double.NaN,
+            Double.NaN,
+            Double.NaN,
+            Double.NaN,
+            Double.NaN,
+            1.0);
+    assertEquals(expected, series.getDataPoints().collect(Collectors.toList()));
+  }
+
+  @Test
+  public void handlesNullInPointlist() {
+    DatadogSeriesEntry series =
+        new DatadogSeriesEntry()
+            .setInterval(INTERVAL_MILLIS / 1000)
+            .setStart(START)
+            .setEnd(START + 10 * INTERVAL_MILLIS)
+            .setPointlist(
+                List.of(
+                    Arrays.asList(START + 0 * INTERVAL_MILLIS, 1),
+                    Arrays.asList(START + 1 * INTERVAL_MILLIS, null),
+                    Arrays.asList(START + 2 * INTERVAL_MILLIS, 1),
+                    Arrays.asList(START + 3 * INTERVAL_MILLIS, 1),
+                    Arrays.asList(START + 4 * INTERVAL_MILLIS, 1),
+                    Arrays.asList(START + 10 * INTERVAL_MILLIS, 1)));
+
+    List<Double> expected =
+        List.of(
+            1.0,
+            Double.NaN,
+            1.0,
+            1.0,
+            1.0,
+            Double.NaN,
+            Double.NaN,
+            Double.NaN,
+            Double.NaN,
+            Double.NaN,
+            1.0);
+    assertEquals(expected, series.getDataPoints().collect(Collectors.toList()));
+  }
+}


### PR DESCRIPTION
There was an attempted fix for this earlier (https://github.com/spinnaker/kayenta/pull/832) but it's incorrect. That fix caused every adjusted point to become `NaN` after the first `null` value. As an example, the `handlesNullInPointlist` test case would fail with `java.lang.AssertionError: expected:<[1.0, NaN, 1.0, 1.0, 1.0, NaN, NaN, NaN, NaN, NaN, 1.0]> but was:<[1.0, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN]>`

