### PR TITLE
fix(dependency): To enable controlled conflict resolution of direct a…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ subprojects { project ->
         api 'com.typesafe.scala-logging:scala-logging_2.12:3.9.2'
         testImplementation 'org.scalatest:scalatest_2.12:3.0.9'
       }
-      implementation platform("io.spinnaker.orca:orca-bom:$orcaVersion")
+      implementation enforcedPlatform("io.spinnaker.orca:orca-bom:$orcaVersion")
       compileOnly "org.projectlombok:lombok"
       annotationProcessor platform("io.spinnaker.orca:orca-bom:$orcaVersion")
       annotationProcessor "org.projectlombok:lombok"


### PR DESCRIPTION
…nd transitive dependencies version using kork-bom for upgrading the spring-boot 2.3.x.

While upgrading the spring-boot 2.2.x to 2.3.x, encountered issue of uncontrolled conflict
resolution of jackson and kotlin dependencies in gate
(https://github.com/spinnaker/gate/pull/1505). In order to avoid any such issue with other
components for upgrades to spring-boot 2.3.x as well as for any future spring-boot
upgrades, we can introduce strict adherence of imported maven kork-bom by replacing
platform to enforcedPlatform closure.

See also the corresponding orca change: https://github.com/spinnaker/orca/pull/4231

This doesn't fix the current test failure:
```
./gradlew :kayenta-integration-tests:test --tests GraphiteStandaloneCanaryAnalysisTest
```
but it still feels correct.  As far as actual dependency changes, they don't seem super
significant, though the guava and groovy changes are solid confirmation for me that this
is the way forward.

Here's a partial list.  There are similar changes for other jackson components.

before:
org.slf4j:slf4j-api -> 1.7.32
org.yaml:snakeyaml:1.26 -> 1.27
io.micrometer:micrometer-core:1.5.14 -> 1.7.5
com.fasterxml.jackson.core:jackson-databind:2.11.4 -> 2.13.2
junit:junit:4.13.1 -> 4.13.2
com.google.guava:guava:22.0 -> 30.1.1-android
org.apache.commons:commons-lang3:3.5 -> 3.11
org.codehaus.groovy:groovy:2.5.14 -> 3.0.6 (c)
org.codehaus.groovy:groovy-xml:2.5.14 -> 3.0.6 (c)
org.codehaus.groovy:groovy-json:2.5.14 -> 3.0.6 (c)

after:

slf4j:slf4j-api -> 1.7.30
org.yaml:snakeyaml:1.26
io.micrometer:micrometer-core:1.5.14
com.fasterxml.jackson.core:jackson-databind:2.11.4 -> 2.12.6.1
junit:junit:4.13.1
com.google.guava:guava:22.0 -> 30.0-jre
org.apache.commons:commons-lang3:3.5 -> 3.9
org.codehaus.groovy:groovy:2.5.14 (c)
org.codehaus.groovy:groovy-xml:2.5.14 (c)
org.codehaus.groovy:groovy-json:2.5.14 (c)
