### PR TITLE
fix(build): bump kork to 7.110.0 & change groupId for dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,12 @@ plugins {
   id 'idea'
 }
 
-subprojects { project ->
-  group = "com.netflix.kayenta"
+allprojects {
   apply plugin: "io.spinnaker.project"
+}
+
+subprojects { project ->
+  group = "io.spinnaker.kayenta"
 
   if (name != "kayenta-bom") {
     apply plugin: "java-library"
@@ -81,20 +84,24 @@ subprojects { project ->
         api 'com.typesafe.scala-logging:scala-logging_2.12:3.9.2'
         testImplementation 'org.scalatest:scalatest_2.12:3.0.9'
       }
-      implementation platform("com.netflix.spinnaker.orca:orca-bom:$orcaVersion")
+      implementation platform("io.spinnaker.orca:orca-bom:$orcaVersion")
       compileOnly "org.projectlombok:lombok"
-      annotationProcessor platform("com.netflix.spinnaker.orca:orca-bom:$orcaVersion")
+      annotationProcessor platform("io.spinnaker.orca:orca-bom:$orcaVersion")
       annotationProcessor "org.projectlombok:lombok"
       annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
-      testAnnotationProcessor platform("com.netflix.spinnaker.orca:orca-bom:$orcaVersion")
+      testAnnotationProcessor platform("io.spinnaker.orca:orca-bom:$orcaVersion")
       testAnnotationProcessor "org.projectlombok:lombok"
       testCompileOnly "org.projectlombok:lombok"
+
+      implementation(platform("io.spinnaker.kork:kork-bom:$korkVersion"))
+      annotationProcessor(platform("io.spinnaker.kork:kork-bom:$korkVersion"))
+      testAnnotationProcessor(platform("io.spinnaker.kork:kork-bom:$korkVersion"))
 
 
       api "org.slf4j:slf4j-api"
       api "org.springframework.boot:spring-boot-starter-web"
-      api "com.netflix.spinnaker.kork:kork-swagger"
-      api "com.netflix.spinnaker.orca:orca-core"
+      api "io.spinnaker.kork:kork-swagger"
+      api "io.spinnaker.orca:orca-core"
 
       api "com.squareup.retrofit:retrofit"
       api "com.squareup.retrofit:converter-jackson"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 kotlinVersion=1.3.70
-orcaVersion=8.12.0
+orcaVersion=8.16.0
+korkVersion=7.110.0
 org.gradle.parallel=true
 spinnakerGradleVersion=8.10.1
 targetJava11=true

--- a/kayenta-bom/kayenta-bom.gradle
+++ b/kayenta-bom/kayenta-bom.gradle
@@ -21,7 +21,7 @@ javaPlatform {
 }
 
 dependencies {
-  api(platform("com.netflix.spinnaker.orca:orca-bom:$orcaVersion"))
+  api(platform("io.spinnaker.orca:orca-bom:$orcaVersion"))
 
   constraints {
     rootProject

--- a/kayenta-core/kayenta-core.gradle
+++ b/kayenta-core/kayenta-core.gradle
@@ -1,7 +1,7 @@
 dependencies {
   api "redis.clients:jedis"
-  api "com.netflix.spinnaker.kork:kork-core"
-  api "com.netflix.spinnaker.kork:kork-web"
+  api "io.spinnaker.kork:kork-core"
+  api "io.spinnaker.kork:kork-web"
   api "com.netflix.spectator:spectator-api"
 
   // TODO update korkSwagger?
@@ -9,8 +9,8 @@ dependencies {
   api "io.springfox:springfox-swagger-ui:2.9.2"
   api "io.springfox:springfox-swagger2:2.9.2"
 
-  api "com.netflix.spinnaker.orca:orca-core"
-  api "com.netflix.spinnaker.orca:orca-retrofit"
+  api "io.spinnaker.orca:orca-core"
+  api "io.spinnaker.orca:orca-retrofit"
   api "net.lariverosc:jesque-spring:1.0.1"
   api "net.greghaines:jesque:1.3.1"
 
@@ -22,5 +22,5 @@ dependencies {
   api "org.springframework.boot:spring-boot-starter-json"
   api "net.logstash.logback:logstash-logback-encoder"
 
-  testImplementation "com.netflix.spinnaker.kork:kork-jedis-test"
+  testImplementation "io.spinnaker.kork:kork-jedis-test"
 }

--- a/kayenta-gcs/kayenta-gcs.gradle
+++ b/kayenta-gcs/kayenta-gcs.gradle
@@ -2,6 +2,6 @@ dependencies {
   implementation project(":kayenta-core")
   implementation project(":kayenta-google")
 
-  api "com.netflix.spinnaker.kork:kork-exceptions"
+  api "io.spinnaker.kork:kork-exceptions"
   api "com.google.apis:google-api-services-storage"
 }

--- a/kayenta-graphite/kayenta-graphite.gradle
+++ b/kayenta-graphite/kayenta-graphite.gradle
@@ -181,7 +181,7 @@ dependencies {
 
     // Apache 2.0 https://github.com/rest-assured/rest-assured/blob/master/LICENSE
     integrationTestCompile 'io.rest-assured:rest-assured:4.3.2'
-    integrationTestAnnotationProcessor platform("com.netflix.spinnaker.orca:orca-bom:$orcaVersion")
+    integrationTestAnnotationProcessor platform("io.spinnaker.orca:orca-bom:$orcaVersion")
     integrationTestAnnotationProcessor "org.projectlombok:lombok"
     integrationTestCompileOnly "org.projectlombok:lombok"
 }

--- a/kayenta-integration-tests/kayenta-integration-tests.gradle
+++ b/kayenta-integration-tests/kayenta-integration-tests.gradle
@@ -6,8 +6,9 @@ dependencies {
     testCompile 'io.micrometer:micrometer-registry-prometheus'
     testCompile 'io.micrometer:micrometer-registry-graphite'
     testCompile 'org.springframework.cloud:spring-cloud-starter:2.1.2.RELEASE'// needed for bootstrap phase when all embedded containers are setup
-    testCompile 'com.playtika.testcontainers:embedded-redis:1.85'
-    testCompile 'com.playtika.testcontainers:embedded-minio:1.85'
+    testCompile 'com.playtika.testcontainers:embedded-redis:1.89'
+    testCompile 'com.playtika.testcontainers:embedded-minio:1.89'
+    testCompile 'org.testcontainers:testcontainers:1.15.1'
 }
 
 test.testLogging {

--- a/kayenta-orca/kayenta-orca.gradle
+++ b/kayenta-orca/kayenta-orca.gradle
@@ -1,14 +1,14 @@
 apply from: "$rootDir/gradle/kotlin.gradle"
 
 dependencies {
-  api "com.netflix.spinnaker.orca:keiko-spring"
-  api "com.netflix.spinnaker.orca:orca-queue"
-  api "com.netflix.spinnaker.orca:orca-queue-redis"
-  api "com.netflix.spinnaker.orca:orca-redis"
+  api "io.spinnaker.orca:keiko-spring"
+  api "io.spinnaker.orca:orca-queue"
+  api "io.spinnaker.orca:orca-queue-redis"
+  api "io.spinnaker.orca:orca-redis"
   api "org.springframework.boot:spring-boot-starter-actuator"
 
   // TODO(duftler): Move these to spinnaker-dependencies.
-  testImplementation "com.netflix.spinnaker.orca:orca-test"
+  testImplementation "io.spinnaker.orca:orca-test"
 
   testImplementation "com.natpryce:hamkrest"
 }

--- a/kayenta-signalfx/kayenta-signalfx.gradle
+++ b/kayenta-signalfx/kayenta-signalfx.gradle
@@ -124,7 +124,7 @@ dependencies {
   // Apache 2.0 https://github.com/rest-assured/rest-assured/blob/master/LICENSE
   integrationTestCompile 'io.rest-assured:rest-assured:4.3.2'
 
-  integrationTestAnnotationProcessor platform("com.netflix.spinnaker.orca:orca-bom:$orcaVersion")
+  integrationTestAnnotationProcessor platform("io.spinnaker.orca:orca-bom:$orcaVersion")
   integrationTestAnnotationProcessor "org.projectlombok:lombok"
   integrationTestCompileOnly "org.projectlombok:lombok"
 }

--- a/kayenta-web/kayenta-web.gradle
+++ b/kayenta-web/kayenta-web.gradle
@@ -38,8 +38,8 @@ dependencies {
   api project(':kayenta-wavefront')
 
   api "org.springframework.boot:spring-boot-starter-actuator"
-  api "com.netflix.spinnaker.kork:kork-web"
-  implementation "com.netflix.spinnaker.kork:kork-plugins"
-  runtimeOnly "com.netflix.spinnaker.kork:kork-secrets-aws"
-  runtimeOnly "com.netflix.spinnaker.kork:kork-secrets-gcp"
+  api "io.spinnaker.kork:kork-web"
+  implementation "io.spinnaker.kork:kork-plugins"
+  runtimeOnly "io.spinnaker.kork:kork-secrets-aws"
+  runtimeOnly "io.spinnaker.kork:kork-secrets-gcp"
 }


### PR DESCRIPTION
There is an issue in the Plugins Framework that was solved in this PR: spinnaker/kork#866

but this fix was released in kork 7.110.0

I bumped the version of kork to include the fix in VersionManager in the plugins framework but this involved changing the groupId of kork because now it's been published under "io.spinnaker" and this release branch is pretty old.

I had to bump the version of Fiat as well because it has issues when trying to download the kork version in fiat due to the groupId change.
