### PR TITLE
fix(graphite): urlencode target query

### DIFF
--- a/kayenta-graphite/src/main/java/com/netflix/kayenta/graphite/service/GraphiteRemoteService.java
+++ b/kayenta-graphite/src/main/java/com/netflix/kayenta/graphite/service/GraphiteRemoteService.java
@@ -27,7 +27,7 @@ public interface GraphiteRemoteService {
   // From https://graphite.readthedocs.io/en/1.1.2/render_api.html#
   @GET("/render")
   List<GraphiteResults> rangeQuery(
-      @Query(value = "target", encodeValue = false) String target,
+      @Query(value = "target", encodeValue = true) String target,
       @Query("from") long from,
       @Query("until") long until,
       @Query("format") String format);


### PR DESCRIPTION
We noticed on newer versions of graphite and certain queries that the target parameter must be properly urlencoded before being sent to the graphite service via GET. Previously we had set this to false as very old versions of graphite did not handle the url encoding properly, I tested this with our graphite and the change seems safe and fixes the bugs we saw in newer graphites.