### PR TITLE
refactor(prometheus/test): fix test assertion message received from SpinnakerHttpException during upgrade to groovy 3.x

### DIFF
--- a/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/service/PrometheusRemoteServiceTest.java
+++ b/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/service/PrometheusRemoteServiceTest.java
@@ -87,7 +87,7 @@ public class PrometheusRemoteServiceTest {
 
     assertThatThrownBy(() -> prometheusRemoteService.isHealthy())
         .isInstanceOf(SpinnakerServerException.class)
-        .hasMessageContaining("500 Internal Server Error");
+        .hasMessageContaining("Internal Server Error");
   }
 
   @Test


### PR DESCRIPTION
While upgrading groovy 3.0.10 and spockframework 2.0-groovy-3.0, encounter below error in test execution of kayenta-prometheus module:
```
java.lang.AssertionError:
Expecting throwable message:
  "Status: 500, URL: http://localhost:41703/-/healthy, Message: Internal Server Error"
to contain:
  "500 Internal Server Error"
but did not.

Throwable that failed the check:

com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException: Status: 500, URL: http://localhost:41703/-/healthy, Message: Internal Server Error
	at com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler.handleError(SpinnakerRetrofitErrorHandler.java:55)
	at retrofit.RestAdapter$RestHandler.invoke(RestAdapter.java:242)
	at com.sun.proxy.$Proxy71.isHealthy(Unknown Source)
	at com.netflix.kayenta.prometheus.service.PrometheusRemoteServiceTest.lambda$isHealthyReturnsInternalServerError$0(PrometheusRemoteServiceTest.java:88)
	at org.assertj.core.api.ThrowableAssert.catchThrowable(ThrowableAssert.java:62)
	at org.assertj.core.api.AssertionsForClassTypes.catchThrowable(AssertionsForClassTypes.java:877)
	at org.assertj.core.api.Assertions.catchThrowable(Assertions.java:1306)
	at org.assertj.core.api.Assertions.assertThatThrownBy(Assertions.java:1178)
	at com.netflix.kayenta.prometheus.service.PrometheusRemoteServiceTest.isHealthyReturnsInternalServerError(PrometheusRemoteServiceTest.java:88)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:688)
        ...
Caused by: retrofit.RetrofitError: 500 Internal Server Error
	at retrofit.RetrofitError.httpError(RetrofitError.java:40)
	at retrofit.RestAdapter$RestHandler.invokeRequest(RestAdapter.java:388)
	at retrofit.RestAdapter$RestHandler.invoke(RestAdapter.java:240)
	... 90 more

	at com.netflix.kayenta.prometheus.service.PrometheusRemoteServiceTest.isHealthyReturnsInternalServerError(PrometheusRemoteServiceTest.java:91)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:688)
	...
```
To fix this issue, edit the assertion message.