### PR TITLE
doc(swagger): Update swagger-ui endpoint with springfox 3.0.0 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ cp kayenta-web/config/kayenta.yml ~/.spinnaker/kayenta.yml
 docker-compose up
 ```
 
-You should then be able to access your local kayenta instance at http://localhost:8090/swagger-ui.html.
+You should then be able to access your local kayenta instance at http://localhost:8090/swagger-ui/index.html.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -16,7 +16,7 @@ See [Kayenta Standalone](./kayenta-standalone.md) for more information.
 
 ## Where are the API docs?
 
-When Kayenta is running, it serves its API docs at [http://localhost:8090/swagger-ui.html](http://localhost:8090/swagger-ui.html).
+When Kayenta is running, it serves its API docs at [http://localhost:8090/swagger-ui/index.html](http://localhost:8090/swagger-ui/index.html).
 
 You can control what endpoints show up on that page via the [swagger config](../kayenta-web/config/kayenta.yml) section of the main config.
 <!-- TODO explain how this is controlled in the yaml. -->


### PR DESCRIPTION
With upgrade of springfox from 2.9.2 to 3.0.0, swagger-ui endpoint changed to [/swagger-ui/index.html](http://springfox.github.io/springfox/docs/current/#changes-in-swagger-ui).