### PR TITLE
fix(test): Issue with kayenta-integration-tests while upgrading spring-boot to 2.3.12

### DIFF
--- a/kayenta-integration-tests/src/test/resources/application-base.yml
+++ b/kayenta-integration-tests/src/test/resources/application-base.yml
@@ -48,6 +48,10 @@ management:
   endpoint.health.show-details: always
   server:
     port: 8081
+  metrics:
+    export:
+      graphite:
+        graphite-tags-enabled: false
 
 # Disable checking Auth headers to external resources (pollutes logs with lots of warnings)
 ok-http-client:

--- a/kayenta-web/config/kayenta.yml
+++ b/kayenta-web/config/kayenta.yml
@@ -168,6 +168,9 @@ kayenta:
 
 management.endpoints.web.exposure.include: '*'
 management.endpoint.health.show-details: always
+# To fix issue with kayenta-integration-tests while upgrading spring-boot to 2.3.12
+# https://github.com/micrometer-metrics/micrometer-docs/issues/123
+management.metrics.export.graphite.graphite-tags-enabled: false
 
 keiko:
   queue:


### PR DESCRIPTION
While upgrading the spring-boot by transitively upgrading the orca version (8.26.0) in kayenta and enforcing the dependencies, the kayenta-integration-tests:GraphiteStandaloneCanaryAnalysisTest failed with below error:

```
java.lang.AssertionError: 1 expectation failed.
JSON path executionStatus doesn't match.
Expected: is "SUCCEEDED"
  Actual: TERMINAL

	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at org.codehaus.groovy.reflection.CachedConstructor.invoke(CachedConstructor.java:72)
	at org.codehaus.groovy.reflection.CachedConstructor.doConstructorInvoke(CachedConstructor.java:59)
	at org.codehaus.groovy.runtime.callsite.ConstructorSite$ConstructorSiteNoUnwrap.callConstructor(ConstructorSite.java:84)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:277)
	at io.restassured.internal.ResponseSpecificationImpl$HamcrestAssertionClosure.validate(ResponseSpecificationImpl.groovy:493)
	at io.restassured.internal.ResponseSpecificationImpl$HamcrestAssertionClosure$validate$1.call(Unknown Source)
	at io.restassured.internal.ResponseSpecificationImpl.validateResponseIfRequired(ResponseSpecificationImpl.groovy:674)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAcc
```

The root cause for this issue is upgrade of io.micrometer:micrometer-registry-graphite from 1.3.16 to 1.5.14 as transitive dependency of spring-boot. In the newer version of micrometer-registry-graphite, there is addition of native Graphite tag support and making it as default behaviour from 1.4+ version. Now the legacy hierarchical tag names need to be explicitly enabled by disabling native graphite support. https://github.com/micrometer-metrics/micrometer/releases/tag/v1.4.0 https://github.com/micrometer-metrics/micrometer/pull/1806. 
Based on the discussions [here](https://github.com/micrometer-metrics/micrometer-docs/issues/123) spring-boot has also exposed the property to disable the native graphite tag support, and implemented in 2.3.x [here](https://github.com/spring-projects/spring-boot/issues/20834).

To fix this issue, explicitly specifying this property `management.metrics.export.graphite.graphite-tags-enabled=false` in test environment and in kayenta config.
