### PR TITLE
refactor(dependency): add explicit dependency of google-http-client-jackson2 while upgrading spockframework 2.3

### DIFF
--- a/kayenta-google/kayenta-google.gradle
+++ b/kayenta-google/kayenta-google.gradle
@@ -5,4 +5,5 @@ dependencies {
   api "com.google.apis:google-api-services-storage"
 
   implementation "com.google.auth:google-auth-library-oauth2-http"
+  implementation "com.google.http-client:google-http-client-jackson2"
 }


### PR DESCRIPTION
While upgrading spockframework 2.3-groovy-4.0, encountered below error during the build process of kayenta-google module:
```
/kayenta/kayenta-google/src/main/java/com/netflix/kayenta/google/security/GoogleClientFactory.java:24: error: package com.google.api.client.json.jackson2 does not exist
import com.google.api.client.json.jackson2.JacksonFactory;
```
Further, dependency insight does not show the dependency of `google-http-client-jackson2`:
```
> Task :kayenta-google:dependencyInsight
No dependencies matching given input were found in configuration ':kayenta-google:compileClasspath'
```
Whereas, before the spockframework upgrade this dependency transitively appears in insight:
```
> Task :kayenta-google:dependencyInsight
com.google.http-client:google-http-client-jackson2:1.41.7
  Variant compile:
    | Attribute Name                 | Provided | Requested         |
    |--------------------------------|----------|-------------------|
    | org.gradle.status              | release  |                   |
    | org.gradle.category            | library  | library           |
    | org.gradle.libraryelements     | jar      | classes+resources |
    | org.gradle.usage               | java-api | java-api          |
    | org.gradle.dependency.bundling |          | external          |
    | org.gradle.jvm.environment     |          | standard-jvm      |
    | org.gradle.jvm.version         |          | 11                |
   Selection reasons:
      - By constraint
      - Forced

com.google.http-client:google-http-client-jackson2:1.41.7
\--- io.spinnaker.orca:orca-bom:8.55.0
     \--- compileClasspath

com.google.http-client:google-http-client-jackson2:1.36.0 -> 1.41.7
\--- com.google.api-client:google-api-client:1.30.10
     +--- io.spinnaker.orca:orca-bom:8.55.0
     |    \--- compileClasspath
     +--- com.google.apis:google-api-services-monitoring:v3-rev477-1.25.0 (requested com.google.api-client:google-api-client:1.25.0)
     |    +--- compileClasspath (requested com.google.apis:google-api-services-monitoring)
     |    \--- io.spinnaker.orca:orca-bom:8.55.0 (*)
     \--- com.google.apis:google-api-services-storage:v1-rev141-1.25.0 (requested com.google.api-client:google-api-client:1.25.0)
          +--- compileClasspath (requested com.google.apis:google-api-services-storage)
          \--- io.spinnaker.orca:orca-bom:8.55.0 (*)
```
So, adding explicit dependency of `google-http-client-jackson2` in kayenta-google.gradle

Dependency insight after refactor:
```
> Task :kayenta-google:dependencyInsight
com.google.http-client:google-http-client-jackson2:1.41.7
  Variant compile:
    | Attribute Name                 | Provided | Requested         |
    |--------------------------------|----------|-------------------|
    | org.gradle.status              | release  |                   |
    | org.gradle.category            | library  | library           |
    | org.gradle.libraryelements     | jar      | classes+resources |
    | org.gradle.usage               | java-api | java-api          |
    | org.gradle.dependency.bundling |          | external          |
    | org.gradle.jvm.environment     |          | standard-jvm      |
    | org.gradle.jvm.version         |          | 11                |
   Selection reasons:
      - By constraint
      - Forced

com.google.http-client:google-http-client-jackson2:1.41.7
\--- io.spinnaker.orca:orca-bom:spock-2-3-SNAPSHOT
     \--- compileClasspath

com.google.http-client:google-http-client-jackson2 -> 1.41.7
\--- compileClasspath
```