### PR TITLE
refactor: Refactor how the kayenta object mapper is being configured to allow overriding from kayenta plugins

### DIFF
--- a/kayenta-core/src/main/java/com/netflix/kayenta/config/KayentaConfiguration.java
+++ b/kayenta-core/src/main/java/com/netflix/kayenta/config/KayentaConfiguration.java
@@ -108,18 +108,25 @@ public class KayentaConfiguration {
         ImmutableList.of("com.netflix.kayenta.canary.providers.metrics"));
   }
 
-  @Primary
   @Bean
-  ObjectMapper kayentaObjectMapper(ObjectMapper mapper) {
-    return mapper;
+  @ConditionalOnMissingBean
+  public ObjectMapperSubtypeConfigurer objectMapperSubtypeConfigurer() {
+    return new ObjectMapperSubtypeConfigurer(true);
   }
 
-  @Autowired
-  public void objectMapper(
+  @Primary
+  @Bean
+  ObjectMapper kayentaObjectMapper(
       ObjectMapper mapper,
+      ObjectMapperSubtypeConfigurer objectMapperSubtypeConfigurer,
       List<ObjectMapperSubtypeConfigurer.SubtypeLocator> subtypeLocators,
       KayentaSerializationConfigurationProperties kayentaSerializationConfigurationProperties) {
-    configureObjectMapper(mapper, subtypeLocators, kayentaSerializationConfigurationProperties);
+    configureObjectMapper(
+        mapper,
+        objectMapperSubtypeConfigurer,
+        subtypeLocators,
+        kayentaSerializationConfigurationProperties);
+    return mapper;
   }
 
   public static void configureObjectMapperFeatures(
@@ -141,9 +148,10 @@ public class KayentaConfiguration {
 
   private void configureObjectMapper(
       ObjectMapper objectMapper,
+      ObjectMapperSubtypeConfigurer objectMapperSubtypeConfigurer,
       List<ObjectMapperSubtypeConfigurer.SubtypeLocator> subtypeLocators,
       KayentaSerializationConfigurationProperties kayentaSerializationConfigurationProperties) {
-    new ObjectMapperSubtypeConfigurer(true).registerSubtypes(objectMapper, subtypeLocators);
+    objectMapperSubtypeConfigurer.registerSubtypes(objectMapper, subtypeLocators);
     configureObjectMapperFeatures(objectMapper, kayentaSerializationConfigurationProperties);
   }
 


### PR DESCRIPTION
Currently if you define a new subtype locator in a plugin it is not possible to be loaded by the configurer because different classloaders are used. This refactoring will give the flexibility of customizing the `ObjectMapperSubtypeConfigurer` from the plugin system 

- ObjectMapperSubtypeConfigurer objectMapperSubtypeConfigurer is defined as a bean
- there's no need to autowire the mapper to configure but instead configure it when creating the kayentaObjectMapper bean

This will allow us to add more metrics providers (via the plugin framework)
