### PR TITLE
fix(test): Update swagger-ui endpoint with springfox 3.0.0 upgrade

### DIFF
--- a/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/SwaggerTest.java
+++ b/kayenta-integration-tests/src/test/java/com/netflix/kayenta/tests/SwaggerTest.java
@@ -25,7 +25,7 @@ public class SwaggerTest extends BaseIntegrationTest {
   public void swaggerUiIsPresent() {
     RestAssured.given()
         .port(serverPort)
-        .get("/swagger-ui.html")
+        .get("/swagger-ui/index.html")
         .prettyPeek()
         .then()
         .assertThat()


### PR DESCRIPTION
With upgrade of springfox from 2.9.2 to 3.0.0, a breaking [change](http://springfox.github.io/springfox/docs/current/#changes-in-swagger-ui) has been introduced in the form of new endpoint for swagger-ui (/swagger-ui/index.html). This change caused  `SwaggerTest.swaggerUiIsPresent` test to fail. In order to fix this test, updating the swagger-ui endpoint as `/swagger-ui/index.html`.
