### PR TITLE
chore(dependencies): Bump orcaVersion

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-orcaVersion=8.27.0
+orcaVersion=8.28.0
 org.gradle.parallel=true
 spinnakerGradleVersion=8.23.0
 targetJava11=true

--- a/kayenta-integration-tests/kayenta-integration-tests.gradle
+++ b/kayenta-integration-tests/kayenta-integration-tests.gradle
@@ -5,9 +5,9 @@ dependencies {
     testImplementation "org.awaitility:awaitility:4.0.3"
     testImplementation "io.micrometer:micrometer-registry-prometheus"
     testImplementation "io.micrometer:micrometer-registry-graphite"
-    testImplementation "org.springframework.cloud:spring-cloud-starter:2.1.2.RELEASE" // needed for bootstrap phase when all embedded containers are setup
-    testImplementation "com.playtika.testcontainers:embedded-redis:1.89"
-    testImplementation "com.playtika.testcontainers:embedded-minio:1.89"
+    testImplementation "org.springframework.cloud:spring-cloud-starter-bootstrap" // needed for bootstrap phase when all embedded containers are setup
+    testImplementation "com.playtika.testcontainers:embedded-redis:2.2.11"
+    testImplementation "com.playtika.testcontainers:embedded-minio:2.2.11"
     testImplementation "org.testcontainers:testcontainers"
 }
 

--- a/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/BaseIntegrationTest.java
+++ b/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/BaseIntegrationTest.java
@@ -19,10 +19,12 @@ import com.netflix.kayenta.Main;
 import com.netflix.kayenta.configuration.MetricsReportingConfiguration;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.actuate.metrics.AutoConfigureMetrics;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
+@AutoConfigureMetrics
 @SpringBootTest(
     classes = {MetricsReportingConfiguration.class, Main.class},
     webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,

--- a/kayenta-integration-tests/src/test/resources/application-base.yml
+++ b/kayenta-integration-tests/src/test/resources/application-base.yml
@@ -34,6 +34,11 @@ server:
 
 # Does it make sense to publish all Kayenta metrics to all datasources in integraion tests?
 spring:
+  cloud:
+    discovery:
+      client:
+        composite-indicator:
+          enabled: false
   autoconfigure:
     exclude: >
       org.springframework.boot.actuate.autoconfigure.metrics.web.tomcat.TomcatMetricsAutoConfiguration,

--- a/kayenta-orca/src/main/java/com/netflix/kayenta/config/OrcaCompositeHealthContributor.java
+++ b/kayenta-orca/src/main/java/com/netflix/kayenta/config/OrcaCompositeHealthContributor.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 JPMorgan Chase & Co
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.config;
+
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.boot.actuate.health.*;
+
+public class OrcaCompositeHealthContributor implements CompositeHealthContributor {
+
+  private final StatusAggregator statusAggregator;
+  private final Map<String, NamedContributor<HealthContributor>> contributors;
+
+  public OrcaCompositeHealthContributor(
+      StatusAggregator statusAggregator, HealthContributorRegistry healthContributorRegistry) {
+    this.statusAggregator = statusAggregator;
+
+    this.contributors = new LinkedHashMap<>();
+    healthContributorRegistry.forEach(
+        contributor ->
+            contributors.put(
+                contributor.getName(),
+                NamedContributor.of(contributor.getName(), contributor.getContributor())));
+  }
+
+  @Override
+  public HealthContributor getContributor(String name) {
+    return contributors.get(name).getContributor();
+  }
+
+  @Override
+  public Stream<NamedContributor<HealthContributor>> stream() {
+    return CompositeHealthContributor.super.stream();
+  }
+
+  @NotNull
+  @Override
+  public Iterator<NamedContributor<HealthContributor>> iterator() {
+    return contributors.values().iterator();
+  }
+
+  @Override
+  public void forEach(Consumer<? super NamedContributor<HealthContributor>> action) {
+    CompositeHealthContributor.super.forEach(action);
+  }
+
+  @Override
+  public Spliterator<NamedContributor<HealthContributor>> spliterator() {
+    return CompositeHealthContributor.super.spliterator();
+  }
+
+  public Status status() {
+    Set<Status> statuses =
+        this.contributors.values().stream()
+            .map(contributor -> ((HealthIndicator) contributor.getContributor()).getHealth(false))
+            .map(Health::getStatus)
+            .collect(Collectors.toSet());
+
+    return this.statusAggregator.getAggregateStatus(statuses);
+  }
+}


### PR DESCRIPTION
* Migrate to HealthContributorRegistry
* Add `@AutoConfigureMetrics`. `@SpringBootTest` no longer configures available monitoring systems and only provide the in-memory MeterRegistry. If you were exporting metrics as part of an integration test, you can add `@AutoConfigureMetrics` to your test to restore the previous behaviour. https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.4-Release-Notes
* Upgrade embedded testcontainers. `testcontainers-spring-boot` project migrated to Spring Boot 2.4 in 2.0.0 version. In order to use this project with Spring Boot 2.4, you need to use `spring-cloud-starter-bootstrap` dependency. https://github.com/PlaytikaOSS/testcontainers-spring-boot#how-to-use
* Disable composite indicator to avoid cast problems with `OrcaCompositeHealthContributor.status()` after moving to `spring-cloud-starter-bootstrap`.