### PR TITLE
refactor(deprecation): remove deprecated gradle constructs/features from kayenta in order to upgrade gradle 7

### DIFF
--- a/kayenta-graphite/kayenta-graphite.gradle
+++ b/kayenta-graphite/kayenta-graphite.gradle
@@ -174,9 +174,7 @@ dependencies {
 
     // Integration Test dependencies
     integrationTestImplementation sourceSets.main.output
-    integrationTestImplementation configurations.testImplementation
     integrationTestImplementation sourceSets.test.output
-    integrationTestRuntime configurations.testRuntime
     integrationTestImplementation project(':kayenta-web')
 
     // Apache 2.0 https://github.com/rest-assured/rest-assured/blob/master/LICENSE
@@ -184,4 +182,9 @@ dependencies {
     integrationTestAnnotationProcessor platform("io.spinnaker.orca:orca-bom:$orcaVersion")
     integrationTestAnnotationProcessor "org.projectlombok:lombok"
     integrationTestCompileOnly "org.projectlombok:lombok"
+}
+
+configurations {
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestImplementation.extendsFrom testRuntime
 }

--- a/kayenta-signalfx/kayenta-signalfx.gradle
+++ b/kayenta-signalfx/kayenta-signalfx.gradle
@@ -116,9 +116,7 @@ dependencies {
 
   // Integration Test dependencies
   integrationTestImplementation sourceSets.main.output
-  integrationTestImplementation configurations.testImplementation
   integrationTestImplementation sourceSets.test.output
-  integrationTestRuntime configurations.testRuntime
   integrationTestImplementation project(':kayenta-web')
 
   // Apache 2.0 https://github.com/rest-assured/rest-assured/blob/master/LICENSE
@@ -127,6 +125,11 @@ dependencies {
   integrationTestAnnotationProcessor platform("io.spinnaker.orca:orca-bom:$orcaVersion")
   integrationTestAnnotationProcessor "org.projectlombok:lombok"
   integrationTestCompileOnly "org.projectlombok:lombok"
+}
+
+configurations {
+  integrationTestImplementation.extendsFrom testImplementation
+  integrationTestImplementation.extendsFrom testRuntime
 }
 
 test {


### PR DESCRIPTION
While executing the build script with --warning-mode=fail received below error:
```
Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0
```
And the deprecated gradle features are:
```
> Configure project :kayenta-graphite
Adding a Configuration as a dependency is a confusing behavior which isn't recommended. This behaviour has been deprecated and is scheduled to be removed in Gradle 8.0. If you're interested in inheriting the dependencies from the Configuration you are adding, you should use Configuration#extendsFrom instead. See https://docs.gradle.org/6.8.1/dsl/org.gradle.api.artifacts.Configuration.html#org.gradle.api.artifacts.Configuration:extendsFrom(org.gradle.api.artifacts.Configuration[]) for more details.
        at kayenta_graphite_1x9iez1l2pvtbue1zqbkhdpai$_run_closure9.doCall(/kayenta/kayenta-graphite/kayenta-graphite.gradle:177)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
> Configure project :kayenta-signalfx
Adding a Configuration as a dependency is a confusing behavior which isn't recommended. This behaviour has been deprecated and is scheduled to be removed in Gradle 8.0. If you're interested in inheriting the dependencies from the Configuration you are adding, you should use Configuration#extendsFrom instead. See https://docs.gradle.org/6.8.1/dsl/org.gradle.api.artifacts.Configuration.html#org.gradle.api.artifacts.Configuration:extendsFrom(org.gradle.api.artifacts.Configuration[]) for more details.
        at kayenta_signalfx_2dzxi188pne1dhhtc7zkfa5wn$_run_closure7.doCall(/kayenta/kayenta-signalfx/kayenta-signalfx.gradle:119)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```
Replaced with Configuration#extendsFrom.

