### PR TITLE
fix(orca): Fix orca contributors status.

### DIFF
--- a/kayenta-orca/kayenta-orca.gradle
+++ b/kayenta-orca/kayenta-orca.gradle
@@ -9,4 +9,6 @@ dependencies {
   testImplementation "io.spinnaker.orca:orca-test"
 
   testImplementation "com.natpryce:hamkrest"
+
+  implementation "org.springframework.cloud:spring-cloud-commons:3.0.6"
 }

--- a/kayenta-orca/src/main/java/com/netflix/kayenta/config/OrcaCompositeHealthContributor.java
+++ b/kayenta-orca/src/main/java/com/netflix/kayenta/config/OrcaCompositeHealthContributor.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.boot.actuate.health.*;
+import org.springframework.cloud.client.discovery.health.DiscoveryCompositeHealthContributor;
 
 public class OrcaCompositeHealthContributor implements CompositeHealthContributor {
 
@@ -69,10 +70,25 @@ public class OrcaCompositeHealthContributor implements CompositeHealthContributo
   public Status status() {
     Set<Status> statuses =
         this.contributors.values().stream()
+            .filter(c -> c.getContributor() instanceof HealthIndicator)
             .map(contributor -> ((HealthIndicator) contributor.getContributor()).getHealth(false))
             .map(Health::getStatus)
             .collect(Collectors.toSet());
+    statuses.addAll(getDiscoveryStatuses());
 
     return this.statusAggregator.getAggregateStatus(statuses);
+  }
+
+  private Set<Status> getDiscoveryStatuses() {
+    NamedContributor<HealthContributor> discoveryComposite = contributors.get("discoveryComposite");
+
+    if (discoveryComposite != null) {
+      return ((DiscoveryCompositeHealthContributor) discoveryComposite.getContributor())
+          .getIndicators().values().stream()
+              .map(i -> i.health().getStatus())
+              .collect(Collectors.toSet());
+    }
+
+    return Collections.EMPTY_SET;
   }
 }


### PR DESCRIPTION
This is a fix for kayenta start-up error:
```
java.lang.ClassCastException: class org.springframework.cloud.client.discovery.health.DiscoveryCompositeHealthContributor cannot be cast to class org.springframework.boot.actuate.health.HealthIndicator (org.springframework.cloud.client.discovery.health.DiscoveryCompositeHealthContributor and org.springframework.boot.actuate.health.HealthIndicator are in unnamed module of loader 'app')
	at com.netflix.kayenta.config.OrcaCompositeHealthContributor.lambda$status$1(OrcaCompositeHealthContributor.java:72) ~[kayenta-orca-2023.06.01.03.14.40.release-1.30.x.jar:2023.06.01.03.14.40.release-1.30.x]
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195) ~[na:na]
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133) ~[na:na]
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801) ~[na:na]
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) ~[na:na]
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[na:na]
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913) ~[na:na]
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[na:na]
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578) ~[na:na]
	at com.netflix.kayenta.config.OrcaCompositeHealthContributor.status(OrcaCompositeHealthContributor.java:74) ~[kayenta-orca-2023.06.01.03.14.40.release-1.30.x.jar:2023.06.01.03.14.40.release-1.30.x]
	at com.netflix.kayenta.orca.controllers.PipelineController.startOrcaQueueProcessing(PipelineController.java:84) ~[kayenta-orca-2023.06.01.03.14.40.release-1.30.x.jar:2023.06.01.03.14.40.release-1.30.x]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:na]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:566) ~[na:na]
	at org.springframework.scheduling.support.ScheduledMethodRunnable.run(ScheduledMethodRunnable.java:84) ~[spring-context-5.3.13.jar:5.3.13]
	at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54) ~[spring-context-5.3.13.jar:5.3.13]
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[na:na]
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) ~[na:na]
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadP
```

The error happened because the DiscoveryCompositeHealthContributor does not implement HelthIndicator. Meaning that we cannot cast it to one. I added the logic for get the status for this specific case. 

Tested on local env.

<img width="1279" alt="image" src="https://github.com/spinnaker/kayenta/assets/111055962/ad4d0139-347e-4ac8-9041-c1252fac71f7">