### PR TITLE
fix(signalfx): Fixed metric type missing due to duplicated field from parent class

### DIFF
--- a/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/security/SignalFxNamedAccountCredentials.java
+++ b/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/security/SignalFxNamedAccountCredentials.java
@@ -21,9 +21,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.netflix.kayenta.retrofit.config.RemoteService;
 import com.netflix.kayenta.security.AccountCredentials;
 import com.netflix.kayenta.signalfx.service.SignalFxSignalFlowRemoteService;
-import java.util.List;
 import javax.validation.constraints.NotNull;
-import lombok.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Getter
@@ -33,8 +34,6 @@ import lombok.experimental.SuperBuilder;
 public class SignalFxNamedAccountCredentials extends AccountCredentials<SignalFxCredentials> {
 
   @NotNull private String name;
-
-  @NotNull @Singular private List<Type> supportedTypes;
 
   @NotNull private SignalFxCredentials credentials;
 

--- a/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/config/SignalFxConfigLoadTest.java
+++ b/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/config/SignalFxConfigLoadTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.kayenta.signalfx.config;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.netflix.kayenta.retrofit.config.RetrofitClientFactory;
+import com.netflix.kayenta.security.AccountCredentials;
+import com.netflix.kayenta.security.AccountCredentialsRepository;
+import com.netflix.kayenta.security.MapBackedAccountCredentialsRepository;
+import com.squareup.okhttp.OkHttpClient;
+import java.util.List;
+import org.junit.Test;
+
+public class SignalFxConfigLoadTest {
+
+  private AccountCredentialsRepository accountRepo = new MapBackedAccountCredentialsRepository();
+
+  @Test
+  public void testThatConfigLoadFromAccountRendersCorrectly() {
+    SignalFxConfigurationProperties signalFxConfigurationProperties =
+        mock(SignalFxConfigurationProperties.class);
+    when(signalFxConfigurationProperties.getAccounts())
+        .thenReturn(List.of(new SignalFxManagedAccount().setName("Test-account")));
+    RetrofitClientFactory mockRetrofitFactory = mock(RetrofitClientFactory.class);
+    OkHttpClient mockOkHttpFactory = mock(OkHttpClient.class);
+    new SignalFxConfiguration()
+        .signalFxMetricService(
+            signalFxConfigurationProperties, mockRetrofitFactory, mockOkHttpFactory, accountRepo);
+    assertEquals("signalfx", accountRepo.getRequiredOne("Test-account").getType());
+    assertEquals(
+        List.of(AccountCredentials.Type.METRICS_STORE),
+        accountRepo.getRequiredOne("Test-account").getSupportedTypes());
+  }
+}


### PR DESCRIPTION
When we refactored the code to extend a base class... we missed a spot that had overloaded the type.  As a result of this no types were returned.  Drop downs for account lists currently don't work unless a type is shown for the given account.