### PR TITLE
chore(dependencies): bump orcaVersion to 8.18.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-orcaVersion=8.18.0
+orcaVersion=8.18.2
 org.gradle.parallel=true
 spinnakerGradleVersion=8.15.0
 targetJava11=true


### PR DESCRIPTION
Kayenta is failing with the following exception on startup:

```
2022-02-15 16:33:30.908 ERROR 1 --- [           main] o.s.b.d.LoggingFailureAnalysisReporter   : 

***************************
APPLICATION FAILED TO START
***************************

Description:

An attempt was made to call a method that does not exist. The attempt was made from the following location:

    com.netflix.spinnaker.kork.plugins.config.SpringEnvironmentConfigResolver.<init>(SpringEnvironmentConfigResolver.kt:61)

The following method did not exist:

    'void com.fasterxml.jackson.module.kotlin.KotlinModule.<init>(int, boolean, boolean, boolean, com.fasterxml.jackson.module.kotlin.SingletonSupport, int, kotlin.jvm.internal.DefaultConstructorMarker)'

The method's class, com.fasterxml.jackson.module.kotlin.KotlinModule, is available from the following locations:

    jar:file:/opt/kayenta/lib/jackson-module-kotlin-2.12.3.jar!/com/fasterxml/jackson/module/kotlin/KotlinModule.class

It was loaded from the following location:

    file:/opt/kayenta/lib/jackson-module-kotlin-2.12.3.jar
```

The reason of this issue is because Kayenta depends on Orca and use the version of kork behind Orca. The fix for this issue is in this PR: https://github.com/spinnaker/kork/pull/908 but I had to create a new Orca release that contains the kork's version with the fix I mentioned above.

SO this change only bumps orcaVersion to get the correct kork in Kayenta.