### PR TITLE
chore(build): upgrade builder image to gradle:7.6.1-jdk17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Builder Image
 #
-FROM gradle:6.5-jdk11 AS builder
+FROM gradle:7.6.1-jdk11 AS builder
 
 # Prep build environment
 ENV GRADLE_USER_HOME=cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Builder Image
 #
-FROM gradle:7.6.1-jdk11 AS builder
+FROM gradle:7.6.1-jdk17 AS builder
 
 # Prep build environment
 ENV GRADLE_USER_HOME=cache


### PR DESCRIPTION
Kayenta build using Dockerfile is currently broken:
```
58.02 FAILURE: Build failed with an exception.
58.02 
58.02 * Where:
58.02 Build file '/tmp/workdir/build.gradle' line: 63
58.02 
58.02 * What went wrong:
58.02 A problem occurred evaluating root project 'kayenta'.
58.02 > Could not get unknown property 'javaToolchains' for task ':kayenta-atlas:test' of type org.gradle.api.tasks.testing.Test.
```

Gradle version was bumped to 7.6.1 in #967, but the base image for the build stage was not updated.
Changing it to `gradle:7.6.1-jdk17` fixes the build.
