### PR TITLE
chore(dependency): unpinning and cleanup springfox dependencies

### DIFF
--- a/kayenta-core/kayenta-core.gradle
+++ b/kayenta-core/kayenta-core.gradle
@@ -5,10 +5,7 @@ dependencies {
   api "io.spinnaker.kork:kork-retrofit"
   api "com.netflix.spectator:spectator-api"
 
-  // TODO update korkSwagger?
-  // Force a newer version than what comes with korkSwagger, so that the api docs page isn't broken.
-  api "io.springfox:springfox-swagger-ui:2.9.2"
-  api "io.springfox:springfox-swagger2:2.9.2"
+  api "io.swagger:swagger-annotations"
 
   api "io.spinnaker.orca:orca-core"
   api "io.spinnaker.orca:orca-retrofit"


### PR DESCRIPTION
The springfox swagger-ui and swagger2 dependencies are not part of the code, whereas io.swagger:swagger-annotations dependency is part of the code. Removing the swagger-ui and swagger2 dependency and introducing swagger-annotations dependency which is available as transitive dependency coming from kork-swagger via orca-bom in kayenta-core module.
The dependency insight before and after the cleanup given below:
Before cleanup: 
```
$ ./gradlew kayenta-web:dI --dependency swagger

> Task :kayenta-web:dependencyInsight
io.spinnaker.kork:kork-swagger:7.206.0
  Variant compile:
    | Attribute Name                 | Provided | Requested         |
    |--------------------------------|----------|-------------------|
    | org.gradle.status              | release  |                   |
    | org.gradle.category            | library  | library           |
    | org.gradle.libraryelements     | jar      | classes+resources |
    | org.gradle.usage               | java-api | java-api          |
    | org.gradle.dependency.bundling |          | external          |
    | org.gradle.jvm.environment     |          | standard-jvm      |
    | org.gradle.jvm.version         |          | 11                |
   Selection reasons:
      - By constraint
      - Forced

io.spinnaker.kork:kork-swagger:7.206.0
\--- io.spinnaker.orca:orca-bom:8.48.0
     \--- compileClasspath

io.spinnaker.kork:kork-swagger -> 7.206.0
+--- project :kayenta-atlas
|    \--- compileClasspath
+--- project :kayenta-aws
|    \--- compileClasspath
+--- project :kayenta-azure
|    \--- compileClasspath
+--- project :kayenta-blobs
|    \--- compileClasspath
+--- project :kayenta-core
|    \--- compileClasspath
+--- project :kayenta-datadog
|    \--- compileClasspath
+--- project :kayenta-gcs
|    \--- compileClasspath
+--- project :kayenta-google
|    \--- compileClasspath
+--- project :kayenta-graphite
|    \--- compileClasspath
+--- project :kayenta-influxdb
|    \--- compileClasspath
+--- project :kayenta-judge
|    \--- compileClasspath
+--- project :kayenta-newrelic-insights
|    \--- compileClasspath
+--- project :kayenta-objectstore-configbin
|    \--- compileClasspath
+--- project :kayenta-objectstore-memory
|    \--- compileClasspath
+--- project :kayenta-orca
|    \--- compileClasspath
+--- project :kayenta-prometheus
|    \--- compileClasspath
+--- project :kayenta-s3
|    \--- compileClasspath
+--- project :kayenta-signalfx
|    \--- compileClasspath
+--- project :kayenta-sql
|    \--- compileClasspath
+--- project :kayenta-stackdriver
|    \--- compileClasspath
+--- project :kayenta-standalone-canary-analysis
|    \--- compileClasspath
+--- project :kayenta-wavefront
|    \--- compileClasspath
\--- compileClasspath

io.springfox:springfox-swagger-common:2.9.2
  Variant compile:
    | Attribute Name                 | Provided | Requested         |
    |--------------------------------|----------|-------------------|
    | org.gradle.status              | release  |                   |
    | org.gradle.category            | library  | library           |
    | org.gradle.libraryelements     | jar      | classes+resources |
    | org.gradle.usage               | java-api | java-api          |
    | org.gradle.dependency.bundling |          | external          |
    | org.gradle.jvm.environment     |          | standard-jvm      |
    | org.gradle.jvm.version         |          | 11                |

io.springfox:springfox-swagger-common:2.9.2
\--- io.springfox:springfox-swagger2:2.9.2
     +--- project :kayenta-core
     |    \--- compileClasspath
     \--- io.spinnaker.orca:orca-bom:8.48.0
          \--- compileClasspath

io.springfox:springfox-swagger-ui:2.9.2
  Variant compile:
    | Attribute Name                 | Provided | Requested         |
    |--------------------------------|----------|-------------------|
    | org.gradle.status              | release  |                   |
    | org.gradle.category            | library  | library           |
    | org.gradle.libraryelements     | jar      | classes+resources |
    | org.gradle.usage               | java-api | java-api          |
    | org.gradle.dependency.bundling |          | external          |
    | org.gradle.jvm.environment     |          | standard-jvm      |
    | org.gradle.jvm.version         |          | 11                |
   Selection reasons:
      - By constraint
      - Forced

io.springfox:springfox-swagger-ui:2.9.2
+--- project :kayenta-core
|    \--- compileClasspath
\--- io.spinnaker.orca:orca-bom:8.48.0
     \--- compileClasspath

io.springfox:springfox-swagger2:2.9.2
  Variant compile:
    | Attribute Name                 | Provided | Requested         |
    |--------------------------------|----------|-------------------|
    | org.gradle.status              | release  |                   |
    | org.gradle.category            | library  | library           |
    | org.gradle.libraryelements     | jar      | classes+resources |
    | org.gradle.usage               | java-api | java-api          |
    | org.gradle.dependency.bundling |          | external          |
    | org.gradle.jvm.environment     |          | standard-jvm      |
    | org.gradle.jvm.version         |          | 11                |
   Selection reasons:
      - By constraint
      - Forced

io.springfox:springfox-swagger2:2.9.2
+--- project :kayenta-core
|    \--- compileClasspath
\--- io.spinnaker.orca:orca-bom:8.48.0
     \--- compileClasspath

io.swagger:swagger-annotations:1.5.20
  Variant compile:
    | Attribute Name                 | Provided | Requested         |
    |--------------------------------|----------|-------------------|
    | org.gradle.status              | release  |                   |
    | org.gradle.category            | library  | library           |
    | org.gradle.libraryelements     | jar      | classes+resources |
    | org.gradle.usage               | java-api | java-api          |
    | org.gradle.dependency.bundling |          | external          |
    | org.gradle.jvm.environment     |          | standard-jvm      |
    | org.gradle.jvm.version         |          | 11                |
   Selection reasons:
      - By constraint
      - Forced

io.swagger:swagger-annotations:1.5.20
+--- io.spinnaker.kork:kork-swagger:7.206.0
|    +--- compileClasspath (requested io.spinnaker.kork:kork-swagger)
|    +--- project :kayenta-atlas (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-aws (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-core (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-datadog (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-gcs (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-google (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-blobs (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-azure (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-graphite (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-influxdb (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-judge (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-newrelic-insights (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-objectstore-configbin (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-objectstore-memory (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-orca (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-prometheus (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-s3 (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-signalfx (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-sql (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-stackdriver (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-standalone-canary-analysis (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-wavefront (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    \--- io.spinnaker.orca:orca-bom:8.48.0
|         \--- compileClasspath
+--- io.spinnaker.orca:orca-bom:8.48.0 (*)
+--- io.springfox:springfox-swagger-common:2.9.2
|    \--- io.springfox:springfox-swagger2:2.9.2
|         +--- project :kayenta-core (*)
|         \--- io.spinnaker.orca:orca-bom:8.48.0 (*)
+--- io.springfox:springfox-swagger2:2.9.2 (*)
\--- io.swagger:swagger-models:1.5.20
     +--- io.springfox:springfox-swagger2:2.9.2 (*)
     \--- io.springfox:springfox-swagger-common:2.9.2 (*)

io.swagger:swagger-models:1.5.20
  Variant compile:
    | Attribute Name                 | Provided | Requested         |
    |--------------------------------|----------|-------------------|
    | org.gradle.status              | release  |                   |
    | org.gradle.category            | library  | library           |
    | org.gradle.libraryelements     | jar      | classes+resources |
    | org.gradle.usage               | java-api | java-api          |
    | org.gradle.dependency.bundling |          | external          |
    | org.gradle.jvm.environment     |          | standard-jvm      |
    | org.gradle.jvm.version         |          | 11                |

io.swagger:swagger-models:1.5.20
+--- io.springfox:springfox-swagger-common:2.9.2
|    \--- io.springfox:springfox-swagger2:2.9.2
|         +--- project :kayenta-core
|         |    \--- compileClasspath
|         \--- io.spinnaker.orca:orca-bom:8.48.0
|              \--- compileClasspath
\--- io.springfox:springfox-swagger2:2.9.2 (*)
```

After cleanup:
```
$ ./gradlew kayenta-web:dI --dependency swagger

> Task :kayenta-web:dependencyInsight
io.spinnaker.kork:kork-swagger:7.206.0
  Variant compile:
    | Attribute Name                 | Provided | Requested         |
    |--------------------------------|----------|-------------------|
    | org.gradle.status              | release  |                   |
    | org.gradle.category            | library  | library           |
    | org.gradle.libraryelements     | jar      | classes+resources |
    | org.gradle.usage               | java-api | java-api          |
    | org.gradle.dependency.bundling |          | external          |
    | org.gradle.jvm.environment     |          | standard-jvm      |
    | org.gradle.jvm.version         |          | 11                |
   Selection reasons:
      - By constraint
      - Forced

io.spinnaker.kork:kork-swagger:7.206.0
\--- io.spinnaker.orca:orca-bom:8.48.0
     \--- compileClasspath

io.spinnaker.kork:kork-swagger -> 7.206.0
+--- project :kayenta-atlas
|    \--- compileClasspath
+--- project :kayenta-aws
|    \--- compileClasspath
+--- project :kayenta-azure
|    \--- compileClasspath
+--- project :kayenta-blobs
|    \--- compileClasspath
+--- project :kayenta-core
|    \--- compileClasspath
+--- project :kayenta-datadog
|    \--- compileClasspath
+--- project :kayenta-gcs
|    \--- compileClasspath
+--- project :kayenta-google
|    \--- compileClasspath
+--- project :kayenta-graphite
|    \--- compileClasspath
+--- project :kayenta-influxdb
|    \--- compileClasspath
+--- project :kayenta-judge
|    \--- compileClasspath
+--- project :kayenta-newrelic-insights
|    \--- compileClasspath
+--- project :kayenta-objectstore-configbin
|    \--- compileClasspath
+--- project :kayenta-objectstore-memory
|    \--- compileClasspath
+--- project :kayenta-orca
|    \--- compileClasspath
+--- project :kayenta-prometheus
|    \--- compileClasspath
+--- project :kayenta-s3
|    \--- compileClasspath
+--- project :kayenta-signalfx
|    \--- compileClasspath
+--- project :kayenta-sql
|    \--- compileClasspath
+--- project :kayenta-stackdriver
|    \--- compileClasspath
+--- project :kayenta-standalone-canary-analysis
|    \--- compileClasspath
+--- project :kayenta-wavefront
|    \--- compileClasspath
\--- compileClasspath

io.swagger:swagger-annotations:1.5.20
  Variant compile:
    | Attribute Name                 | Provided | Requested         |
    |--------------------------------|----------|-------------------|
    | org.gradle.status              | release  |                   |
    | org.gradle.category            | library  | library           |
    | org.gradle.libraryelements     | jar      | classes+resources |
    | org.gradle.usage               | java-api | java-api          |
    | org.gradle.dependency.bundling |          | external          |
    | org.gradle.jvm.environment     |          | standard-jvm      |
    | org.gradle.jvm.version         |          | 11                |
   Selection reasons:
      - By constraint
      - Forced

io.swagger:swagger-annotations:1.5.20
+--- io.spinnaker.kork:kork-swagger:7.206.0
|    +--- compileClasspath (requested io.spinnaker.kork:kork-swagger)
|    +--- project :kayenta-atlas (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-aws (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-core (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-datadog (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-gcs (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-google (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-blobs (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-azure (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-graphite (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-influxdb (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-judge (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-newrelic-insights (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-objectstore-configbin (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-objectstore-memory (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-orca (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-prometheus (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-s3 (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-signalfx (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-sql (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-stackdriver (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-standalone-canary-analysis (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    +--- project :kayenta-wavefront (requested io.spinnaker.kork:kork-swagger)
|    |    \--- compileClasspath
|    \--- io.spinnaker.orca:orca-bom:8.48.0
|         \--- compileClasspath
\--- io.spinnaker.orca:orca-bom:8.48.0 (*)

io.swagger:swagger-annotations -> 1.5.20
\--- project :kayenta-core
     \--- compileClasspath
```