### PR TITLE
Influxdb enhancements

### DIFF
--- a/kayenta-influxdb/src/main/java/com/netflix/kayenta/canary/providers/metrics/InfluxdbCanaryMetricSetQueryConfig.java
+++ b/kayenta-influxdb/src/main/java/com/netflix/kayenta/canary/providers/metrics/InfluxdbCanaryMetricSetQueryConfig.java
@@ -19,14 +19,15 @@ package com.netflix.kayenta.canary.providers.metrics;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.netflix.kayenta.canary.CanaryMetricSetQueryConfig;
 import java.util.List;
-import javax.validation.constraints.NotNull;
+import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.springframework.util.StringUtils;
 
-@Builder
+@Builder(toBuilder = true)
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
@@ -35,9 +36,21 @@ public class InfluxdbCanaryMetricSetQueryConfig implements CanaryMetricSetQueryC
 
   public static final String SERVICE_TYPE = "influxdb";
 
-  @NotNull @Getter private String metricName;
+  @Nullable @Getter private String metricName;
 
   @Getter private List<String> fields;
+  @Nullable @Getter private String customInlineTemplate;
+
+  @Override
+  public CanaryMetricSetQueryConfig cloneWithEscapedInlineTemplate() {
+    if (StringUtils.isEmpty(customInlineTemplate)) {
+      return this;
+    } else {
+      return this.toBuilder()
+          .customInlineTemplate(customInlineTemplate.replace("${", "$\\{"))
+          .build();
+    }
+  }
 
   @Override
   public String getServiceType() {

--- a/kayenta-influxdb/src/main/java/com/netflix/kayenta/influxdb/config/InfluxDbResponseConverter.java
+++ b/kayenta-influxdb/src/main/java/com/netflix/kayenta/influxdb/config/InfluxDbResponseConverter.java
@@ -82,7 +82,8 @@ public class InfluxDbResponseConverter implements Converter {
         List<Double> values = new ArrayList<>(seriesValues.size());
         for (List<Object> valueRow : seriesValues) {
           if (valueRow.get(i) != null) {
-            values.add(Double.valueOf((Integer) valueRow.get(i)));
+            String val = valueRow.get(i).toString();
+            values.add(Double.valueOf(val));
           }
         }
         influxDbResultsList.add(new InfluxDbResult(id, firstTimeMillis, stepMillis, null, values));

--- a/kayenta-influxdb/src/main/java/com/netflix/kayenta/influxdb/metrics/InfluxDbQueryBuilder.java
+++ b/kayenta-influxdb/src/main/java/com/netflix/kayenta/influxdb/metrics/InfluxDbQueryBuilder.java
@@ -18,8 +18,7 @@ package com.netflix.kayenta.influxdb.metrics;
 
 import com.netflix.kayenta.canary.CanaryScope;
 import com.netflix.kayenta.canary.providers.metrics.InfluxdbCanaryMetricSetQueryConfig;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -34,26 +33,31 @@ public class InfluxDbQueryBuilder {
   private static final String SCOPE_INVALID_FORMAT_MSG =
       "Scope expected in the format of 'name:value'. e.g. autoscaling_group:myapp-prod-v002, received: ";
 
-  // TODO(joerajeev): update to accept tags and groupby fields
   // TODO(joerajeev): protect against injection. Influxdb is supposed to support binding params,
   // https://docs.influxdata.com/influxdb/v1.5/tools/api/
   public String build(InfluxdbCanaryMetricSetQueryConfig queryConfig, CanaryScope canaryScope) {
-
-    validateManadtoryParams(queryConfig, canaryScope);
-
     StringBuilder query = new StringBuilder();
-    addBaseQuery(queryConfig.getMetricName(), handleFields(queryConfig), query);
-    addTimeRangeFilter(canaryScope, query);
-    addScopeFilter(canaryScope, query);
+    validateMandatoryParams(queryConfig, canaryScope);
+
+    if (!StringUtils.isEmpty(queryConfig.getCustomInlineTemplate())) {
+      buildCustomQuery(queryConfig, canaryScope, getTimeFilter(canaryScope), query);
+    } else {
+      addBaseQuery(queryConfig.getMetricName(), handleFields(queryConfig), query);
+      addTimeRangeFilter(getTimeFilter(canaryScope), query);
+      addScopeFilter(canaryScope, query);
+    }
 
     String builtQuery = query.toString();
+    validateQuery(builtQuery);
     log.debug("Built query: {} config: {} scope: {}", builtQuery, queryConfig, canaryScope);
+
     return builtQuery;
   }
 
-  private void validateManadtoryParams(
+  private void validateMandatoryParams(
       InfluxdbCanaryMetricSetQueryConfig queryConfig, CanaryScope canaryScope) {
-    if (StringUtils.isEmpty(queryConfig.getMetricName())) {
+    if (StringUtils.isEmpty(queryConfig.getMetricName())
+        && StringUtils.isEmpty(queryConfig.getCustomInlineTemplate())) {
       throw new IllegalArgumentException("Measurement is required to query metrics");
     }
     if (null == canaryScope) {
@@ -61,6 +65,14 @@ public class InfluxDbQueryBuilder {
     }
     if (null == canaryScope.getStart() || null == canaryScope.getEnd()) {
       throw new IllegalArgumentException("Start and End times are required");
+    }
+    if (!StringUtils.isEmpty(queryConfig.getCustomInlineTemplate())) {
+      if (!queryConfig.getCustomInlineTemplate().contains("$\\{timeFilter}")) {
+        throw new IllegalArgumentException("${timeFilter} is required in query");
+      }
+      if (!queryConfig.getCustomInlineTemplate().contains("$\\{scope}")) {
+        throw new IllegalArgumentException("${scope} is required in query");
+      }
     }
   }
 
@@ -78,16 +90,13 @@ public class InfluxDbQueryBuilder {
   private void addBaseQuery(String measurement, List<String> fields, StringBuilder query) {
     query.append("SELECT ");
     query.append(fields.stream().collect(Collectors.joining(", ")));
-    query.append(" FROM ");
-    query.append(measurement);
+    query.append(" FROM " + measurement + " ");
   }
 
-  private void addScopeFilter(CanaryScope canaryScope, StringBuilder sb) {
+  private void addScopeFilter(CanaryScope canaryScope, StringBuilder query) {
     String scope = canaryScope.getScope();
     if (scope != null) {
-      String[] scopeParts = validateAndExtractScope(scope);
-      sb.append(" AND ");
-      sb.append(scopeParts[0] + "='" + scopeParts[1] + "'");
+      query.append(" AND " + getScope(canaryScope));
     }
   }
 
@@ -102,10 +111,68 @@ public class InfluxDbQueryBuilder {
     return scopeParts;
   }
 
-  private void addTimeRangeFilter(CanaryScope canaryScope, StringBuilder query) {
-    query.append(" WHERE");
-    query.append(" time >= '" + canaryScope.getStart().toString() + "'");
-    query.append(" AND");
-    query.append(" time < '" + canaryScope.getEnd().toString() + "'");
+  private String getScope(CanaryScope canaryScope) {
+    String scope = canaryScope.getScope();
+    String[] scopeParts = validateAndExtractScope(scope);
+    return scopeParts[0] + " = '" + scopeParts[1] + "'";
+  }
+
+  private void addTimeRangeFilter(String timeFilter, StringBuilder query) {
+    query.append("WHERE " + timeFilter);
+  }
+
+  private void buildCustomQuery(
+      InfluxdbCanaryMetricSetQueryConfig queryConfig,
+      CanaryScope canaryScope,
+      String timeFilter,
+      StringBuilder query) {
+    String inlineQuery = queryConfig.getCustomInlineTemplate();
+    validateQuery(inlineQuery);
+    String queryWithTimeFilter = inlineQuery.replace("$\\{timeFilter}", timeFilter);
+    String queryWithScope = queryWithTimeFilter.replace("$\\{scope}", getScope(canaryScope));
+    query.append(addOptionalStep(canaryScope, queryWithScope));
+  }
+
+  private String addOptionalStep(CanaryScope canaryScope, String query) {
+    if (query.contains("$\\{step}")) {
+      query = query.replace("$\\{step}", canaryScope.getStep().toString() + "s");
+    }
+    return query;
+  }
+
+  private String getTimeFilter(CanaryScope canaryScope) {
+    return "time >= '"
+        + canaryScope.getStart().toString()
+        + "' AND time < '"
+        + canaryScope.getEnd().toString()
+        + "'";
+  }
+
+  private void validateQuery(String query) {
+    List<String> blocked = new ArrayList<>();
+    blocked.add("SHOW CONTINUOUS QUERIES");
+    blocked.add("SHOW DATABASES");
+    blocked.add("SHOW DIAGNOSTICS");
+    blocked.add("SHOW FIELD");
+    blocked.add("SHOW TAG");
+    blocked.add("SHOW USERS");
+    blocked.add("SHOW GRANTS");
+    blocked.add("SHOW MEASUREMENT");
+    blocked.add("SHOW QUERIES");
+    blocked.add("SHOW RETENTION POLICIES");
+    blocked.add("SHOW SERIES");
+    blocked.add("SHOW SHARD");
+    blocked.add("SHOW STATS");
+    blocked.add("SHOW SUBSCRIPTIONS");
+    blocked.add(";");
+    blocked.add("--");
+
+    blocked.stream()
+        .forEach(
+            (stmt) -> {
+              if (query.contains(stmt)) {
+                throw new IllegalArgumentException("Query type not allowed.");
+              }
+            });
   }
 }

--- a/kayenta-influxdb/src/test/java/com/netflix/kayenta/influxdb/config/InfluxDbResponseConverterTest.java
+++ b/kayenta-influxdb/src/test/java/com/netflix/kayenta/influxdb/config/InfluxDbResponseConverterTest.java
@@ -25,7 +25,6 @@ import com.netflix.kayenta.influxdb.model.InfluxDbResult;
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Before;
 import org.junit.Test;
 import retrofit.converter.ConversionException;
 import retrofit.mime.TypedByteArray;
@@ -35,12 +34,14 @@ import retrofit.mime.TypedOutput;
 public class InfluxDbResponseConverterTest {
 
   private static final String MIME_TYPE = "application/json; charset=UTF-8";
-  private final String JSON =
+  private final String EXAMPLE_ALL_INTEGERS =
       "{\"results\":[{\"statement_id\":0,\"series\":[{\"name\":\"temperature\",\"columns\":[\"time\",\"external\",\"internal\"],\"values\":[[\"2018-05-27T04:50:44.105612486Z\",25,37],[\"2018-05-27T04:51:44.105612486Z\",25,37],[\"2018-05-27T04:52:06.585796188Z\",26,38]]}]}]}";
-  private List<InfluxDbResult> results = new ArrayList<>();
 
-  @Before
-  public void setup() {
+  private final String EXAMPLE_WITH_FLOATS =
+      "{\"results\":[{\"statement_id\":0,\"series\":[{\"name\":\"temperature\",\"columns\":[\"time\",\"external\",\"internal\"],\"values\":[[\"2018-05-27T04:50:44.105612486Z\",25.1,37.1],[\"2018-05-27T04:51:44.105612486Z\",25,37.2],[\"2018-05-27T04:52:06.585796188Z\",26.5,38]]}]}]}";
+
+  public List<InfluxDbResult> setupAllIntegers() {
+    List<InfluxDbResult> results = new ArrayList<>();
     List<Double> externalDataValues = new ArrayList<>();
     externalDataValues.add(25d);
     externalDataValues.add(25d);
@@ -56,6 +57,27 @@ public class InfluxDbResponseConverterTest {
     InfluxDbResult internalTempResult =
         new InfluxDbResult("internal", 1527396644105L, 60000L, null, internalDataValues);
     results.add(internalTempResult);
+    return results;
+  }
+
+  public List<InfluxDbResult> setupWithFloats() {
+    List<InfluxDbResult> results = new ArrayList<>();
+    List<Double> externalDataValues = new ArrayList<>();
+    externalDataValues.add(25.1);
+    externalDataValues.add(25d);
+    externalDataValues.add(26.5);
+    InfluxDbResult externalTempResult =
+        new InfluxDbResult("external", 1527396644105L, 60000L, null, externalDataValues);
+    results.add(externalTempResult);
+
+    List<Double> internalDataValues = new ArrayList<>();
+    internalDataValues.add(37.1);
+    internalDataValues.add(37.2);
+    internalDataValues.add(38d);
+    InfluxDbResult internalTempResult =
+        new InfluxDbResult("internal", 1527396644105L, 60000L, null, internalDataValues);
+    results.add(internalTempResult);
+    return results;
   }
 
   private final InfluxDbResponseConverter influxDbResponseConverter =
@@ -63,12 +85,23 @@ public class InfluxDbResponseConverterTest {
 
   @Test
   public void serialize() throws Exception {
+    List<InfluxDbResult> results = setupAllIntegers();
     assertThat(influxDbResponseConverter.toBody(results), is(nullValue()));
   }
 
   @Test
   public void deserialize() throws Exception {
-    TypedInput input = new TypedByteArray(MIME_TYPE, JSON.getBytes());
+    List<InfluxDbResult> results = setupAllIntegers();
+    TypedInput input = new TypedByteArray(MIME_TYPE, EXAMPLE_ALL_INTEGERS.getBytes());
+    List<InfluxDbResult> result =
+        (List<InfluxDbResult>) influxDbResponseConverter.fromBody(input, List.class);
+    assertThat(result, is(results));
+  }
+
+  @Test
+  public void deserializeWithFloatValues() throws Exception {
+    List<InfluxDbResult> results = setupWithFloats();
+    TypedInput input = new TypedByteArray(MIME_TYPE, EXAMPLE_WITH_FLOATS.getBytes());
     List<InfluxDbResult> result =
         (List<InfluxDbResult>) influxDbResponseConverter.fromBody(input, List.class);
     assertThat(result, is(results));

--- a/kayenta-influxdb/src/test/java/com/netflix/kayenta/influxdb/service/InfluxdbQueryBuilderTest.java
+++ b/kayenta-influxdb/src/test/java/com/netflix/kayenta/influxdb/service/InfluxdbQueryBuilderTest.java
@@ -36,7 +36,7 @@ public class InfluxdbQueryBuilderTest {
     String measurement = "temperature";
 
     InfluxDbCanaryScope canaryScope = createScope();
-    InfluxdbCanaryMetricSetQueryConfig queryConfig = queryConfig(measurement, fieldsList());
+    InfluxdbCanaryMetricSetQueryConfig queryConfig = queryConfig(measurement, fieldsList(), null);
     String query = queryBuilder.build(queryConfig, canaryScope);
     assertThat(
         query,
@@ -64,7 +64,7 @@ public class InfluxdbQueryBuilderTest {
 
     InfluxDbCanaryScope canaryScope = createScope();
     canaryScope.setScope("server='myapp-prod-v002'");
-    InfluxdbCanaryMetricSetQueryConfig queryConfig = queryConfig(measurement, fieldsList());
+    InfluxdbCanaryMetricSetQueryConfig queryConfig = queryConfig(measurement, fieldsList(), null);
     queryBuilder.build(queryConfig, canaryScope);
   }
 
@@ -74,20 +74,21 @@ public class InfluxdbQueryBuilderTest {
 
     InfluxDbCanaryScope canaryScope = createScope();
     canaryScope.setScope("server:myapp-prod-v002");
-    InfluxdbCanaryMetricSetQueryConfig queryConfig = queryConfig(measurement, fieldsList());
+    InfluxdbCanaryMetricSetQueryConfig queryConfig = queryConfig(measurement, fieldsList(), null);
     String query = queryBuilder.build(queryConfig, canaryScope);
     assertThat(
         query,
         is(
-            "SELECT external, internal FROM temperature WHERE time >= '2010-01-01T12:00:00Z' AND time < '2010-01-01T12:01:40Z' AND server='myapp-prod-v002'"));
+            "SELECT external, internal FROM temperature WHERE time >= '2010-01-01T12:00:00Z' AND time < '2010-01-01T12:01:40Z' AND server = 'myapp-prod-v002'"));
   }
 
   private InfluxdbCanaryMetricSetQueryConfig queryConfig(
-      String measurement, List<String> fieldsList) {
+      String measurement, List<String> fieldsList, String customInlineTemplate) {
     InfluxdbCanaryMetricSetQueryConfig queryConfig =
         InfluxdbCanaryMetricSetQueryConfig.builder()
             .metricName(measurement)
             .fields(fieldsList)
+            .customInlineTemplate(customInlineTemplate)
             .build();
     return queryConfig;
   }
@@ -98,11 +99,69 @@ public class InfluxdbQueryBuilderTest {
 
     InfluxDbCanaryScope canaryScope = createScope();
     canaryScope.setScope("server:myapp-prod-v002");
-    InfluxdbCanaryMetricSetQueryConfig queryConfig = queryConfig(measurement, null);
+    InfluxdbCanaryMetricSetQueryConfig queryConfig = queryConfig(measurement, null, null);
     String query = queryBuilder.build(queryConfig, canaryScope);
     assertThat(
         query,
         is(
-            "SELECT *::field FROM temperature WHERE time >= '2010-01-01T12:00:00Z' AND time < '2010-01-01T12:01:40Z' AND server='myapp-prod-v002'"));
+            "SELECT *::field FROM temperature WHERE time >= '2010-01-01T12:00:00Z' AND time < '2010-01-01T12:01:40Z' AND server = 'myapp-prod-v002'"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBuild_customInlineTemplateWithMissingRequiredVariables() {
+    String inLineQuery = "SELECT count FROM measurement";
+
+    InfluxDbCanaryScope canaryScope = createScope();
+    canaryScope.setScope("server:myapp-prod-v002");
+    InfluxdbCanaryMetricSetQueryConfig queryConfig = queryConfig(null, null, inLineQuery);
+    queryBuilder.build(queryConfig, canaryScope);
+  }
+
+  @Test
+  public void testBuild_customInlineTemplateWithRequiredVariables() {
+    String inLineQuery =
+        "SELECT count FROM measurement WHERE label1 = 'value1' AND $\\{timeFilter} AND $\\{scope}";
+
+    InfluxDbCanaryScope canaryScope = createScope();
+    canaryScope.setScope("server:myapp-prod-v002");
+    InfluxdbCanaryMetricSetQueryConfig queryConfig = queryConfig(null, null, inLineQuery);
+    String query = queryBuilder.build(queryConfig, canaryScope);
+    assertThat(
+        query,
+        is(
+            "SELECT count FROM measurement WHERE label1 = 'value1' AND time >= '2010-01-01T12:00:00Z' AND time < '2010-01-01T12:01:40Z' AND server = 'myapp-prod-v002'"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBuild_customInlineTemplateWithInvalidAdditionalQuery() {
+    String inLineQuery =
+        "SELECT sum(count) FROM web_requests WHERE $\\{scope} AND $\\{timeFilter} GROUP BY time(1m); DROP DATABASE metrics";
+
+    InfluxDbCanaryScope canaryScope = createScope();
+    canaryScope.setScope("server:myapp-prod-v002");
+    InfluxdbCanaryMetricSetQueryConfig queryConfig = queryConfig(null, null, inLineQuery);
+    queryBuilder.build(queryConfig, canaryScope);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBuild_customInlineTemplateWithInvalidQueryType() {
+    String inLineQuery =
+        "SELECT sum(count) FROM web_requests WHERE $\\{scope} AND $\\{timeFilter} GROUP BY time(1m); SHOW SERIES";
+
+    InfluxDbCanaryScope canaryScope = createScope();
+    canaryScope.setScope("server:myapp-prod-v002");
+    InfluxdbCanaryMetricSetQueryConfig queryConfig = queryConfig(null, null, inLineQuery);
+    queryBuilder.build(queryConfig, canaryScope);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBuild_customInlineTemplateWithInvalidLineComments() {
+    String inLineQuery =
+        "'SELECT count FROM web_requests WHERE $\\{scope} AND $\\{timeFilter}' or 1=1--";
+
+    InfluxDbCanaryScope canaryScope = createScope();
+    canaryScope.setScope("server:myapp-prod-v002");
+    InfluxdbCanaryMetricSetQueryConfig queryConfig = queryConfig(null, null, inLineQuery);
+    queryBuilder.build(queryConfig, canaryScope);
   }
 }


### PR DESCRIPTION
We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](https://spinnaker.io/community/contributing/submitting/).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

------
**Summary of changes:**

- changes to [InfluxDbResponseConverter.java](https://github.com/spinnaker/kayenta/compare/master...ichiong:kayenta:influxdb_enhancements?expand=1#diff-34932f6cb0f2ad6328393e2dee0a28e5ab9d17b1c8dc6e3d27cdecea6541e5b9) is to fix kayenta-influxdb plugin when it returns or throws an error if the result that we got from influx contains values that are of type float or double. 
   - example error that we get: `class java.lang.Double cannot be cast to class java.lang.Integer (java.lang.Double and java.lang.Integer are in module java.base of loader 'bootstrap'`. 
   - The [InfluxDbResponseConverterTest.java](https://github.com/spinnaker/kayenta/compare/master...ichiong:kayenta:influxdb_enhancements?expand=1#diff-fd0110b9903b56b110bf8df044950f3c05b1213ad527dde0e5033846a3a19e97) contains unit tests for these changes.
- changes to [InfluxDbMetricsService.java](https://github.com/spinnaker/kayenta/compare/master...ichiong:kayenta:influxdb_enhancements?expand=1#diff-d391e3cf0245b9e1c153f02dca44cd313850be0dca905af2ac263f864818da51) is to fix situations when an influx query returns no results:

![kayenta_error](https://user-images.githubusercontent.com/6732772/180274600-1d59b652-76f5-4f59-bcb0-115c5ba9802e.png)
 
- changes to [InfluxDbQueryBuilder.java](https://github.com/spinnaker/kayenta/compare/master...ichiong:kayenta:influxdb_enhancements?expand=1#diff-c6fd46d4e96406b97f208a8a3113d3315b341fa6bb5bf0aa012b255678aa1a65) and [InfluxdbCanaryMetricSetQueryConfig.java](https://github.com/spinnaker/kayenta/compare/master...ichiong:kayenta:influxdb_enhancements?expand=1#diff-82cd0eea2321d979c2fa21f1e0994c7eb50bc55eb2bce2879afcd6f2084815c5) is to support `customInlineTemplate` just like in other kayenta plugins such as Prometheus and New Relic
   - [InfluxdbQueryBuilderTest.java](https://github.com/spinnaker/kayenta/compare/master...ichiong:kayenta:influxdb_enhancements?expand=1#diff-bb5959e65b9c4a290d25b579b6e8b1bf0f8f1f9e59de47f1f3451e8337244670) contains unit tests to test these changes