### PR TITLE
chore(dependency): unpin mysql-connector-java and liquibase-core

### DIFF
--- a/kayenta-sql/kayenta-sql.gradle
+++ b/kayenta-sql/kayenta-sql.gradle
@@ -1,7 +1,7 @@
 dependencies {
     implementation project(":kayenta-core")
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
-    implementation "org.liquibase:liquibase-core:4.20.0"
-    runtimeOnly "mysql:mysql-connector-java:8.0.25"
+    implementation "org.liquibase:liquibase-core"
+    runtimeOnly "mysql:mysql-connector-java"
     runtimeOnly "org.postgresql:postgresql"
 }


### PR DESCRIPTION
mysql-connector-java and liquibase-core are transitive dependencies part of orca-bom.

Before:
```
$ ./gradlew kayenta-sql:dI --dependency mysql-connector-java --configuration runtimeClasspath

> Task :kayenta-sql:dependencyInsight
mysql:mysql-connector-java:8.0.33
  Variant runtime:
    | Attribute Name                 | Provided     | Requested    |
    |--------------------------------|--------------|--------------|
    | org.gradle.status              | release      |              |
    | org.gradle.category            | library      | library      |
    | org.gradle.libraryelements     | jar          | jar          |
    | org.gradle.usage               | java-runtime | java-runtime |
    | org.gradle.dependency.bundling |              | external     |
    | org.gradle.jvm.environment     |              | standard-jvm |
    | org.gradle.jvm.version         |              | 11           |
   Selection reasons:
      - By constraint
      - Forced

mysql:mysql-connector-java:8.0.33
\--- io.spinnaker.orca:orca-bom:8.51.0
     +--- runtimeClasspath
     \--- project :kayenta-core
          \--- runtimeClasspath

mysql:mysql-connector-java:8.0.25 -> 8.0.33
\--- runtimeClasspath

(*) - dependencies omitted (listed previously)
```

After:
```
$ ./gradlew kayenta-sql:dI --dependency mysql-connector-java --configuration runtimeClasspath

> Task :kayenta-sql:dependencyInsight
mysql:mysql-connector-java:8.0.33
  Variant runtime:
    | Attribute Name                 | Provided     | Requested    |
    |--------------------------------|--------------|--------------|
    | org.gradle.status              | release      |              |
    | org.gradle.category            | library      | library      |
    | org.gradle.libraryelements     | jar          | jar          |
    | org.gradle.usage               | java-runtime | java-runtime |
    | org.gradle.dependency.bundling |              | external     |
    | org.gradle.jvm.environment     |              | standard-jvm |
    | org.gradle.jvm.version         |              | 11           |
   Selection reasons:
      - By constraint
      - Forced

mysql:mysql-connector-java:8.0.33
\--- io.spinnaker.orca:orca-bom:8.51.0
     +--- runtimeClasspath
     \--- project :kayenta-core
          \--- runtimeClasspath

mysql:mysql-connector-java -> 8.0.33
\--- runtimeClasspath

(*) - dependencies omitted (listed previously)

```

Before:
```
$ ./gradlew kayenta-sql:dI --dependency liquibase-core

> Task :kayenta-sql:dependencyInsight
org.liquibase:liquibase-core:4.24.0
  Variant compile:
    | Attribute Name                 | Provided | Requested         |
    |--------------------------------|----------|-------------------|
    | org.gradle.status              | release  |                   |
    | org.gradle.category            | library  | library           |
    | org.gradle.libraryelements     | jar      | classes+resources |
    | org.gradle.usage               | java-api | java-api          |
    | org.gradle.dependency.bundling |          | external          |
    | org.gradle.jvm.environment     |          | standard-jvm      |
    | org.gradle.jvm.version         |          | 11                |
   Selection reasons:
      - By constraint
      - Forced

org.liquibase:liquibase-core:4.24.0
\--- io.spinnaker.orca:orca-bom:8.51.0
     \--- compileClasspath

org.liquibase:liquibase-core:4.20.0 -> 4.24.0
\--- compileClasspath
```

After:
```
$ ./gradlew kayenta-sql:dI --dependency liquibase-core

> Task :kayenta-sql:dependencyInsight
org.liquibase:liquibase-core:4.24.0
  Variant compile:
    | Attribute Name                 | Provided | Requested         |
    |--------------------------------|----------|-------------------|
    | org.gradle.status              | release  |                   |
    | org.gradle.category            | library  | library           |
    | org.gradle.libraryelements     | jar      | classes+resources |
    | org.gradle.usage               | java-api | java-api          |
    | org.gradle.dependency.bundling |          | external          |
    | org.gradle.jvm.environment     |          | standard-jvm      |
    | org.gradle.jvm.version         |          | 11                |
   Selection reasons:
      - By constraint
      - Forced

org.liquibase:liquibase-core:4.24.0
\--- io.spinnaker.orca:orca-bom:8.51.0
     \--- compileClasspath

org.liquibase:liquibase-core -> 4.24.0
\--- compileClasspath

```
