### PR TITLE
refactor(core/test): replace deprecated mockito api verifyZeroInteractions() with verifyNoMoreInteractions() during upgrade to spring boot 2.6.x

### DIFF
--- a/kayenta-core/src/test/groovy/com/netflix/kayenta/metrics/SynchronousQueryProcessorTest.java
+++ b/kayenta-core/src/test/groovy/com/netflix/kayenta/metrics/SynchronousQueryProcessorTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.BAD_GATEWAY;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
@@ -118,7 +118,7 @@ public class SynchronousQueryProcessorTest {
             any(CanaryConfig.class),
             any(CanaryMetricConfig.class),
             any(CanaryScope.class));
-    verifyZeroInteractions(storageService);
+    verifyNoMoreInteractions(storageService);
   }
 
   @Test
@@ -198,7 +198,7 @@ public class SynchronousQueryProcessorTest {
             any(CanaryConfig.class),
             any(CanaryMetricConfig.class),
             any(CanaryScope.class));
-    verifyZeroInteractions(storageService);
+    verifyNoMoreInteractions(storageService);
   }
 
   @Test
@@ -226,7 +226,7 @@ public class SynchronousQueryProcessorTest {
             any(CanaryConfig.class),
             any(CanaryMetricConfig.class),
             any(CanaryScope.class));
-    verifyZeroInteractions(storageService);
+    verifyNoMoreInteractions(storageService);
   }
 
   @Test
@@ -256,7 +256,7 @@ public class SynchronousQueryProcessorTest {
             any(CanaryConfig.class),
             any(CanaryMetricConfig.class),
             any(CanaryScope.class));
-    verifyZeroInteractions(storageService);
+    verifyNoMoreInteractions(storageService);
   }
 
   private SpinnakerHttpException getSpinnakerHttpException(int status) {


### PR DESCRIPTION
While upgrading spring boot 2.6.15 and spring cloud 2021.0.8, encounter errors in kayenta-core module during test compilation:
```
> Task :kayenta-core:compileTestGroovy
/kayenta/kayenta-core/src/test/groovy/com/netflix/kayenta/metrics/SynchronousQueryProcessorTest.java:29: error: cannot find symbol
import static org.mockito.Mockito.verifyZeroInteractions;
^
  symbol:   static verifyZeroInteractions
  location: class Mockito
/kayenta/kayenta-core/src/test/groovy/com/netflix/kayenta/metrics/SynchronousQueryProcessorTest.java:121: error: cannot find symbol
    verifyZeroInteractions(storageService);
    ^
  symbol:   method verifyZeroInteractions(StorageService)
  location: class SynchronousQueryProcessorTest
/kayenta/kayenta-core/src/test/groovy/com/netflix/kayenta/metrics/SynchronousQueryProcessorTest.java:201: error: cannot find symbol
    verifyZeroInteractions(storageService);
    ^
  symbol:   method verifyZeroInteractions(StorageService)
  location: class SynchronousQueryProcessorTest
/kayenta/kayenta-core/src/test/groovy/com/netflix/kayenta/metrics/SynchronousQueryProcessorTest.java:229: error: cannot find symbol
    verifyZeroInteractions(storageService);
    ^
  symbol:   method verifyZeroInteractions(StorageService)
  location: class SynchronousQueryProcessorTest
/kayenta/kayenta-core/src/test/groovy/com/netflix/kayenta/metrics/SynchronousQueryProcessorTest.java:259: error: cannot find symbol
    verifyZeroInteractions(storageService);
    ^
  symbol:   method verifyZeroInteractions(StorageService)
  location: class SynchronousQueryProcessorTest
Note: /kayenta/kayenta-core/src/test/groovy/com/netflix/kayenta/metrics/SynchronousQueryProcessorTest.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
5 errors
startup failed:
Compilation failed; see the compiler error output for details.
1 error
> Task :kayenta-core:compileTestGroovy FAILED
```
Spring boot [2.6.15](https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/2.6.15/spring-boot-dependencies-2.6.15.pom) brings mockito 4.0.0 as transitive dependency. The `verifyZeroInteractions()` was deprecated in 3.x as mentioned here: https://github.com/mockito/mockito-kotlin/issues/383 And now it is removed from mockito [4.0.0](https://github.com/mockito/mockito/releases/tag/v4.0.0). To fix these issues, replacing `verifyZeroInteractions()` with `verifyNoMoreInteractions()`
