### PR TITLE
chore(ci): GHA - plugin builds require SemVer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-java@v2
         with:
           java-version: 11
@@ -26,7 +28,7 @@ jobs:
         id: build_variables
         run: |
           echo ::set-output name=REPO::${GITHUB_REPOSITORY##*/}
-          echo ::set-output name=VERSION::"${GITHUB_REF_NAME}-${GITHUB_SHA::8}-$(date --utc +'%Y%m%d%H%M')"
+          echo ::set-output name=VERSION::"$(git describe --tags --abbrev=0 --match="v[0-9]*" | cut -c2-)-dev-${GITHUB_REF_NAME}-${GITHUB_SHA::8}-$(date --utc +'%Y%m%d%H%M')"
       - name: Build
         env:
           ORG_GRADLE_PROJECT_version: ${{ steps.build_variables.outputs.VERSION }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -64,6 +64,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-java@v2
         with:
           java-version: 11
@@ -73,8 +75,10 @@ jobs:
         id: build_variables
         run: |
           echo ::set-output name=REPO::${GITHUB_REPOSITORY##*/}
-          echo ::set-output name=VERSION::"${GITHUB_SHA::8}-$(date --utc +'%Y%m%d%H%M')"
+          echo ::set-output name=VERSION::"$(git describe --tags --abbrev=0 --match="v[0-9]*" | cut -c2-)-dev-pr-${GITHUB_SHA::8}-$(date --utc +'%Y%m%d%H%M')"
       - name: Build
+        env:
+          ORG_GRADLE_PROJECT_version: ${{ steps.build_variables.outputs.VERSION }}
         run: ./gradlew build ${{ steps.build_variables.outputs.REPO }}-web:installDist $GRADLE_ARGS
 
       - name: Build slim container image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: git fetch --prune --unshallow
+        with:
+          fetch-depth: 0
       - uses: actions/setup-java@v2
         with:
           java-version: 11


### PR DESCRIPTION
I wanted to avoid confusion between a git tag `X` building version `X` and a
master or release branch building version `X-dev-*` but it seems unavoidable.
SemVer is required by plugins.
See constraint: https://github.com/spinnaker/kork/blob/5dc6bb98615667f1b4f3e18445c1651d773c9f6b/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerServiceVersionManager.kt#L47

changes:
- fetch full git repository so that we can access previous tag in branch.
  Convert `release.yml` to this method instead of `run: git.. --unshallow`.
- use previous git tag as start of version string. Cut the 'v' prefix from the
  tag, 'v1.2.3' -> '1.2.3' as required for Plugins (and Debians fwiw):
  `Caused by: Unexpected character 'LETTER(v)' at position '0', expecting '[DIGIT]'`
- append `-dev-<branch_name|'pr'>` to designate that it is not an
  official version. The short git SHA and date time are NOT present on
  release versions (eg: 1.2.3) so that also differs.
- do this version setting in `pr.yml` as well so we might pick up version
  issues in PR's and not just at merge.
