### PR TITLE
chore(dockerfile): upgrade to latest alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN tar -xf /tmp/workdir/kayenta-web/build/distributions/kayenta.tar -C /opt
 #
 # Release Image
 #
-FROM alpine:3.11
+FROM alpine:3.16
 
 LABEL maintainer="delivery-engineering@netflix.com"
 

--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.16
 RUN apk add --update \
     openjdk11 \
     && rm -rf /var/cache/apk

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.16
 LABEL maintainer="sig-platform@spinnaker.io"
 RUN apk --no-cache add --update bash openjdk11-jre
 RUN addgroup -S -g 10111 spinnaker


### PR DESCRIPTION
This resolves a performance issue in JDK11 when Spinnaker is running in
a cluster with containerd.