### PR TITLE
fix(timeouts): Enable timeout configs on retrofit

### DIFF
--- a/kayenta-core/src/main/java/com/netflix/kayenta/retrofit/config/RetrofitClientConfiguration.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/retrofit/config/RetrofitClientConfiguration.java
@@ -29,7 +29,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.*;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeUnit;
 
 @Configuration
 public class RetrofitClientConfiguration {

--- a/kayenta-core/src/main/java/com/netflix/kayenta/retrofit/config/RetrofitClientConfiguration.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/retrofit/config/RetrofitClientConfiguration.java
@@ -23,23 +23,23 @@ import com.netflix.spinnaker.config.OkHttpClientConfiguration;
 import com.netflix.spinnaker.orca.retrofit.exceptions.RetrofitExceptionHandler;
 import com.squareup.okhttp.ConnectionPool;
 import com.squareup.okhttp.OkHttpClient;
+import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.*;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
-import java.util.concurrent.TimeUnit;
 
 @Configuration
 public class RetrofitClientConfiguration {
-  
+
   @Value("${ok-http-client.connection-pool.read-timeout-ms:30000}")
   long readTimeoutMs;
 
   @Value("${ok-http-client.connection-pool.connect-timeout-ms:5000}")
   long connectTimeoutMs;
-    
+
   @Value("${ok-http-client.connection-pool.max-idle-connections:5}")
   int maxIdleConnections;
 

--- a/kayenta-core/src/main/java/com/netflix/kayenta/retrofit/config/RetrofitClientConfiguration.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/retrofit/config/RetrofitClientConfiguration.java
@@ -29,10 +29,17 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.*;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import java.util.concurrent.TimeUnit
 
 @Configuration
 public class RetrofitClientConfiguration {
+  
+  @Value("${ok-http-client.connection-pool.read-timeout-ms:30000}")
+  long readTimeoutMs;
 
+  @Value("${ok-http-client.connection-pool.connect-timeout-ms:5000}")
+  long connectTimeoutMs;
+    
   @Value("${ok-http-client.connection-pool.max-idle-connections:5}")
   int maxIdleConnections;
 
@@ -48,6 +55,8 @@ public class RetrofitClientConfiguration {
     OkHttpClient okHttpClient = okHttpClientConfig.create();
     okHttpClient.setConnectionPool(new ConnectionPool(maxIdleConnections, keepAliveDurationMs));
     okHttpClient.setRetryOnConnectionFailure(retryOnConnectionFailure);
+    okHttpClient.setConnectTimeout(connectTimeoutMs, TimeUnit.MILLISECONDS);
+    okHttpClient.setReadTimeout(readTimeoutMs, TimeUnit.MILLISECONDS);
     return okHttpClient;
   }
 


### PR DESCRIPTION
Adds read & connect timeouts to increase from default 10 seconds Ok http client uses.  Probably need to adjust:
https://github.com/spinnaker/kayenta/blob/master/kayenta-core/src/main/java/com/netflix/kayenta/retrofit/config/RetrofitClientFactory.java
to ALSO support these settings...
