### PR TITLE
refactor(prometheus/test): replace deprecated test application context initializer class during upgrade to spring boot 2.6.x

### DIFF
--- a/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/config/PrometheusHealthConfigurationTest.java
+++ b/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/config/PrometheusHealthConfigurationTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -34,7 +34,7 @@ public class PrometheusHealthConfigurationTest {
 
   private final ApplicationContextRunner contextRunner =
       new ApplicationContextRunner()
-          .withInitializer(new ConfigFileApplicationContextInitializer())
+          .withInitializer(new ConfigDataApplicationContextInitializer())
           .withUserConfiguration(
               PrometheusConfiguration.PrometheusHealthConfiguration.class,
               PrometheusMockConfiguration.class);


### PR DESCRIPTION
While upgrading spring boot 2.6.15 and spring cloud 2021.0.8, encounter below error in kayenta-prometheus module during test compilation:
```
> Task :kayenta-prometheus:compileTestJava FAILED
/kayenta/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/config/PrometheusHealthConfigurationTest.java:28: error: cannot find symbol
import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
                                            ^
  symbol:   class ConfigFileApplicationContextInitializer
  location: package org.springframework.boot.test.context
1 error
```
The root cause is the removal of `ConfigFileApplicationContextInitializer` class which got deprecated since [spring boot 2.4.x](https://javadoc.io/doc/org.springframework.boot/spring-boot-test/2.4.4/deprecated-list.html) in favour of `ConfigDataApplicationContextInitializer` class from [spring boot 2.6.x](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes#deprecations-from-spring-boot-24). To fix this issue replacing the deprecated class with new class.