### PR TITLE
refactor(auto-configuration): replace spring.factories with AutoConfiguration.imports file to enable auto-configuration during upgrade to spring boot 2.7.x

### DIFF
--- a/kayenta-atlas/src/main/resources/META-INF/spring.factories
+++ b/kayenta-atlas/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.netflix.kayenta.atlas.config.AtlasConfiguration

--- a/kayenta-atlas/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kayenta-atlas/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.kayenta.atlas.config.AtlasConfiguration

--- a/kayenta-aws/src/main/resources/META-INF/spring.factories
+++ b/kayenta-aws/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.netflix.kayenta.aws.config.AwsConfiguration

--- a/kayenta-aws/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kayenta-aws/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.kayenta.aws.config.AwsConfiguration

--- a/kayenta-azure/src/main/resources/META-INF/spring.factories
+++ b/kayenta-azure/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.netflix.kayenta.azure.config.AzureConfiguration

--- a/kayenta-azure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kayenta-azure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.kayenta.azure.config.AzureConfiguration

--- a/kayenta-blobs/src/main/resources/META-INF/spring.factories
+++ b/kayenta-blobs/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.netflix.kayenta.blobs.config.BlobsConfiguration

--- a/kayenta-blobs/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kayenta-blobs/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.kayenta.blobs.config.BlobsConfiguration

--- a/kayenta-datadog/src/main/resources/META-INF/spring.factories
+++ b/kayenta-datadog/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.netflix.kayenta.datadog.config.DatadogConfiguration

--- a/kayenta-datadog/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kayenta-datadog/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.kayenta.datadog.config.DatadogConfiguration

--- a/kayenta-gcs/src/main/resources/META-INF/spring.factories
+++ b/kayenta-gcs/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.netflix.kayenta.gcs.config.GcsConfiguration

--- a/kayenta-gcs/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kayenta-gcs/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.kayenta.gcs.config.GcsConfiguration

--- a/kayenta-google/src/main/resources/META-INF/spring.factories
+++ b/kayenta-google/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.netflix.kayenta.google.config.GoogleConfiguration

--- a/kayenta-google/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kayenta-google/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.kayenta.google.config.GoogleConfiguration

--- a/kayenta-graphite/src/main/resources/META-INF/spring.factories
+++ b/kayenta-graphite/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.netflix.kayenta.graphite.config.GraphiteConfiguration

--- a/kayenta-graphite/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kayenta-graphite/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.kayenta.graphite.config.GraphiteConfiguration

--- a/kayenta-influxdb/src/main/resources/META-INF/spring.factories
+++ b/kayenta-influxdb/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.netflix.kayenta.influxdb.config.InfluxDbConfiguration

--- a/kayenta-influxdb/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kayenta-influxdb/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.kayenta.influxdb.config.InfluxDbConfiguration

--- a/kayenta-judge/src/main/resources/META-INF/spring.factories
+++ b/kayenta-judge/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.netflix.kayenta.judge.config.NetflixJudgeConfiguration,\
-com.netflix.kayenta.judge.config.RemoteJudgeConfiguration

--- a/kayenta-judge/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kayenta-judge/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+com.netflix.kayenta.judge.config.NetflixJudgeConfiguration
+com.netflix.kayenta.judge.config.RemoteJudgeConfiguration

--- a/kayenta-newrelic-insights/src/main/resources/META-INF/spring.factories
+++ b/kayenta-newrelic-insights/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.netflix.kayenta.newrelic.config.NewRelicConfiguration

--- a/kayenta-newrelic-insights/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kayenta-newrelic-insights/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.kayenta.newrelic.config.NewRelicConfiguration

--- a/kayenta-objectstore-configbin/src/main/resources/META-INF/spring.factories
+++ b/kayenta-objectstore-configbin/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.netflix.kayenta.configbin.config.ConfigBinConfiguration

--- a/kayenta-objectstore-configbin/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kayenta-objectstore-configbin/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.kayenta.configbin.config.ConfigBinConfiguration

--- a/kayenta-objectstore-memory/src/main/resources/META-INF/spring.factories
+++ b/kayenta-objectstore-memory/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.netflix.kayenta.memory.config.MemoryConfiguration

--- a/kayenta-objectstore-memory/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kayenta-objectstore-memory/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.kayenta.memory.config.MemoryConfiguration

--- a/kayenta-orca/src/main/resources/META-INF/spring.factories
+++ b/kayenta-orca/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.netflix.kayenta.config.OrcaConfiguration

--- a/kayenta-orca/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kayenta-orca/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.kayenta.config.OrcaConfiguration

--- a/kayenta-prometheus/src/main/resources/META-INF/spring.factories
+++ b/kayenta-prometheus/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.netflix.kayenta.prometheus.config.PrometheusConfiguration

--- a/kayenta-prometheus/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kayenta-prometheus/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.kayenta.prometheus.config.PrometheusConfiguration

--- a/kayenta-s3/src/main/resources/META-INF/spring.factories
+++ b/kayenta-s3/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.netflix.kayenta.s3.config.S3Configuration

--- a/kayenta-s3/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kayenta-s3/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.kayenta.s3.config.S3Configuration

--- a/kayenta-signalfx/src/main/resources/META-INF/spring.factories
+++ b/kayenta-signalfx/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.netflix.kayenta.signalfx.config.SignalFxConfiguration

--- a/kayenta-signalfx/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kayenta-signalfx/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.kayenta.signalfx.config.SignalFxConfiguration

--- a/kayenta-sql/src/main/resources/META-INF/spring.factories
+++ b/kayenta-sql/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-    com.netflix.kayenta.sql.config.SqlConfiguration

--- a/kayenta-sql/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kayenta-sql/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.kayenta.sql.config.SqlConfiguration

--- a/kayenta-stackdriver/src/main/resources/META-INF/spring.factories
+++ b/kayenta-stackdriver/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.netflix.kayenta.stackdriver.config.StackdriverConfiguration

--- a/kayenta-stackdriver/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kayenta-stackdriver/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.kayenta.stackdriver.config.StackdriverConfiguration

--- a/kayenta-standalone-canary-analysis/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kayenta-standalone-canary-analysis/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,1 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 com.netflix.kayenta.standalonecanaryanalysis.config.StandaloneCanaryAnalysisModuleConfiguration

--- a/kayenta-wavefront/src/main/resources/META-INF/spring.factories
+++ b/kayenta-wavefront/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.netflix.kayenta.wavefront.config.WavefrontConfiguration

--- a/kayenta-wavefront/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kayenta-wavefront/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.kayenta.wavefront.config.WavefrontConfiguration


### PR DESCRIPTION
In spring boot 2.7.x, major change has been introduced for auto-configuration registration. The registration has been moved from `spring.factories` under the `org.springframework.boot.autoconfigure.EnableAutoConfiguration` key to a new file named `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`.

https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#changes-to-auto-configuration

So, replacing the registration of auto-configuration classes from `spring.factories` to `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`.