### PR TITLE
refactor(mysql): update mysql connector coordinate during upgrade to spring boot 2.7.x

### DIFF
--- a/kayenta-sql/kayenta-sql.gradle
+++ b/kayenta-sql/kayenta-sql.gradle
@@ -2,6 +2,6 @@ dependencies {
     implementation project(":kayenta-core")
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
     implementation "org.liquibase:liquibase-core"
-    runtimeOnly "mysql:mysql-connector-java"
+    runtimeOnly "com.mysql:mysql-connector-j"
     runtimeOnly "org.postgresql:postgresql"
 }


### PR DESCRIPTION
In spring boot 2.7.8 onwards mysql connector coordinate `mysql:mysql-connector-java` has been removed and only `com.mysql:mysql-connector-j` coordinate exist.

https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#mysql-jdbc-driver

So, updating the mysql connector coordinate as `com.mysql:mysql-connector-j` with spring boot upgrade to 2.7.18.

https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/2.7.18/spring-boot-dependencies-2.7.18.pom