### PR TITLE
chore(dependency): unpinning the version of io.rest-assured

### DIFF
--- a/kayenta-graphite/kayenta-graphite.gradle
+++ b/kayenta-graphite/kayenta-graphite.gradle
@@ -180,7 +180,7 @@ dependencies {
     integrationTestImplementation project(':kayenta-web')
 
     // Apache 2.0 https://github.com/rest-assured/rest-assured/blob/master/LICENSE
-    integrationTestImplementation "io.rest-assured:rest-assured:4.3.2"
+    integrationTestImplementation "io.rest-assured:rest-assured"
     integrationTestAnnotationProcessor platform("io.spinnaker.orca:orca-bom:$orcaVersion")
     integrationTestAnnotationProcessor "org.projectlombok:lombok"
     integrationTestCompileOnly "org.projectlombok:lombok"

--- a/kayenta-integration-tests/kayenta-integration-tests.gradle
+++ b/kayenta-integration-tests/kayenta-integration-tests.gradle
@@ -1,7 +1,7 @@
 dependencies {
 
     testImplementation project(":kayenta-web")
-    testImplementation "io.rest-assured:rest-assured:4.3.2"
+    testImplementation "io.rest-assured:rest-assured"
     testImplementation "org.awaitility:awaitility:4.0.3"
     testImplementation "io.micrometer:micrometer-registry-prometheus"
     testImplementation "io.micrometer:micrometer-registry-graphite"

--- a/kayenta-signalfx/kayenta-signalfx.gradle
+++ b/kayenta-signalfx/kayenta-signalfx.gradle
@@ -122,7 +122,7 @@ dependencies {
   integrationTestImplementation project(':kayenta-web')
 
   // Apache 2.0 https://github.com/rest-assured/rest-assured/blob/master/LICENSE
-  integrationTestImplementation "io.rest-assured:rest-assured:4.3.2"
+  integrationTestImplementation "io.rest-assured:rest-assured"
 
   integrationTestAnnotationProcessor platform("io.spinnaker.orca:orca-bom:$orcaVersion")
   integrationTestAnnotationProcessor "org.projectlombok:lombok"


### PR DESCRIPTION
Currently, version is pinned to io.rest-assured:rest-assured:4.3.2. Since it is a transitive dependency of spring boot, unpinning the same.
