### PR TITLE
chore(dependencies): add explicit dependency on javax.validation:vali…

### DIFF
--- a/kayenta-core/kayenta-core.gradle
+++ b/kayenta-core/kayenta-core.gradle
@@ -19,5 +19,7 @@ dependencies {
   api "org.springframework.boot:spring-boot-starter-json"
   api "net.logstash.logback:logstash-logback-encoder"
 
+  api "javax.validation:validation-api"
+
   testImplementation "io.spinnaker.kork:kork-jedis-test"
 }


### PR DESCRIPTION
…dation-api

since spring cloud Hoxton.SR12 doesn't bring it in.  See https://github.com/spinnaker/orca/pull/4254 for more.
