### PR TITLE
refactor(tests): convert junit4 based testcases to junit5 and clean up in kayenta

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ subprojects { project ->
     }
 
     test {
+      useJUnitPlatform()
       testLogging {
         exceptionFormat = "full"
       }
@@ -76,6 +77,7 @@ subprojects { project ->
         api 'org.scala-lang:scala-reflect:2.12.12'
         api 'com.typesafe.scala-logging:scala-logging_2.12:3.9.2'
         testImplementation 'org.scalatest:scalatest_2.12:3.0.9'
+        testRuntimeOnly 'org.scalatestplus:junit-5-9_2.12:3.2.16.0'
       }
       implementation enforcedPlatform("io.spinnaker.orca:orca-bom:$orcaVersion")
       compileOnly "org.projectlombok:lombok"
@@ -105,6 +107,8 @@ subprojects { project ->
       testImplementation "org.hamcrest:hamcrest-core"
       testRuntimeOnly "cglib:cglib-nodep"
       testRuntimeOnly "org.objenesis:objenesis"
+      testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
+      testRuntimeOnly "org.junit.vintage:junit-vintage-engine" //Required for spock tests to execute along with junit5 tests
     }
   }
 

--- a/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/BackendTest.java
+++ b/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/BackendTest.java
@@ -1,12 +1,13 @@
 package com.netflix.kayenta.atlas;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.netflix.kayenta.atlas.model.Backend;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BackendTest {
   @Test

--- a/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/BackendsTest.java
+++ b/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/BackendsTest.java
@@ -1,6 +1,8 @@
 package com.netflix.kayenta.atlas;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -12,20 +14,20 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.io.IOUtils;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @Configuration
 @ComponentScan({"com.netflix.kayenta.retrofit.config"})
 class BackendsConfig {}
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {BackendsConfig.class})
 public class BackendsTest {
   @Autowired private ResourceLoader resourceLoader;

--- a/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/IntegrationTest.java
+++ b/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/IntegrationTest.java
@@ -19,14 +19,14 @@ import java.util.stream.Collectors;
 import javax.validation.constraints.NotNull;
 import lombok.*;
 import org.apache.commons.io.IOUtils;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @Configuration
 @ComponentScan({"com.netflix.kayenta.retrofit.config"})
@@ -43,7 +43,7 @@ class CanaryMetricConfigWithResults {
   @NotNull @Getter private List<AtlasResults> atlasResults;
 }
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {TestConfig.class})
 public class IntegrationTest {
 

--- a/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/config/AtlasSSEConverterTest.java
+++ b/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/config/AtlasSSEConverterTest.java
@@ -1,6 +1,7 @@
 package com.netflix.kayenta.atlas.config;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.kayenta.atlas.model.AtlasResults;
@@ -9,7 +10,7 @@ import com.netflix.kayenta.metrics.RetryableQueryException;
 import java.io.BufferedReader;
 import java.io.StringReader;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AtlasSSEConverterTest {
 
@@ -39,18 +40,19 @@ public class AtlasSSEConverterTest {
     assertEquals(2, results.size());
   }
 
-  @Test(expected = RetryableQueryException.class)
+  @Test
   public void missingCloseThrows() {
-    atlasResultsFromSSE(timeseriesMessage);
+    assertThrows(RetryableQueryException.class, () -> atlasResultsFromSSE(timeseriesMessage));
   }
 
-  @Test(expected = FatalQueryException.class)
+  @Test
   public void fatalErrorWithoutClose() {
-    atlasResultsFromSSE(errorMessageIllegalStateMessage);
+    assertThrows(
+        FatalQueryException.class, () -> atlasResultsFromSSE(errorMessageIllegalStateMessage));
   }
 
-  @Test(expected = RetryableQueryException.class)
+  @Test
   public void retryableErrorWithoutClose() {
-    atlasResultsFromSSE(retryableErrorMessage);
+    assertThrows(RetryableQueryException.class, () -> atlasResultsFromSSE(retryableErrorMessage));
   }
 }

--- a/kayenta-blobs/kayenta-blobs.gradle
+++ b/kayenta-blobs/kayenta-blobs.gradle
@@ -4,5 +4,4 @@ dependencies {
 
     api 'com.microsoft.azure:azure-storage:8.3.0'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '1.9.10'
-    testImplementation group: 'com.tngtech.java', name: 'junit-dataprovider', version: '1.13.1'
 }

--- a/kayenta-core/src/test/groovy/com/netflix/kayenta/canary/providers/metrics/QueryConfigUtilsTest.java
+++ b/kayenta-core/src/test/groovy/com/netflix/kayenta/canary/providers/metrics/QueryConfigUtilsTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.when;
 import com.netflix.kayenta.canary.CanaryConfig;
 import com.netflix.kayenta.canary.CanaryMetricSetQueryConfig;
 import com.netflix.kayenta.canary.CanaryScope;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class QueryConfigUtilsTest {
 

--- a/kayenta-core/src/test/groovy/com/netflix/kayenta/metrics/SynchronousQueryProcessorTest.java
+++ b/kayenta-core/src/test/groovy/com/netflix/kayenta/metrics/SynchronousQueryProcessorTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -47,17 +48,17 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import retrofit.RetrofitError;
 import retrofit.client.Response;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public class SynchronousQueryProcessorTest {
 
   private static final String METRICS = "metrics-account";
@@ -77,16 +78,19 @@ public class SynchronousQueryProcessorTest {
 
   @InjectMocks SynchronousQueryProcessor processor;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     when(metricsServiceRepository.getRequiredOne(METRICS)).thenReturn(metricsService);
     when(storageServiceRepository.getRequiredOne(STORAGE)).thenReturn(storageService);
-    when(retryConfiguration.getAttempts()).thenReturn(ATTEMPTS);
-    when(retryConfiguration.getSeries())
+    lenient().when(retryConfiguration.getAttempts()).thenReturn(ATTEMPTS);
+    lenient()
+        .when(retryConfiguration.getSeries())
         .thenReturn(
             new HashSet<>(
                 Arrays.asList(HttpStatus.Series.SERVER_ERROR, HttpStatus.Series.REDIRECTION)));
-    when(retryConfiguration.getStatuses()).thenReturn(new HashSet<>(Arrays.asList(LOCKED)));
+    lenient()
+        .when(retryConfiguration.getStatuses())
+        .thenReturn(new HashSet<>(Arrays.asList(LOCKED)));
   }
 
   @Test

--- a/kayenta-core/src/test/groovy/com/netflix/kayenta/security/MapBackedAccountCredentialsRepositoryTest.java
+++ b/kayenta-core/src/test/groovy/com/netflix/kayenta/security/MapBackedAccountCredentialsRepositoryTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MapBackedAccountCredentialsRepositoryTest {
 

--- a/kayenta-core/src/test/groovy/com/netflix/kayenta/storage/MapBackedStorageServiceRepositoryTest.java
+++ b/kayenta-core/src/test/groovy/com/netflix/kayenta/storage/MapBackedStorageServiceRepositoryTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MapBackedStorageServiceRepositoryTest {
 

--- a/kayenta-core/src/test/groovy/com/netflix/kayenta/util/RetrySpec.groovy
+++ b/kayenta-core/src/test/groovy/com/netflix/kayenta/util/RetrySpec.groovy
@@ -51,6 +51,7 @@ class RetrySpec extends Specification {
     11       || 10         || 10               || "Failed after 10 attempts"
   }
 
+  @Unroll
   def "should sleep exponentially"() {
     given:
     def retry = Spy(Retry) {

--- a/kayenta-datadog/kayenta-datadog.gradle
+++ b/kayenta-datadog/kayenta-datadog.gradle
@@ -1,6 +1,5 @@
 dependencies {
   implementation project(":kayenta-core")
 
-  testImplementation group: 'junit', name: 'junit'
-  testImplementation group: 'org.mock-server', name: 'mockserver-junit-rule', version: '5.10.0'
+  testImplementation "org.mock-server:mockserver-junit-jupiter:5.15.0"
 }

--- a/kayenta-datadog/src/test/java/com/netflix/kayenta/datadog/service/DatadogTimeSeriesTest.java
+++ b/kayenta-datadog/src/test/java/com/netflix/kayenta/datadog/service/DatadogTimeSeriesTest.java
@@ -17,12 +17,12 @@
 package com.netflix.kayenta.datadog.service;
 
 import static com.netflix.kayenta.datadog.service.DatadogTimeSeries.*;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DatadogTimeSeriesTest {
 

--- a/kayenta-graphite/src/integration-test/java/com/netflix/kayenta/graphite/E2EIntegrationTest.java
+++ b/kayenta-graphite/src/integration-test/java/com/netflix/kayenta/graphite/E2EIntegrationTest.java
@@ -38,14 +38,14 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Instant;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Main.class)
 public class E2EIntegrationTest {
 

--- a/kayenta-graphite/src/test/java/com/netflix/kayenta/graphite/IntegrationTest.java
+++ b/kayenta-graphite/src/test/java/com/netflix/kayenta/graphite/IntegrationTest.java
@@ -16,7 +16,7 @@
 
 package com.netflix.kayenta.graphite;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Charsets;
@@ -43,14 +43,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.apache.commons.io.IOUtils;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @Configuration
 @ComponentScan({"com.netflix.kayenta.retrofit.config"})
@@ -67,7 +67,7 @@ class CanaryMetricConfigWithResults {
   @NotNull @Getter private List<GraphiteResults> graphiteResults;
 }
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {TestConfig.class})
 public class IntegrationTest {
 

--- a/kayenta-influxdb/src/test/java/com/netflix/kayenta/influxdb/config/InfluxDbResponseConverterTest.java
+++ b/kayenta-influxdb/src/test/java/com/netflix/kayenta/influxdb/config/InfluxDbResponseConverterTest.java
@@ -16,16 +16,15 @@
 
 package com.netflix.kayenta.influxdb.config;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.kayenta.influxdb.model.InfluxDbResult;
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import retrofit.converter.ConversionException;
 import retrofit.mime.TypedByteArray;
 import retrofit.mime.TypedInput;
@@ -86,7 +85,7 @@ public class InfluxDbResponseConverterTest {
   @Test
   public void serialize() throws Exception {
     List<InfluxDbResult> results = setupAllIntegers();
-    assertThat(influxDbResponseConverter.toBody(results), is(nullValue()));
+    assertThat(influxDbResponseConverter.toBody(results)).isNull();
   }
 
   @Test
@@ -95,7 +94,7 @@ public class InfluxDbResponseConverterTest {
     TypedInput input = new TypedByteArray(MIME_TYPE, EXAMPLE_ALL_INTEGERS.getBytes());
     List<InfluxDbResult> result =
         (List<InfluxDbResult>) influxDbResponseConverter.fromBody(input, List.class);
-    assertThat(result, is(results));
+    assertThat(result).isEqualTo(results);
   }
 
   @Test
@@ -104,13 +103,14 @@ public class InfluxDbResponseConverterTest {
     TypedInput input = new TypedByteArray(MIME_TYPE, EXAMPLE_WITH_FLOATS.getBytes());
     List<InfluxDbResult> result =
         (List<InfluxDbResult>) influxDbResponseConverter.fromBody(input, List.class);
-    assertThat(result, is(results));
+    assertThat(result).isEqualTo(results);
   }
 
-  @Test(expected = ConversionException.class)
+  @Test
   public void deserializeWrongValue() throws Exception {
     TypedInput input = new TypedByteArray(MIME_TYPE, "{\"foo\":\"bar\"}".getBytes());
-    influxDbResponseConverter.fromBody(input, List.class);
+    assertThrows(
+        ConversionException.class, () -> influxDbResponseConverter.fromBody(input, List.class));
   }
 
   private String asString(TypedOutput typedOutput) throws Exception {

--- a/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/BaseIntegrationTest.java
+++ b/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/BaseIntegrationTest.java
@@ -17,19 +17,19 @@ package com.netflix.kayenta.tests;
 
 import com.netflix.kayenta.Main;
 import com.netflix.kayenta.configuration.MetricsReportingConfiguration;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.actuate.metrics.AutoConfigureMetrics;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @AutoConfigureMetrics
 @SpringBootTest(
     classes = {MetricsReportingConfiguration.class, Main.class},
     webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
     value = "spring.application.name=kayenta")
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles({"base", "prometheus", "graphite", "cases"})
 public abstract class BaseIntegrationTest {
 

--- a/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/ManagementTest.java
+++ b/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/ManagementTest.java
@@ -19,7 +19,7 @@ import static com.netflix.kayenta.utils.AwaitilityUtils.awaitThirtySecondsUntil;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 

--- a/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/SwaggerTest.java
+++ b/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/SwaggerTest.java
@@ -16,7 +16,7 @@
 package com.netflix.kayenta.tests;
 
 import io.restassured.RestAssured;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
 public class SwaggerTest extends BaseIntegrationTest {

--- a/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/standalone/GraphiteStandaloneCanaryAnalysisTest.java
+++ b/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/standalone/GraphiteStandaloneCanaryAnalysisTest.java
@@ -20,7 +20,7 @@ import static org.hamcrest.CoreMatchers.is;
 import com.netflix.kayenta.steps.StandaloneCanaryAnalysisSteps;
 import com.netflix.kayenta.tests.BaseIntegrationTest;
 import io.restassured.response.ValidatableResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class GraphiteStandaloneCanaryAnalysisTest extends BaseIntegrationTest {

--- a/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/standalone/PrometheusStandaloneCanaryAnalysisTest.java
+++ b/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/standalone/PrometheusStandaloneCanaryAnalysisTest.java
@@ -20,7 +20,7 @@ import static org.hamcrest.CoreMatchers.is;
 import com.netflix.kayenta.steps.StandaloneCanaryAnalysisSteps;
 import com.netflix.kayenta.tests.BaseIntegrationTest;
 import io.restassured.response.ValidatableResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class PrometheusStandaloneCanaryAnalysisTest extends BaseIntegrationTest {

--- a/kayenta-judge/kayenta-judge.gradle
+++ b/kayenta-judge/kayenta-judge.gradle
@@ -12,6 +12,7 @@ dependencies {
   api 'org.scala-lang:scala-reflect'
   api 'com.typesafe.scala-logging:scala-logging_2.12'
   testImplementation 'org.scalatest:scalatest_2.12'
+  testRuntimeOnly 'org.scalatestplus:junit-5-9_2.12'
 }
 
 task scalaTest(dependsOn: ['testClasses'], type: JavaExec) {

--- a/kayenta-mannwhitney/kayenta-mannwhitney.gradle
+++ b/kayenta-mannwhitney/kayenta-mannwhitney.gradle
@@ -9,6 +9,7 @@ dependencies {
   api 'com.typesafe.scala-logging:scala-logging_2.12'
 
   testImplementation 'org.scalatest:scalatest_2.12'
+  testRuntimeOnly 'org.scalatestplus:junit-5-9_2.12'
 }
 
 task scalaTest(dependsOn: ['testClasses'], type: JavaExec) {

--- a/kayenta-mannwhitney/src/test/scala/com/netflix/kayenta/mannwhitney/MannWhitneySuite.scala
+++ b/kayenta-mannwhitney/src/test/scala/com/netflix/kayenta/mannwhitney/MannWhitneySuite.scala
@@ -16,7 +16,7 @@
 
 package com.netflix.kayenta.mannwhitney
 
-import junit.framework.TestCase.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.apache.commons.math3.analysis.UnivariateFunction
 import org.apache.commons.math3.distribution.NormalDistribution
 import org.scalatest.FunSuite

--- a/kayenta-prometheus/kayenta-prometheus.gradle
+++ b/kayenta-prometheus/kayenta-prometheus.gradle
@@ -1,5 +1,5 @@
 dependencies {
   implementation project(":kayenta-core")
 
-  testImplementation 'org.mock-server:mockserver-junit-rule:5.11.1'
+  testImplementation "org.mock-server:mockserver-junit-jupiter:5.15.0"
 }

--- a/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/config/PrometheusHealthConfigurationTest.java
+++ b/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/config/PrometheusHealthConfigurationTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.mock;
 
 import com.netflix.kayenta.metrics.MetricsService;
 import com.netflix.kayenta.security.AccountCredentialsRepository;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;

--- a/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/health/PrometheusHealthIndicatorTest.java
+++ b/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/health/PrometheusHealthIndicatorTest.java
@@ -22,15 +22,15 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.Collections;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public class PrometheusHealthIndicatorTest {
 
   @Mock PrometheusHealthCache healthCache;

--- a/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/health/PrometheusHealthJobTest.java
+++ b/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/health/PrometheusHealthJobTest.java
@@ -26,15 +26,15 @@ import com.netflix.kayenta.retrofit.config.RemoteService;
 import com.netflix.kayenta.security.AccountCredentialsRepository;
 import java.util.Arrays;
 import java.util.Optional;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.actuate.health.Status;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public class PrometheusHealthJobTest {
 
   private static final String PROM_ACCOUNT_1 = "a1";
@@ -48,7 +48,7 @@ public class PrometheusHealthJobTest {
 
   @InjectMocks PrometheusHealthJob healthJob;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     when(prometheusConfigurationProperties.getAccounts())
         .thenReturn(

--- a/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/integration/CanaryAnalysisPrometheusMetricsMixerServiceIntegrationTest.java
+++ b/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/integration/CanaryAnalysisPrometheusMetricsMixerServiceIntegrationTest.java
@@ -1,7 +1,7 @@
 package com.netflix.kayenta.prometheus.integration;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -22,8 +22,8 @@ import com.netflix.kayenta.security.AccountCredentialsRepository;
 import com.netflix.spectator.api.NoopRegistry;
 import java.time.Instant;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import retrofit.mime.TypedByteArray;
 import retrofit.mime.TypedInput;
@@ -48,7 +48,7 @@ public class CanaryAnalysisPrometheusMetricsMixerServiceIntegrationTest {
 
   private MetricSetMixerService metricSetMixerService;
 
-  @Before
+  @BeforeEach
   public void before() {
     initMocks(this);
     prometheusResponseConverter = new PrometheusResponseConverter(new ObjectMapper());

--- a/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/metrics/PrometheusMetricDescriptorsCacheTest.java
+++ b/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/metrics/PrometheusMetricDescriptorsCacheTest.java
@@ -30,13 +30,13 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PrometheusMetricDescriptorsCacheTest {
 
   private static final String ACCOUNT_1 = "metrics-acc-1";

--- a/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/service/PrometheusRemoteServiceTest.java
+++ b/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/service/PrometheusRemoteServiceTest.java
@@ -37,15 +37,15 @@ import java.util.List;
 import java.util.Scanner;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockserver.client.MockServerClient;
-import org.mockserver.junit.MockServerRule;
 import org.mockserver.model.MediaType;
+import org.mockserver.netty.MockServer;
 
 public class PrometheusRemoteServiceTest {
-  @Rule public MockServerRule mockServerRule = new MockServerRule(this, true);
+  public MockServer mockServer;
 
   private MockServerClient mockServerClient;
 
@@ -55,9 +55,17 @@ public class PrometheusRemoteServiceTest {
   OkHttpClient okHttpClient = new OkHttpClient();
   PrometheusRemoteService prometheusRemoteService;
 
-  @Before
+  @BeforeEach
   public void setUp() {
+    mockServer = new MockServer();
+    mockServerClient = new MockServerClient("localhost", mockServer.getPort());
     prometheusRemoteService = createClient(mockServerClient.getPort());
+  }
+
+  @AfterEach
+  public void cleanup() {
+    mockServer.close();
+    mockServer.stop();
   }
 
   @Test

--- a/kayenta-signalfx/kayenta-signalfx.gradle
+++ b/kayenta-signalfx/kayenta-signalfx.gradle
@@ -111,7 +111,6 @@ dependencies {
 
   api 'com.signalfx.public:signalfx-java:1.0.5'
 
-  testImplementation 'com.tngtech.java:junit-dataprovider:1.13.1'
   testImplementation project(":kayenta-standalone-canary-analysis")
 
   // Integration Test dependencies

--- a/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/BaseSignalFxIntegrationTest.java
+++ b/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/BaseSignalFxIntegrationTest.java
@@ -22,14 +22,14 @@ import com.netflix.kayenta.canary.CanaryConfig;
 import java.io.IOException;
 import java.time.Instant;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.Before;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Main.class)
 @Slf4j
 public abstract class BaseSignalFxIntegrationTest {
@@ -55,7 +55,7 @@ public abstract class BaseSignalFxIntegrationTest {
     return "http://localhost:" + serverPort + "%s";
   }
 
-  @Before
+  @BeforeEach
   public void before() {
     try {
       integrationTestCanaryConfig =

--- a/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/EndToEndCanaryIntegrationTests.java
+++ b/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/EndToEndCanaryIntegrationTests.java
@@ -34,8 +34,8 @@ import io.restassured.response.ValidatableResponse;
 import java.io.IOException;
 import java.time.Instant;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /** End to end integration tests */
 @Slf4j
@@ -43,7 +43,7 @@ public class EndToEndCanaryIntegrationTests extends BaseSignalFxIntegrationTest 
 
   public static final int CANARY_WINDOW_IN_MINUTES = 5;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     System.setProperty("block.for.metrics", System.getProperty("block.for.metrics", "true"));
   }

--- a/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/EndToEndStandaloneCanaryAnalysisIntegrationTests.java
+++ b/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/EndToEndStandaloneCanaryAnalysisIntegrationTests.java
@@ -31,13 +31,13 @@ import com.netflix.kayenta.standalonecanaryanalysis.domain.CanaryAnalysisExecuti
 import com.netflix.kayenta.standalonecanaryanalysis.domain.StageMetadata;
 import io.restassured.response.ValidatableResponse;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 @Slf4j
 public class EndToEndStandaloneCanaryAnalysisIntegrationTests extends BaseSignalFxIntegrationTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     System.setProperty("block.for.metrics", System.getProperty("block.for.metrics", "false"));
   }

--- a/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/config/SignalFxConfigLoadTest.java
+++ b/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/config/SignalFxConfigLoadTest.java
@@ -16,7 +16,7 @@
 
 package com.netflix.kayenta.signalfx.config;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -26,7 +26,7 @@ import com.netflix.kayenta.security.AccountCredentialsRepository;
 import com.netflix.kayenta.security.MapBackedAccountCredentialsRepository;
 import com.squareup.okhttp.OkHttpClient;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SignalFxConfigLoadTest {
 

--- a/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/metrics/SignalFxQueryBuilderServiceTest.java
+++ b/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/metrics/SignalFxQueryBuilderServiceTest.java
@@ -16,7 +16,7 @@
 
 package com.netflix.kayenta.signalfx.metrics;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 import com.google.common.collect.ImmutableMap;
@@ -25,14 +25,14 @@ import com.netflix.kayenta.canary.CanaryScope;
 import com.netflix.kayenta.canary.providers.metrics.SignalFxCanaryMetricSetQueryConfig;
 import com.netflix.kayenta.signalfx.canary.SignalFxCanaryScope;
 import com.netflix.kayenta.signalfx.config.SignalFxScopeConfiguration;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SignalFxQueryBuilderServiceTest {
 
   private SignalFxQueryBuilderService signalFxQueryBuilderService;
 
-  @Before
+  @BeforeEach
   public void before() {
     signalFxQueryBuilderService = new SignalFxQueryBuilderService();
   }

--- a/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/metrics/SimpleSignalFlowProgramBuilderTest.java
+++ b/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/metrics/SimpleSignalFlowProgramBuilderTest.java
@@ -17,19 +17,16 @@
 
 package com.netflix.kayenta.signalfx.metrics;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.collect.ImmutableMap;
 import com.netflix.kayenta.canary.providers.metrics.QueryPair;
 import com.netflix.kayenta.signalfx.canary.SignalFxCanaryScope;
 import com.netflix.kayenta.signalfx.config.SignalFxScopeConfiguration;
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(DataProviderRunner.class)
 public class SimpleSignalFlowProgramBuilderTest {
 
   @Test
@@ -67,7 +64,6 @@ public class SimpleSignalFlowProgramBuilderTest {
     assertEquals(expected, builder.build());
   }
 
-  @DataProvider
   public static Object[][] locationScopeProvider() {
     return new Object[][] {
       {
@@ -94,8 +90,8 @@ public class SimpleSignalFlowProgramBuilderTest {
     };
   }
 
-  @Test
-  @UseDataProvider("locationScopeProvider")
+  @ParameterizedTest
+  @MethodSource("locationScopeProvider")
   public void test_that_the_program_builder_builds_the_expected_program_when_location_is_provided(
       SignalFxCanaryScope scope, SignalFxScopeConfiguration scopeConfiguration) {
 

--- a/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/service/SignalFxRemoteServiceTest.java
+++ b/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/service/SignalFxRemoteServiceTest.java
@@ -17,13 +17,12 @@
 
 package com.netflix.kayenta.signalfx.service;
 
-import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.google.common.io.ByteStreams;
 import java.io.InputStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import retrofit.mime.TypedByteArray;
 import retrofit.mime.TypedInput;
 
@@ -39,9 +38,8 @@ public class SignalFxRemoteServiceTest {
         (SignalFlowExecutionResult) converter.fromBody(typedInput, SignalFlowExecutionResult.class);
 
     assertNotNull(signalFlowExecutionResult);
-    assertThat(
-        "The signalFlowExecutionResult contains the channel messages",
-        signalFlowExecutionResult.getChannelMessages().size(),
-        greaterThan(1));
+    assertThat(signalFlowExecutionResult.getChannelMessages().size())
+        .describedAs("The signalFlowExecutionResult contains the channel messages")
+        .isGreaterThan(1);
   }
 }

--- a/kayenta-sql/src/test/java/com/netflix/kayenta/sql/migration/StorageDataMigratorTest.java
+++ b/kayenta-sql/src/test/java/com/netflix/kayenta/sql/migration/StorageDataMigratorTest.java
@@ -27,15 +27,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public class StorageDataMigratorTest {
 
   private static final String testSourceAccountName = "testSourceAccountName";

--- a/kayenta-sql/src/test/java/com/netflix/kayenta/sql/storage/SqlStorageServiceTest.java
+++ b/kayenta-sql/src/test/java/com/netflix/kayenta/sql/storage/SqlStorageServiceTest.java
@@ -16,9 +16,9 @@
 
 package com.netflix.kayenta.sql.storage;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -40,15 +40,15 @@ import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.*;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public class SqlStorageServiceTest {
 
   private static ObjectMapper objectMapper =

--- a/kayenta-standalone-canary-analysis/kayenta-standalone-canary-analysis.gradle
+++ b/kayenta-standalone-canary-analysis/kayenta-standalone-canary-analysis.gradle
@@ -1,7 +1,6 @@
 dependencies {
   implementation project(":kayenta-core")
 
-  testImplementation 'com.tngtech.java:junit-dataprovider:1.13.1'
 }
 
 test {

--- a/kayenta-standalone-canary-analysis/src/test/java/com/netflix/kayenta/standalonecanaryanalysis/orca/stage/SetupAndExecuteCanariesStageTest.java
+++ b/kayenta-standalone-canary-analysis/src/test/java/com/netflix/kayenta/standalonecanaryanalysis/orca/stage/SetupAndExecuteCanariesStageTest.java
@@ -16,7 +16,8 @@
 
 package com.netflix.kayenta.standalonecanaryanalysis.orca.stage;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -28,8 +29,8 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 public class SetupAndExecuteCanariesStageTest {
@@ -40,7 +41,7 @@ public class SetupAndExecuteCanariesStageTest {
 
   private Instant now = Instant.now();
 
-  @Before
+  @BeforeEach
   public void before() {
     initMocks(this);
 
@@ -59,7 +60,7 @@ public class SetupAndExecuteCanariesStageTest {
     Duration actual = stage.calculateLifetime(now, later, request);
     Duration expected = Duration.ofMinutes(lifetimeInMinutes);
 
-    assertEquals("The duration should be 5 minutes", expected, actual);
+    assertEquals(expected, actual, "The duration should be 5 minutes");
   }
 
   @Test
@@ -74,14 +75,16 @@ public class SetupAndExecuteCanariesStageTest {
     Duration actual = stage.calculateLifetime(now, later, request);
     Duration expected = Duration.ofMinutes(lifetimeInMinutes);
 
-    assertEquals("The duration should be 5 minutes", expected, actual);
+    assertEquals(expected, actual, "The duration should be 5 minutes");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void
       test_that_calculateLifetime_throws_an_error_if_lifetime_and_start_and_endtime_not_provided() {
     Instant now = Instant.now();
-    stage.calculateLifetime(now, null, CanaryAnalysisExecutionRequest.builder().build());
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> stage.calculateLifetime(now, null, CanaryAnalysisExecutionRequest.builder().build()));
   }
 
   @Test

--- a/kayenta-standalone-canary-analysis/src/test/java/com/netflix/kayenta/standalonecanaryanalysis/orca/task/GenerateCanaryAnalysisResultTaskTest.java
+++ b/kayenta-standalone-canary-analysis/src/test/java/com/netflix/kayenta/standalonecanaryanalysis/orca/task/GenerateCanaryAnalysisResultTaskTest.java
@@ -17,7 +17,7 @@
 package com.netflix.kayenta.standalonecanaryanalysis.orca.task;
 
 import static com.netflix.kayenta.standalonecanaryanalysis.orca.stage.RunCanaryStage.STAGE_TYPE;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -28,20 +28,16 @@ import com.google.common.collect.Maps;
 import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(DataProviderRunner.class)
 public class GenerateCanaryAnalysisResultTaskTest {
 
   private GenerateCanaryAnalysisResultTask task;
 
-  @DataProvider
   public static Object[][] dataProviderGetAggregatedJudgment() {
     return new Object[][] {
       // final score, marginal, pass, expected didPass result
@@ -53,7 +49,7 @@ public class GenerateCanaryAnalysisResultTaskTest {
     };
   }
 
-  @Before
+  @BeforeEach
   public void before() {
     task = new GenerateCanaryAnalysisResultTask(new ObjectMapper());
   }
@@ -81,8 +77,8 @@ public class GenerateCanaryAnalysisResultTaskTest {
     }
   }
 
-  @Test
-  @UseDataProvider("dataProviderGetAggregatedJudgment")
+  @ParameterizedTest
+  @MethodSource("dataProviderGetAggregatedJudgment")
   public void test_getAggregatedJudgment(
       Double finalCanaryScore, Double marginalThreshold, Double passThreshold, boolean expected) {
     GenerateCanaryAnalysisResultTask.AggregatedJudgement aggregatedJudgement =

--- a/kayenta-wavefront/src/test/java/com/netflix/kayenta/wavefront/canary/WavefrontCanaryScopeFactoryTest.java
+++ b/kayenta-wavefront/src/test/java/com/netflix/kayenta/wavefront/canary/WavefrontCanaryScopeFactoryTest.java
@@ -15,12 +15,11 @@
  */
 package com.netflix.kayenta.wavefront.canary;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.netflix.kayenta.canary.CanaryScope;
 import java.time.Instant;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class WavefrontCanaryScopeFactoryTest {
 
@@ -38,7 +37,7 @@ public class WavefrontCanaryScopeFactoryTest {
             null);
     CanaryScope generatedCanaryScope = queryBuilder.buildCanaryScope(canaryScope);
     WavefrontCanaryScope wavefrontCanaryScope = (WavefrontCanaryScope) generatedCanaryScope;
-    assertThat(wavefrontCanaryScope.getGranularity(), is("s"));
+    assertThat(wavefrontCanaryScope.getGranularity()).isEqualTo("s");
   }
 
   @Test
@@ -53,7 +52,7 @@ public class WavefrontCanaryScopeFactoryTest {
             null);
     CanaryScope generatedCanaryScope = queryBuilder.buildCanaryScope(canaryScope);
     WavefrontCanaryScope wavefrontCanaryScope = (WavefrontCanaryScope) generatedCanaryScope;
-    assertThat(wavefrontCanaryScope.getGranularity(), is("m"));
+    assertThat(wavefrontCanaryScope.getGranularity()).isEqualTo("m");
   }
 
   @Test
@@ -68,7 +67,7 @@ public class WavefrontCanaryScopeFactoryTest {
             null);
     CanaryScope generatedCanaryScope = queryBuilder.buildCanaryScope(canaryScope);
     WavefrontCanaryScope wavefrontCanaryScope = (WavefrontCanaryScope) generatedCanaryScope;
-    assertThat(wavefrontCanaryScope.getGranularity(), is("h"));
+    assertThat(wavefrontCanaryScope.getGranularity()).isEqualTo("h");
   }
 
   @Test
@@ -83,6 +82,6 @@ public class WavefrontCanaryScopeFactoryTest {
             null);
     CanaryScope generatedCanaryScope = queryBuilder.buildCanaryScope(canaryScope);
     WavefrontCanaryScope wavefrontCanaryScope = (WavefrontCanaryScope) generatedCanaryScope;
-    assertThat(wavefrontCanaryScope.getGranularity(), is("d"));
+    assertThat(wavefrontCanaryScope.getGranularity()).isEqualTo("d");
   }
 }

--- a/kayenta-wavefront/src/test/java/com/netflix/kayenta/wavefront/metrics/WavefrontMetricsServiceTest.java
+++ b/kayenta-wavefront/src/test/java/com/netflix/kayenta/wavefront/metrics/WavefrontMetricsServiceTest.java
@@ -15,14 +15,13 @@
  */
 package com.netflix.kayenta.wavefront.metrics;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.netflix.kayenta.canary.CanaryMetricConfig;
 import com.netflix.kayenta.canary.CanaryScope;
 import com.netflix.kayenta.canary.providers.metrics.WavefrontCanaryMetricSetQueryConfig;
 import com.netflix.kayenta.wavefront.canary.WavefrontCanaryScope;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class WavefrontMetricsServiceTest {
 
@@ -38,7 +37,7 @@ public class WavefrontMetricsServiceTest {
     CanaryMetricConfig canaryMetricSetQueryConfig = queryConfig(AGGREGATE);
     String query =
         wavefrontMetricsService.buildQuery("", null, canaryMetricSetQueryConfig, canaryScope);
-    assertThat(query, is(AGGREGATE + "(ts(" + METRIC_NAME + "))"));
+    assertThat(query).isEqualTo(AGGREGATE + "(ts(" + METRIC_NAME + "))");
   }
 
   @Test
@@ -47,7 +46,7 @@ public class WavefrontMetricsServiceTest {
     CanaryMetricConfig canaryMetricSetQueryConfig = queryConfig("");
     String query =
         wavefrontMetricsService.buildQuery("", null, canaryMetricSetQueryConfig, canaryScope);
-    assertThat(query, is("ts(" + METRIC_NAME + ", " + SCOPE + ")"));
+    assertThat(query).isEqualTo("ts(" + METRIC_NAME + ", " + SCOPE + ")");
   }
 
   @Test
@@ -56,7 +55,7 @@ public class WavefrontMetricsServiceTest {
     CanaryMetricConfig canaryMetricSetQueryConfig = queryConfig("avg");
     String query =
         wavefrontMetricsService.buildQuery("", null, canaryMetricSetQueryConfig, canaryScope);
-    assertThat(query, is(AGGREGATE + "(ts(" + METRIC_NAME + ", " + SCOPE + "))"));
+    assertThat(query).isEqualTo(AGGREGATE + "(ts(" + METRIC_NAME + ", " + SCOPE + "))");
   }
 
   private CanaryMetricConfig queryConfig(String aggregate) {

--- a/kayenta-wavefront/src/test/java/com/netflix/kayenta/wavefront/service/WavefrontTimeSeriesTest.java
+++ b/kayenta-wavefront/src/test/java/com/netflix/kayenta/wavefront/service/WavefrontTimeSeriesTest.java
@@ -15,13 +15,12 @@
  */
 package com.netflix.kayenta.wavefront.service;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class WavefrontTimeSeriesTest {
 
@@ -29,28 +28,28 @@ public class WavefrontTimeSeriesTest {
   public void testGetAdjustedPointList_AddPoints() {
     List<Double> adjustedDataPoints = generateAdjustedPointList(2L);
 
-    assertThat(adjustedDataPoints.get(0), is(0.0));
-    assertThat(adjustedDataPoints.get(1), is(2.0));
-    assertThat(adjustedDataPoints.get(2), is(4.0));
+    assertThat(adjustedDataPoints.get(0)).isEqualTo(0.0);
+    assertThat(adjustedDataPoints.get(1)).isEqualTo(2.0);
+    assertThat(adjustedDataPoints.get(2)).isEqualTo(4.0);
   }
 
   @Test
   public void testGetAdjustedPointList_addNaNForMissingPoints() {
     List<Double> adjustedDataPoints = generateAdjustedPointList(1L);
 
-    assertThat(adjustedDataPoints.get(0), is(0.0));
-    assertThat(adjustedDataPoints.get(1), is(Double.NaN));
-    assertThat(adjustedDataPoints.get(2), is(2.0));
-    assertThat(adjustedDataPoints.get(3), is(Double.NaN));
-    assertThat(adjustedDataPoints.get(4), is(4.0));
+    assertThat(adjustedDataPoints.get(0)).isEqualTo(0.0);
+    assertThat(adjustedDataPoints.get(1)).isNaN();
+    assertThat(adjustedDataPoints.get(2)).isEqualTo(2.0);
+    assertThat(adjustedDataPoints.get(3)).isNaN();
+    assertThat(adjustedDataPoints.get(4)).isEqualTo(4.0);
   }
 
   @Test
   public void testGetAdjustedPointList_SkipPointsOutsideStep() {
     List<Double> adjustedDataPoints = generateAdjustedPointList(4L);
 
-    assertThat(adjustedDataPoints.get(0), is(0.0));
-    assertThat(adjustedDataPoints.get(1), is(4.0));
+    assertThat(adjustedDataPoints.get(0)).isEqualTo(0.0);
+    assertThat(adjustedDataPoints.get(1)).isEqualTo(4.0);
   }
 
   private List<Double> generateAdjustedPointList(long step) {

--- a/kayenta-web/src/test/java/com/netflix/kayenta/controllers/BaseControllerTest.java
+++ b/kayenta-web/src/test/java/com/netflix/kayenta/controllers/BaseControllerTest.java
@@ -22,8 +22,8 @@ import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Before;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -32,7 +32,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -41,7 +41,7 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 @SpringBootTest(
     classes = BaseControllerTest.TestControllersConfiguration.class,
     webEnvironment = SpringBootTest.WebEnvironment.MOCK)
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public abstract class BaseControllerTest {
 
   protected static final String CONFIGS_ACCOUNT = "configs-account";
@@ -65,7 +65,7 @@ public abstract class BaseControllerTest {
 
   protected MockMvc mockMvc;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     this.mockMvc =
         MockMvcBuilders.webAppContextSetup(this.webApplicationContext).alwaysDo(print()).build();

--- a/kayenta-web/src/test/java/com/netflix/kayenta/controllers/CanaryConfigControllerTest.java
+++ b/kayenta-web/src/test/java/com/netflix/kayenta/controllers/CanaryConfigControllerTest.java
@@ -15,7 +15,7 @@ import com.netflix.kayenta.storage.ObjectType;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import java.io.InputStream;
 import org.apache.commons.io.IOUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CanaryConfigControllerTest extends BaseControllerTest {
 

--- a/kayenta-web/src/test/java/com/netflix/kayenta/controllers/CanaryControllerTest.java
+++ b/kayenta-web/src/test/java/com/netflix/kayenta/controllers/CanaryControllerTest.java
@@ -7,7 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.netflix.kayenta.canary.CanaryConfig;
 import com.netflix.kayenta.storage.ObjectType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CanaryControllerTest extends BaseControllerTest {
 


### PR DESCRIPTION
Before refactor, total test cases executed were 336. 
After refactor, total test cases executed are ~~326~~ 420.