### PR TITLE
refactor(core/test): fix test placeholders to show unrolled iteration names during upgrade to groovy 3.x

### DIFF
--- a/kayenta-core/src/test/groovy/com/netflix/kayenta/metrics/MetricSetMixerServiceSpec.groovy
+++ b/kayenta-core/src/test/groovy/com/netflix/kayenta/metrics/MetricSetMixerServiceSpec.groovy
@@ -251,7 +251,7 @@ class MetricSetMixerServiceSpec extends Specification {
   }
 
   @Unroll
-  void "mixing #controlMetricSet and #experimentMetricSet should fail"() {
+  void "mixing #controlMetricSet.name and #experimentMetricSet.name should fail"() {
     setup:
     MetricSetMixerService metricSetMixerService = new MetricSetMixerService()
 


### PR DESCRIPTION
While upgrading groovy 3.0.10 and spockframework 2.0-groovy-3.0, encounter below error in test execution of kayenta-core module:
```
Error in @Unroll expression: controlMetricSet
	at app//org.spockframework.runtime.extension.builtin.UnrollIterationNameProvider.evaluateExpression(UnrollIterationNameProvider.java:100)
	at app//org.spockframework.runtime.extension.builtin.UnrollIterationNameProvider.nameFor(UnrollIterationNameProvider.java:55)
	at app//org.spockframework.runtime.extension.builtin.UnrollIterationNameProvider.getName(UnrollIterationNameProvider.java:46)
	at app//org.spockframework.runtime.extension.builtin.UnrollIterationNameProvider.getName(UnrollIterationNameProvider.java:30)
	at app//org.spockframework.runtime.SafeIterationNameProvider.getName(SafeIterationNameProvider.java:33)
	at app//org.spockframework.runtime.SafeIterationNameProvider.getName(SafeIterationNameProvider.java:21)
	at app//org.spockframework.runtime.PlatformSpecRunner.createIterationInfo(PlatformSpecRunner.java:230)
	at app//org.spockframework.runtime.PlatformParameterizedSpecRunner.runIterations(PlatformParameterizedSpecRunner.java:178)
	at app//org.spockframework.runtime.PlatformParameterizedSpecRunner.runParameterizedFeature(PlatformParameterizedSpecRunner.java:45)
	at app//org.spockframework.runtime.ParameterizedFeatureNode.execute(ParameterizedFeatureNode.java:40)
	at app//org.spockframework.runtime.ParameterizedFeatureNode.execute(ParameterizedFeatureNode.java:16)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
	at app//org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:129)
	at app//org.spockframework.runtime.SpockNode.sneakyInvoke(SpockNode.java:40)
	....
Caused by: java.lang.IllegalArgumentException: Metric set name was not set.
	at com.netflix.kayenta.metrics.MetricSet.getMetricSetKey(MetricSet.java:80)
	at com.netflix.kayenta.metrics.MetricSet.toString(MetricSet.java:29)
	at org.codehaus.groovy.runtime.InvokerHelper.format(InvokerHelper.java:677)
	at org.codehaus.groovy.runtime.InvokerHelper.toString(InvokerHelper.java:152)
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.toString(DefaultGroovyMethods.java:15713)
	at org.spockframework.runtime.GroovyRuntimeUtil.toString(GroovyRuntimeUtil.java:74)
	at org.spockframework.util.RenderUtil.toStringOrDump(RenderUtil.java:49)
	at org.spockframework.runtime.extension.builtin.UnrollIterationNameProvider.evaluateExpression(UnrollIterationNameProvider.java:97)
	... 86 more
```
To fix this issue put the qualified placeholder with name field.