### PR TITLE
feat: SPLAT-582: Add a storage data migrator.

### DIFF
--- a/kayenta-sql/src/main/java/com/netflix/kayenta/sql/config/DataMigrationConfiguration.java
+++ b/kayenta-sql/src/main/java/com/netflix/kayenta/sql/config/DataMigrationConfiguration.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.sql.config;
+
+import com.netflix.kayenta.sql.migration.StorageDataMigrator;
+import com.netflix.kayenta.storage.StorageService;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.Executors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty("kayenta.data-migration.enabled")
+@EnableConfigurationProperties(DataMigrationProperties.class)
+@RequiredArgsConstructor
+public class DataMigrationConfiguration {
+
+  private final DataMigrationProperties dataMigrationProperties;
+  private final List<StorageService> storageServices;
+
+  @Bean
+  public StorageDataMigrator storageDataMigrator() throws IOException {
+    var sourceStorageServiceClassName = dataMigrationProperties.getSourceStorageServiceClassName();
+    var targetStorageServiceClassName = dataMigrationProperties.getTargetStorageServiceClassName();
+
+    var sourceStorageService = findStorageService(sourceStorageServiceClassName);
+    var targetStorageService = findStorageService(targetStorageServiceClassName);
+
+    return new StorageDataMigrator(
+        dataMigrationProperties,
+        sourceStorageService,
+        targetStorageService,
+        Executors.newCachedThreadPool());
+  }
+
+  private StorageService findStorageService(String className) throws IOException {
+    return storageServices.stream()
+        .filter(storageService -> storageService.getClass().getCanonicalName().equals(className))
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new IOException(
+                    String.format("Failed to find storage service for class name: %s", className)));
+  }
+}

--- a/kayenta-sql/src/main/java/com/netflix/kayenta/sql/config/DataMigrationProperties.java
+++ b/kayenta-sql/src/main/java/com/netflix/kayenta/sql/config/DataMigrationProperties.java
@@ -20,17 +20,12 @@ import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Data
-@ConfigurationProperties("kayenta.sql")
-public class SqlProperties {
+@ConfigurationProperties("kayenta.data-migration")
+public class DataMigrationProperties {
 
-  private Migration migration = new Migration();
-
-  @Data
-  public static class Migration {
-    private boolean enabled;
-    private String sourceAccountName;
-    private String targetAccountName;
-    private String sourceStorageServiceClassName;
-    private String targetStorageServiceClassName;
-  }
+  private boolean enabled;
+  private String sourceAccountName;
+  private String targetAccountName;
+  private String sourceStorageServiceClassName;
+  private String targetStorageServiceClassName;
 }

--- a/kayenta-sql/src/main/java/com/netflix/kayenta/sql/config/SqlConfiguration.java
+++ b/kayenta-sql/src/main/java/com/netflix/kayenta/sql/config/SqlConfiguration.java
@@ -16,17 +16,9 @@
 
 package com.netflix.kayenta.sql.config;
 
-import com.netflix.kayenta.sql.migration.StorageDataMigrator;
-import com.netflix.kayenta.storage.StorageService;
-import java.io.IOException;
-import java.util.List;
-import java.util.concurrent.Executors;
-import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -36,36 +28,4 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @ComponentScan({"com.netflix.kayenta.sql"})
 @EntityScan({"com.netflix.kayenta.sql"})
 @EnableJpaRepositories({"com.netflix.kayenta.sql"})
-@EnableConfigurationProperties(DataMigrationProperties.class)
-@RequiredArgsConstructor
-public class SqlConfiguration extends DataSourceAutoConfiguration {
-
-  private final DataMigrationProperties dataMigrationProperties;
-  private final List<StorageService> storageServices;
-
-  @Bean
-  @ConditionalOnProperty("kayenta.data-migration.enabled")
-  public StorageDataMigrator storageDataMigrator() throws IOException {
-    var sourceStorageServiceClassName = dataMigrationProperties.getSourceStorageServiceClassName();
-    var targetStorageServiceClassName = dataMigrationProperties.getTargetStorageServiceClassName();
-
-    var sourceStorageService = findStorageService(sourceStorageServiceClassName);
-    var targetStorageService = findStorageService(targetStorageServiceClassName);
-
-    return new StorageDataMigrator(
-        dataMigrationProperties,
-        sourceStorageService,
-        targetStorageService,
-        Executors.newCachedThreadPool());
-  }
-
-  private StorageService findStorageService(String className) throws IOException {
-    return storageServices.stream()
-        .filter(storageService -> storageService.getClass().getCanonicalName().equals(className))
-        .findFirst()
-        .orElseThrow(
-            () ->
-                new IOException(
-                    String.format("Failed to find storage service for class name: %s", className)));
-  }
-}
+public class SqlConfiguration extends DataSourceAutoConfiguration {}

--- a/kayenta-sql/src/main/java/com/netflix/kayenta/sql/config/SqlConfiguration.java
+++ b/kayenta-sql/src/main/java/com/netflix/kayenta/sql/config/SqlConfiguration.java
@@ -36,26 +36,27 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @ComponentScan({"com.netflix.kayenta.sql"})
 @EntityScan({"com.netflix.kayenta.sql"})
 @EnableJpaRepositories({"com.netflix.kayenta.sql"})
-@EnableConfigurationProperties(SqlProperties.class)
+@EnableConfigurationProperties(DataMigrationProperties.class)
 @RequiredArgsConstructor
 public class SqlConfiguration extends DataSourceAutoConfiguration {
 
-  private final SqlProperties sqlProperties;
+  private final DataMigrationProperties dataMigrationProperties;
   private final List<StorageService> storageServices;
 
   @Bean
-  @ConditionalOnProperty("kayenta.sql.migration.enabled")
+  @ConditionalOnProperty("kayenta.data-migration.enabled")
   public StorageDataMigrator storageDataMigrator() throws IOException {
-    var sourceStorageServiceClassName =
-        sqlProperties.getMigration().getSourceStorageServiceClassName();
-    var targetStorageServiceClassName =
-        sqlProperties.getMigration().getTargetStorageServiceClassName();
+    var sourceStorageServiceClassName = dataMigrationProperties.getSourceStorageServiceClassName();
+    var targetStorageServiceClassName = dataMigrationProperties.getTargetStorageServiceClassName();
 
     var sourceStorageService = findStorageService(sourceStorageServiceClassName);
     var targetStorageService = findStorageService(targetStorageServiceClassName);
 
     return new StorageDataMigrator(
-        sqlProperties, sourceStorageService, targetStorageService, Executors.newCachedThreadPool());
+        dataMigrationProperties,
+        sourceStorageService,
+        targetStorageService,
+        Executors.newCachedThreadPool());
   }
 
   private StorageService findStorageService(String className) throws IOException {

--- a/kayenta-sql/src/main/java/com/netflix/kayenta/sql/config/SqlConfiguration.java
+++ b/kayenta-sql/src/main/java/com/netflix/kayenta/sql/config/SqlConfiguration.java
@@ -16,9 +16,17 @@
 
 package com.netflix.kayenta.sql.config;
 
+import com.netflix.kayenta.sql.migration.StorageDataMigrator;
+import com.netflix.kayenta.storage.StorageService;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.Executors;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -28,4 +36,35 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @ComponentScan({"com.netflix.kayenta.sql"})
 @EntityScan({"com.netflix.kayenta.sql"})
 @EnableJpaRepositories({"com.netflix.kayenta.sql"})
-public class SqlConfiguration extends DataSourceAutoConfiguration {}
+@EnableConfigurationProperties(SqlProperties.class)
+@RequiredArgsConstructor
+public class SqlConfiguration extends DataSourceAutoConfiguration {
+
+  private final SqlProperties sqlProperties;
+  private final List<StorageService> storageServices;
+
+  @Bean
+  @ConditionalOnProperty("kayenta.sql.migration.enabled")
+  public StorageDataMigrator storageDataMigrator() throws IOException {
+    var sourceStorageServiceClassName =
+        sqlProperties.getMigration().getSourceStorageServiceClassName();
+    var targetStorageServiceClassName =
+        sqlProperties.getMigration().getTargetStorageServiceClassName();
+
+    var sourceStorageService = findStorageService(sourceStorageServiceClassName);
+    var targetStorageService = findStorageService(targetStorageServiceClassName);
+
+    return new StorageDataMigrator(
+        sqlProperties, sourceStorageService, targetStorageService, Executors.newCachedThreadPool());
+  }
+
+  private StorageService findStorageService(String className) throws IOException {
+    return storageServices.stream()
+        .filter(storageService -> storageService.getClass().getCanonicalName().equals(className))
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new IOException(
+                    String.format("Failed to find storage service for class name: %s", className)));
+  }
+}

--- a/kayenta-sql/src/main/java/com/netflix/kayenta/sql/config/SqlProperties.java
+++ b/kayenta-sql/src/main/java/com/netflix/kayenta/sql/config/SqlProperties.java
@@ -14,19 +14,23 @@
  * limitations under the License.
  */
 
-package com.netflix.kayenta.sql.storage.model;
+package com.netflix.kayenta.sql.config;
 
-import java.time.Instant;
-import javax.persistence.Id;
-import javax.persistence.MappedSuperclass;
 import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Data
-@MappedSuperclass
-public class SqlBaseObject {
+@ConfigurationProperties("kayenta.sql")
+public class SqlProperties {
 
-  @Id private String id;
-  private String content;
-  private Instant createdAt;
-  private Instant updatedAt;
+  private Migration migration = new Migration();
+
+  @Data
+  public static class Migration {
+    private boolean enabled;
+    private String sourceAccountName;
+    private String targetAccountName;
+    private String sourceStorageServiceClassName;
+    private String targetStorageServiceClassName;
+  }
 }

--- a/kayenta-sql/src/main/java/com/netflix/kayenta/sql/migration/StorageDataMigrator.java
+++ b/kayenta-sql/src/main/java/com/netflix/kayenta/sql/migration/StorageDataMigrator.java
@@ -16,7 +16,7 @@
 
 package com.netflix.kayenta.sql.migration;
 
-import com.netflix.kayenta.sql.config.SqlProperties;
+import com.netflix.kayenta.sql.config.DataMigrationProperties;
 import com.netflix.kayenta.storage.ObjectType;
 import com.netflix.kayenta.storage.StorageService;
 import java.util.Objects;
@@ -30,7 +30,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 @RequiredArgsConstructor
 public class StorageDataMigrator {
 
-  private final SqlProperties sqlProperties;
+  private final DataMigrationProperties dataMigrationProperties;
   private final StorageService sourceStorageService;
   private final StorageService targetStorageService;
   private final ExecutorService executorService;
@@ -38,8 +38,8 @@ public class StorageDataMigrator {
   private void migrate(ObjectType objectType) {
     log.info("Migrating {}", objectType);
 
-    var sourceAccountName = sqlProperties.getMigration().getSourceAccountName();
-    var targetAccountName = sqlProperties.getMigration().getTargetAccountName();
+    var sourceAccountName = dataMigrationProperties.getSourceAccountName();
+    var targetAccountName = dataMigrationProperties.getTargetAccountName();
 
     var sourceObjectKeys =
         sourceStorageService.listObjectKeys(sourceAccountName, objectType).stream()
@@ -95,11 +95,6 @@ public class StorageDataMigrator {
 
   @Scheduled(fixedDelay = 60000)
   public void migrate() {
-    if (!sqlProperties.getMigration().isEnabled()) {
-      log.info("Migration is disabled");
-      return;
-    }
-
     log.info("Migration started");
     migrate(ObjectType.CANARY_RESULT_ARCHIVE);
     migrate(ObjectType.CANARY_CONFIG);

--- a/kayenta-sql/src/main/java/com/netflix/kayenta/sql/migration/StorageDataMigrator.java
+++ b/kayenta-sql/src/main/java/com/netflix/kayenta/sql/migration/StorageDataMigrator.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2023 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.sql.migration;
+
+import com.netflix.kayenta.sql.config.SqlProperties;
+import com.netflix.kayenta.storage.ObjectType;
+import com.netflix.kayenta.storage.StorageService;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Slf4j
+@RequiredArgsConstructor
+public class StorageDataMigrator {
+
+  private final SqlProperties sqlProperties;
+  private final StorageService sourceStorageService;
+  private final StorageService targetStorageService;
+  private final ExecutorService executorService;
+
+  private void migrate(ObjectType objectType) {
+    log.info("Migrating {}", objectType);
+
+    var sourceAccountName = sqlProperties.getMigration().getSourceAccountName();
+    var targetAccountName = sqlProperties.getMigration().getTargetAccountName();
+
+    var sourceObjectKeys =
+        sourceStorageService.listObjectKeys(sourceAccountName, objectType).stream()
+            .map(sourceObjectKey -> (String) sourceObjectKey.get("id"))
+            .collect(Collectors.toList());
+
+    var targetObjectKeys =
+        targetStorageService.listObjectKeys(targetAccountName, objectType).stream()
+            .map(sourceObjectKey -> (String) sourceObjectKey.get("id"))
+            .collect(Collectors.toList());
+
+    var objectKeysToMigrate =
+        sourceObjectKeys.stream()
+            .filter(
+                sourceObjectKey ->
+                    targetObjectKeys.stream()
+                        .filter(targetObjectKey -> Objects.equals(targetObjectKey, sourceObjectKey))
+                        .findFirst()
+                        .isEmpty())
+            .collect(Collectors.toList());
+
+    if (objectKeysToMigrate.isEmpty()) {
+      log.info(
+          "No objects to migrate for objectType: {}, sourceObjectCount: {}, targetObjectCount: {}",
+          objectType,
+          sourceObjectKeys.size(),
+          targetObjectKeys.size());
+      return;
+    }
+
+    for (var objectKey : objectKeysToMigrate) {
+      executorService.submit(
+          () -> {
+            try {
+              var object =
+                  sourceStorageService.loadObject(sourceAccountName, objectType, objectKey);
+              targetStorageService.storeObject(targetAccountName, objectType, objectKey, object);
+            } catch (Exception e) {
+              log.error(
+                  "Unable to migrate objectType: {}, objectKey: {}", objectType, objectKey, e);
+            }
+          });
+    }
+  }
+
+  @Scheduled(fixedDelay = 60000)
+  public void migrate() {
+    if (!sqlProperties.getMigration().isEnabled()) {
+      log.info("Migration is disabled");
+      return;
+    }
+
+    log.info("Migration started");
+    migrate(ObjectType.CANARY_RESULT_ARCHIVE);
+    migrate(ObjectType.CANARY_CONFIG);
+    migrate(ObjectType.METRIC_SET_PAIR_LIST);
+    migrate(ObjectType.METRIC_SET_LIST);
+    log.info("Migration complete");
+  }
+}

--- a/kayenta-sql/src/main/java/com/netflix/kayenta/sql/migration/StorageDataMigrator.java
+++ b/kayenta-sql/src/main/java/com/netflix/kayenta/sql/migration/StorageDataMigrator.java
@@ -58,6 +58,14 @@ public class StorageDataMigrator {
                     targetObjectKeys.stream()
                         .filter(targetObjectKey -> Objects.equals(targetObjectKey, sourceObjectKey))
                         .findFirst()
+                        .map(
+                            object -> {
+                              log.warn(
+                                  "Object for objectType: {}, key: {} already exists",
+                                  objectType,
+                                  sourceObjectKey);
+                              return object;
+                            })
                         .isEmpty())
             .collect(Collectors.toList());
 

--- a/kayenta-sql/src/test/java/com/netflix/kayenta/sql/migration/StorageDataMigratorTest.java
+++ b/kayenta-sql/src/test/java/com/netflix/kayenta/sql/migration/StorageDataMigratorTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.*;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import com.netflix.kayenta.canary.CanaryConfig;
-import com.netflix.kayenta.sql.config.SqlProperties;
+import com.netflix.kayenta.sql.config.DataMigrationProperties;
 import com.netflix.kayenta.storage.ObjectType;
 import com.netflix.kayenta.storage.StorageService;
 import java.util.ArrayList;
@@ -51,19 +51,20 @@ public class StorageDataMigratorTest {
     private StorageService targetStorageService;
 
     @Bean
-    public SqlProperties sqlProperties() {
-      var sqlProperties = new SqlProperties();
-      sqlProperties.getMigration().setEnabled(true);
-      sqlProperties.getMigration().setSourceAccountName(testSourceAccountName);
-      sqlProperties.getMigration().setTargetAccountName(testTargetAccountName);
+    public DataMigrationProperties dataMigrationProperties() {
+      var dataMigrationProperties = new DataMigrationProperties();
+      dataMigrationProperties.setEnabled(true);
+      dataMigrationProperties.setSourceAccountName(testSourceAccountName);
+      dataMigrationProperties.setTargetAccountName(testTargetAccountName);
 
-      return sqlProperties;
+      return dataMigrationProperties;
     }
 
     @Bean
-    public StorageDataMigrator storageDataMigrator(SqlProperties sqlProperties) {
+    public StorageDataMigrator storageDataMigrator(
+        DataMigrationProperties dataMigrationProperties) {
       return new StorageDataMigrator(
-          sqlProperties,
+          dataMigrationProperties,
           sourceStorageService,
           targetStorageService,
           MoreExecutors.newDirectExecutorService());

--- a/kayenta-sql/src/test/java/com/netflix/kayenta/sql/migration/StorageDataMigratorTest.java
+++ b/kayenta-sql/src/test/java/com/netflix/kayenta/sql/migration/StorageDataMigratorTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2023 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.sql.migration;
+
+import static org.mockito.Mockito.*;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import com.netflix.kayenta.canary.CanaryConfig;
+import com.netflix.kayenta.sql.config.SqlProperties;
+import com.netflix.kayenta.storage.ObjectType;
+import com.netflix.kayenta.storage.StorageService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+public class StorageDataMigratorTest {
+
+  private static final String testSourceAccountName = "testSourceAccountName";
+  private static final String testTargetAccountName = "testTargetAccountName";
+
+  @TestConfiguration
+  static class StorageDataMigratorTestConfig {
+
+    @MockBean(name = "sourceStorageService")
+    private StorageService sourceStorageService;
+
+    @MockBean(name = "targetStorageService")
+    private StorageService targetStorageService;
+
+    @Bean
+    public SqlProperties sqlProperties() {
+      var sqlProperties = new SqlProperties();
+      sqlProperties.getMigration().setEnabled(true);
+      sqlProperties.getMigration().setSourceAccountName(testSourceAccountName);
+      sqlProperties.getMigration().setTargetAccountName(testTargetAccountName);
+
+      return sqlProperties;
+    }
+
+    @Bean
+    public StorageDataMigrator storageDataMigrator(SqlProperties sqlProperties) {
+      return new StorageDataMigrator(
+          sqlProperties,
+          sourceStorageService,
+          targetStorageService,
+          MoreExecutors.newDirectExecutorService());
+    }
+  }
+
+  @Autowired private StorageService sourceStorageService;
+
+  @Autowired private StorageService targetStorageService;
+
+  @Autowired private StorageDataMigrator storageDataMigrator;
+
+  @Test
+  public void testMigrateWhenNoCollisions() {
+    var testCanaryConfig = createTestCanaryConfig();
+
+    when(sourceStorageService.listObjectKeys(testSourceAccountName, ObjectType.CANARY_CONFIG))
+        .thenReturn(List.of(Map.of("id", testCanaryConfig.getId())));
+
+    when(targetStorageService.listObjectKeys(testTargetAccountName, ObjectType.CANARY_CONFIG))
+        .thenReturn(new ArrayList<>());
+
+    when(sourceStorageService.loadObject(
+            testSourceAccountName, ObjectType.CANARY_CONFIG, testCanaryConfig.getId()))
+        .thenReturn(testCanaryConfig);
+
+    storageDataMigrator.migrate();
+
+    verify(sourceStorageService)
+        .loadObject(testSourceAccountName, ObjectType.CANARY_CONFIG, testCanaryConfig.getId());
+
+    verify(targetStorageService)
+        .storeObject(
+            testTargetAccountName,
+            ObjectType.CANARY_CONFIG,
+            testCanaryConfig.getId(),
+            testCanaryConfig);
+  }
+
+  @Test
+  public void testMigrateWhenCollisions() {
+    var testCanaryConfig = createTestCanaryConfig();
+
+    when(sourceStorageService.listObjectKeys(testSourceAccountName, ObjectType.CANARY_CONFIG))
+        .thenReturn(List.of(Map.of("id", testCanaryConfig.getId())));
+
+    when(targetStorageService.listObjectKeys(testTargetAccountName, ObjectType.CANARY_CONFIG))
+        .thenReturn(List.of(Map.of("id", testCanaryConfig.getId())));
+
+    storageDataMigrator.migrate();
+
+    verify(sourceStorageService, never())
+        .loadObject(testSourceAccountName, ObjectType.CANARY_CONFIG, testCanaryConfig.getId());
+
+    verify(targetStorageService, never())
+        .storeObject(
+            testTargetAccountName,
+            ObjectType.CANARY_CONFIG,
+            testCanaryConfig.getId(),
+            testCanaryConfig);
+  }
+
+  private CanaryConfig createTestCanaryConfig() {
+    return CanaryConfig.builder()
+        .id(UUID.randomUUID().toString())
+        .name(UUID.randomUUID().toString())
+        .applications(List.of(UUID.randomUUID().toString()))
+        .build();
+  }
+}

--- a/kayenta-sql/src/test/java/com/netflix/kayenta/sql/storage/SqlStorageServiceTest.java
+++ b/kayenta-sql/src/test/java/com/netflix/kayenta/sql/storage/SqlStorageServiceTest.java
@@ -114,7 +114,7 @@ public class SqlStorageServiceTest {
   }
 
   @Test
-  public void testLoadObjectWhenCanaryArchiveNotFound() throws IOException {
+  public void testLoadObjectWhenCanaryArchiveNotFound() {
     var testAccountName = UUID.randomUUID().toString();
     var testObjectType = ObjectType.CANARY_RESULT_ARCHIVE;
     var testObjectKey = UUID.randomUUID().toString();


### PR DESCRIPTION
**How to use?**

Data migration and SQL is disabled by default, use these properties (in kayenta-local.yml) to enable the data migration and MySQL or PostgreSQL data source.

```
kayenta:
  sql:
    enabled: true
  data-migration:
    enabled: true
    sourceStorageServiceClassName: com.netflix.kayenta.s3.storage.S3StorageService
    targetStorageServiceClassName: com.netflix.kayenta.sql.storage.SqlStorageService
    sourceAccountName: monitoring
    targetAccountName: monitoring
  aws:
    enabled: true
    accounts:
      - name: monitoring
        bucket: ...
        region: us-west-2
        explicitCredentials:
          accessKey: ...
          secretKey: ...
          sessionToken: ...
        rootFolder: kayenta
        roleName: default
        supportedTypes:
          - OBJECT_STORE
          - CONFIGURATION_STORE
          - METRICS_STORE
  cloudwatch:
    enabled: true
  s3:
    enabled: true

spring:
  datasource:
    driver-class-name: com.mysql.cj.jdbc.Driver or org.postgresql.Driver
    username: ...
    password: ...
    url: jdbc:mysql://...
```